### PR TITLE
Add Serializer and Deserializer constructors

### DIFF
--- a/src/main/scala/zio/kafka/client/serde/Serializer.scala
+++ b/src/main/scala/zio/kafka/client/serde/Serializer.scala
@@ -1,7 +1,8 @@
 package zio.kafka.client.serde
 
-import zio.RIO
+import zio.{ RIO, Task }
 import org.apache.kafka.common.header.Headers
+import org.apache.kafka.common.serialization.{ Serializer => KafkaSerializer }
 
 /**
  * Serializer from values of some type T to a byte array
@@ -39,4 +40,12 @@ object Serializer extends Serdes {
       override def serialize(topic: String, headers: Headers, value: T): RIO[R, Array[Byte]] =
         ser(topic, headers, value)
     }
+
+  /**
+   * Create a Serializer from a Kafka Serializer
+   */
+  def apply[T](serializer: KafkaSerializer[T]): Serializer[Any, T] = new Serializer[Any, T] {
+    override def serialize(topic: String, headers: Headers, value: T): Task[Array[Byte]] =
+      Task(serializer.serialize(topic, headers, value))
+  }
 }


### PR DESCRIPTION
 based on their Kafka equivalents, just like `Serde` has. 

Useful to have now that Producer and Consumer take just a Serializer or Deserializer instead of a whole Serde.