### PR TITLE
Fix type inference issue in Producer.make

### DIFF
--- a/src/main/scala/zio/kafka/client/Producer.scala
+++ b/src/main/scala/zio/kafka/client/Producer.scala
@@ -11,7 +11,7 @@ import zio.stream.ZSink
 
 import scala.collection.JavaConverters._
 
-class Producer[R, K, V] private (
+class Producer[-R, K, V] private (
   p: ByteArrayProducer,
   keySerializer: Serializer[R, K],
   valueSerializer: Serializer[R, V]


### PR DESCRIPTION
Producer.make(settings, Serde.string, Serde.int) would be inferred to be of type `ZManaged[Blocking, Throwable, Producer[Nothing, String, Int]]`.

This fix changes that to infer to `ZManaged[Blocking, Throwable, Producer[Any, String, Int]]`.

`Producer` could theoretically be contravariant in `K` and `V` as well if it wasn't for the invariant `ProducerRecord[K, V]` from the apache kafka library.