### PR TITLE
Add a nicer constructor for subscribe-then-stream

### DIFF
--- a/src/main/scala/zio/kafka/client/Consumer.scala
+++ b/src/main/scala/zio/kafka/client/Consumer.scala
@@ -15,7 +15,7 @@ class Consumer private (
   private val consumer: ConsumerAccess,
   private val settings: ConsumerSettings,
   private val runloop: Runloop
-) {
+) { self =>
   def assignment: BlockingTask[Set[TopicPartition]] =
     consumer.withConsumer(_.assignment().asScala.toSet)
 
@@ -88,6 +88,9 @@ class Consumer private (
         case Subscription.Topics(topics)   => c.subscribe(topics.asJava, runloop.deps.rebalanceListener)
       }
     }
+
+  def subscribeAnd(subscription: Subscription): SubscribedConsumer =
+    new SubscribedConsumer(subscribe(subscription).as(self))
 
   def subscription: BlockingTask[Set[String]] =
     consumer.withConsumer(_.subscription().asScala.toSet)

--- a/src/main/scala/zio/kafka/client/SubscribedConsumer.scala
+++ b/src/main/scala/zio/kafka/client/SubscribedConsumer.scala
@@ -1,0 +1,23 @@
+package zio.kafka.client
+
+import org.apache.kafka.common.TopicPartition
+import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.kafka.client.serde.Deserializer
+import zio.stream.{ ZStream, ZStreamChunk }
+
+class SubscribedConsumer(private val underlying: BlockingTask[Consumer]) {
+
+  def partitionedStream[R, K, V](
+    keyDeserializer: Deserializer[R, K],
+    valueDeserializer: Deserializer[R, V]
+  ): ZStream[Clock with Blocking, Throwable, (TopicPartition, ZStreamChunk[R, Throwable, CommittableRecord[K, V]])] =
+    ZStream.fromEffect(underlying).flatMap(_.partitionedStream(keyDeserializer, valueDeserializer))
+
+  def plainStream[R, K, V](
+    keyDeserializer: Deserializer[R, K],
+    valueDeserializer: Deserializer[R, V]
+  ): ZStreamChunk[R with Clock with Blocking, Throwable, CommittableRecord[K, V]] =
+    ZStreamChunk(partitionedStream[R, K, V](keyDeserializer, valueDeserializer).flatMapPar(Int.MaxValue)(_._2.chunks))
+
+}


### PR DESCRIPTION
Implements #28, and improves README to make use of the new API. Also fixes README code snippets in order to make them compile and to use the latest Serde features recently merged in master.

