### PR TITLE
WIP: Consumer/Producer Modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,10 @@ Compile / doc / scalacOptions ++= {
   if (scalaBinaryVersion.value == "2.13") Seq("-P:silencer:globalFilters=[import scala.collection.compat._]")
   else Seq.empty
 }
+Compile / test / scalacOptions ++= {
+  if (scalaBinaryVersion.value == "2.13") Seq("-P:silencer:globalFilters=[import scala.collection.compat._]")
+  else Seq.empty
+}
 
 testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
 

--- a/src/main/scala/zio/kafka/client/Consumer.scala
+++ b/src/main/scala/zio/kafka/client/Consumer.scala
@@ -61,6 +61,48 @@ object Consumer {
     def unsubscribe(): BlockingTask[Unit]
   }
 
+  type ConsumerTask[A] = ZIO[Consumer with Blocking, Throwable, A]
+  def assignment: ConsumerTask[Set[TopicPartition]] = ???
+  def beginningOffsets(
+    partitions: Set[TopicPartition],
+    timeout: Duration = Duration.Infinity
+  ): ConsumerTask[Map[TopicPartition, Long]] = ???
+  def committed(
+    partitions: Set[TopicPartition],
+    timeout: Duration = Duration.Infinity
+  ): ConsumerTask[Map[TopicPartition, Option[OffsetAndMetadata]]] = ???
+  def endOffsets(
+    partitions: Set[TopicPartition],
+    timeout: Duration = Duration.Infinity
+  ): ConsumerTask[Map[TopicPartition, Long]]                                                            = ???
+  def stopConsumption: URIO[Consumer with Blocking, Unit]                                               = ???
+  def listTopics(timeout: Duration = Duration.Infinity): ConsumerTask[Map[String, List[PartitionInfo]]] = ???
+  def offsetsForTimes(
+    timestamps: Map[TopicPartition, Long],
+    timeout: Duration = Duration.Infinity
+  ): ConsumerTask[Map[TopicPartition, OffsetAndTimestamp]] = ???
+  def partitionedStream[R, K, V](
+    keyDeserializer: Deserializer[R, K],
+    valueDeserializer: Deserializer[R, V]
+  ): ZStream[
+    Consumer with Clock with Blocking,
+    Throwable,
+    (TopicPartition, ZStreamChunk[R, Throwable, CommittableRecord[K, V]])
+  ]                                                                                                          = ???
+  def partitionsFor(topic: String, timeout: Duration = Duration.Infinity): ConsumerTask[List[PartitionInfo]] = ???
+  def position(partition: TopicPartition, timeout: Duration = Duration.Infinity): ConsumerTask[Long]         = ???
+  def plainStream[R, K, V](
+    keyDeserializer: Deserializer[R, K],
+    valueDeserializer: Deserializer[R, V]
+  ): ZStreamChunk[R with Consumer with Clock with Blocking, Throwable, CommittableRecord[K, V]] = ???
+  def seek(partition: TopicPartition, offset: Long): ConsumerTask[Unit]                         = ???
+  def seekToBeginning(partitions: Set[TopicPartition]): ConsumerTask[Unit]                      = ???
+  def seekToEnd(partitions: Set[TopicPartition]): ConsumerTask[Unit]                            = ???
+  def subscribe(subscription: Subscription): ConsumerTask[Unit]                                 = ???
+  def subscribeAnd(subscription: Subscription): ConsumerTask[SubscribedConsumer]                = ???
+  def subscription(): ConsumerTask[Set[String]]                                                 = ???
+  def unsubscribe(): ConsumerTask[Unit]                                                         = ???
+
   val offsetBatches: ZSink[Any, Nothing, Nothing, Offset, OffsetBatch] =
     ZSink.foldLeft[Offset, OffsetBatch](OffsetBatch.empty)(_ merge _)
 

--- a/src/main/scala/zio/kafka/client/Consumer.scala
+++ b/src/main/scala/zio/kafka/client/Consumer.scala
@@ -68,21 +68,24 @@ object Consumer {
   def beginningOffsets(
     partitions: Set[TopicPartition],
     timeout: Duration = Duration.Infinity
-  ): ConsumerTask[Map[TopicPartition, Long]] = ???
+  ): ConsumerTask[Map[TopicPartition, Long]] = ZIO.accessM[Self](_.consumer.beginningOffsets(partitions, timeout))
   def committed(
     partitions: Set[TopicPartition],
     timeout: Duration = Duration.Infinity
-  ): ConsumerTask[Map[TopicPartition, Option[OffsetAndMetadata]]] = ???
+  ): ConsumerTask[Map[TopicPartition, Option[OffsetAndMetadata]]] =
+    ZIO.accessM[Self](_.consumer.committed(partitions, timeout))
   def endOffsets(
     partitions: Set[TopicPartition],
     timeout: Duration = Duration.Infinity
-  ): ConsumerTask[Map[TopicPartition, Long]]                                                            = ???
-  def stopConsumption: URIO[Consumer with Blocking, Unit]                                               = ???
-  def listTopics(timeout: Duration = Duration.Infinity): ConsumerTask[Map[String, List[PartitionInfo]]] = ???
+  ): ConsumerTask[Map[TopicPartition, Long]]              = ZIO.accessM[Self](_.consumer.endOffsets(partitions, timeout))
+  def stopConsumption: URIO[Consumer with Blocking, Unit] = ZIO.accessM[Self](_.consumer.stopConsumption)
+  def listTopics(timeout: Duration = Duration.Infinity): ConsumerTask[Map[String, List[PartitionInfo]]] =
+    ZIO.accessM[Self](_.consumer.listTopics(timeout))
   def offsetsForTimes(
     timestamps: Map[TopicPartition, Long],
     timeout: Duration = Duration.Infinity
-  ): ConsumerTask[Map[TopicPartition, OffsetAndTimestamp]] = ???
+  ): ConsumerTask[Map[TopicPartition, OffsetAndTimestamp]] =
+    ZIO.accessM[Self](_.consumer.offsetsForTimes(timestamps, timeout))
   def partitionedStream[R, K, V](
     keyDeserializer: Deserializer[R, K],
     valueDeserializer: Deserializer[R, V]
@@ -90,20 +93,25 @@ object Consumer {
     Consumer with Clock with Blocking,
     Throwable,
     (TopicPartition, ZStreamChunk[R, Throwable, CommittableRecord[K, V]])
-  ]                                                                                                          = ???
-  def partitionsFor(topic: String, timeout: Duration = Duration.Infinity): ConsumerTask[List[PartitionInfo]] = ???
-  def position(partition: TopicPartition, timeout: Duration = Duration.Infinity): ConsumerTask[Long]         = ???
+  ] = ???
+  def partitionsFor(topic: String, timeout: Duration = Duration.Infinity): ConsumerTask[List[PartitionInfo]] =
+    ZIO.accessM[Self](_.consumer.partitionsFor(topic, timeout))
+  def position(partition: TopicPartition, timeout: Duration = Duration.Infinity): ConsumerTask[Long] =
+    ZIO.accessM[Self](_.consumer.position(partition, timeout))
   def plainStream[R, K, V](
     keyDeserializer: Deserializer[R, K],
     valueDeserializer: Deserializer[R, V]
   ): ZStreamChunk[R with Consumer with Clock with Blocking, Throwable, CommittableRecord[K, V]] = ???
-  def seek(partition: TopicPartition, offset: Long): ConsumerTask[Unit]                         = ???
-  def seekToBeginning(partitions: Set[TopicPartition]): ConsumerTask[Unit]                      = ???
-  def seekToEnd(partitions: Set[TopicPartition]): ConsumerTask[Unit]                            = ???
-  def subscribe(subscription: Subscription): ConsumerTask[Unit]                                 = ???
-  def subscribeAnd(subscription: Subscription): ConsumerTask[SubscribedConsumer]                = ???
-  def subscription(): ConsumerTask[Set[String]]                                                 = ???
-  def unsubscribe(): ConsumerTask[Unit]                                                         = ???
+  def seek(partition: TopicPartition, offset: Long): ConsumerTask[Unit] =
+    ZIO.accessM[Self](_.consumer.seek(partition, offset))
+  def seekToBeginning(partitions: Set[TopicPartition]): ConsumerTask[Unit] =
+    ZIO.accessM[Self](_.consumer.seekToBeginning(partitions))
+  def seekToEnd(partitions: Set[TopicPartition]): ConsumerTask[Unit] =
+    ZIO.accessM[Self](_.consumer.seekToEnd(partitions))
+  def subscribe(subscription: Subscription): ConsumerTask[Unit]                  = ZIO.accessM[Self](_.consumer.subscribe(subscription))
+  def subscribeAnd(subscription: Subscription): ConsumerTask[SubscribedConsumer] = ???
+  def subscription(): ConsumerTask[Set[String]]                                  = ZIO.accessM[Self](_.consumer.subscription())
+  def unsubscribe(): ConsumerTask[Unit]                                          = ZIO.accessM[Self](_.consumer.unsubscribe())
 
   val offsetBatches: ZSink[Any, Nothing, Nothing, Offset, OffsetBatch] =
     ZSink.foldLeft[Offset, OffsetBatch](OffsetBatch.empty)(_ merge _)

--- a/src/main/scala/zio/kafka/client/Consumer.scala
+++ b/src/main/scala/zio/kafka/client/Consumer.scala
@@ -61,8 +61,10 @@ object Consumer {
     def unsubscribe(): BlockingTask[Unit]
   }
 
-  type ConsumerTask[A] = ZIO[Consumer with Blocking, Throwable, A]
-  def assignment: ConsumerTask[Set[TopicPartition]] = ???
+  private type Self    = Consumer with Blocking
+  type ConsumerTask[A] = ZIO[Self, Throwable, A]
+
+  def assignment: ConsumerTask[Set[TopicPartition]] = ZIO.accessM[Self](_.consumer.assignment)
   def beginningOffsets(
     partitions: Set[TopicPartition],
     timeout: Duration = Duration.Infinity

--- a/src/main/scala/zio/kafka/client/Producer.scala
+++ b/src/main/scala/zio/kafka/client/Producer.scala
@@ -2,7 +2,7 @@ package zio.kafka.client
 
 import java.util.concurrent.atomic.AtomicLong
 
-import org.apache.kafka.clients.producer.{ Callback, KafkaProducer => JKafkaProducer, ProducerRecord, RecordMetadata }
+import org.apache.kafka.clients.producer.{ Callback, KafkaProducer, ProducerRecord, RecordMetadata }
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import zio._
 import zio.blocking._
@@ -11,120 +11,16 @@ import zio.stream.ZSink
 
 import scala.jdk.CollectionConverters._
 
-trait KafkaProducer[K, V] {
-  val kafkaProducer: KafkaProducer.Service[K, V, Any]
+trait Producer[R, K, V] {
+  val producer: Producer.Service[R, K, V]
 }
 
-object KafkaProducer {
+object Producer {
   trait Service[-R, K, V] {
     def produce(record: ProducerRecord[K, V]): RIO[R with Blocking, Task[RecordMetadata]]
     def produceChunk(records: Chunk[ProducerRecord[K, V]]): RIO[R with Blocking, Task[Chunk[RecordMetadata]]]
     def flush(): BlockingTask[Unit]
   }
-}
-
-class Producer[-R, K, V] private (
-  p: ByteArrayProducer,
-  keySerializer: Serializer[R, K],
-  valueSerializer: Serializer[R, V]
-) extends KafkaProducer.Service[R, K, V] {
-
-  /**
-   * Produce a single record. The effect returned from this method has two layers and
-   * describes the completion of two actions:
-   * 1. The outer layer describes the enqueueing of the record to the Producer's internal
-   *    buffer.
-   * 2. The inner layer describes receiving an acknowledgement from the broker for the
-   *    transmission of the record.
-   *
-   * It is usually recommended to not await the inner layer of every individual record,
-   * but enqueue a batch of records and await all of their acknowledgements at once. That
-   * amortizes the cost of sending requests to Kafka and increases throughput.
-   */
-  override def produce(record: ProducerRecord[K, V]): RIO[R with Blocking, Task[RecordMetadata]] =
-    for {
-      done             <- Promise.make[Throwable, RecordMetadata]
-      serializedRecord <- serialize(record)
-      runtime          <- ZIO.runtime[Blocking]
-      _ <- effectBlocking {
-            p.send(
-              serializedRecord,
-              new Callback {
-                def onCompletion(metadata: RecordMetadata, err: Exception): Unit = {
-                  if (err != null) runtime.unsafeRun(done.fail(err))
-                  else runtime.unsafeRun(done.succeed(metadata))
-
-                  ()
-                }
-              }
-            )
-          }
-    } yield done.await
-
-  /**
-   * Produces a chunk of records record. The effect returned from this method has two layers
-   * and describes the completion of two actions:
-   * 1. The outer layer describes the enqueueing of all the records to the Producer's
-   *    internal buffer.
-   * 2. The inner layer describes receiving an acknowledgement from the broker for the
-   *    transmission of the records.
-   *
-   * It is possible that for chunks that exceed the producer's internal buffer size, the
-   * outer layer will also signal the transmission of part of the chunk. Regardless,
-   * awaiting the inner layer guarantees the transmission of the entire chunk.
-   */
-  override def produceChunk(records: Chunk[ProducerRecord[K, V]]): RIO[R with Blocking, Task[Chunk[RecordMetadata]]] =
-    if (records.isEmpty) ZIO.succeed(Task.succeed(Chunk.empty))
-    else {
-      for {
-        done              <- Promise.make[Throwable, Chunk[RecordMetadata]]
-        runtime           <- ZIO.runtime[Blocking]
-        serializedRecords <- ZIO.traverse(records.toSeq)(serialize(_))
-        _ <- effectBlocking {
-              val it: Iterator[(ByteArrayProducerRecord, Int)] =
-                serializedRecords.iterator.zipWithIndex
-              val res: Array[RecordMetadata] = new Array[RecordMetadata](records.length)
-              val count: AtomicLong          = new AtomicLong
-
-              while (it.hasNext) {
-                val (rec, idx): (ByteArrayProducerRecord, Int) = it.next
-
-                p.send(
-                  rec,
-                  new Callback {
-                    def onCompletion(metadata: RecordMetadata, err: Exception): Unit = {
-                      if (err != null) runtime.unsafeRun(done.fail(err))
-                      else {
-                        res(idx) = metadata
-                        if (count.incrementAndGet == records.length)
-                          runtime.unsafeRun(done.succeed(Chunk.fromArray(res)))
-                      }
-
-                      ()
-                    }
-                  }
-                )
-              }
-            }
-      } yield done.await
-    }
-
-  /**
-   * Flushes the producer's internal buffer. This will guarantee that all records
-   * currently buffered will be transmitted to the broker.
-   */
-  override def flush: BlockingTask[Unit] = effectBlocking(p.flush())
-
-  private def serialize(
-    r: ProducerRecord[K, V]
-  ): RIO[R, ByteArrayProducerRecord] =
-    for {
-      key   <- keySerializer.serialize(r.topic, r.headers, r.key())
-      value <- valueSerializer.serialize(r.topic, r.headers, r.value())
-    } yield new ProducerRecord(r.topic, r.partition(), r.timestamp(), key, value, r.headers)
-}
-
-object Producer {
 
   /**
    * Create a new Producer for records of some type
@@ -141,10 +37,10 @@ object Producer {
     settings: ProducerSettings,
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V]
-  ): ZManaged[Blocking, Throwable, Producer[R, K, V]] = {
+  ): ZManaged[Blocking, Throwable, Producer.Service[R, K, V]] = {
     val p = ZIO {
       val props = settings.driverSettings.asJava
-      new JKafkaProducer[Array[Byte], Array[Byte]](
+      new KafkaProducer[Array[Byte], Array[Byte]](
         props,
         new ByteArraySerializer(),
         new ByteArraySerializer()
@@ -152,7 +48,7 @@ object Producer {
     }
 
     p.toManaged(p => UIO(p.close(settings.closeTimeout.asJava)))
-      .map(new Producer[R, K, V](_, keySerializer, valueSerializer))
+      .map(new Live[R, K, V](_, keySerializer, valueSerializer))
   }
 
   /**
@@ -171,4 +67,105 @@ object Producer {
     make[R, K, V](settings, keySerializer, valueSerializer).map { producer =>
       ZSink.drain.contramapM(producer.produceChunk)
     }
+
+  class Live[-R, K, V] private[Producer] (
+    p: ByteArrayProducer,
+    keySerializer: Serializer[R, K],
+    valueSerializer: Serializer[R, V]
+  ) extends Service[R, K, V] {
+
+    /**
+     * Produce a single record. The effect returned from this method has two layers and
+     * describes the completion of two actions:
+     * 1. The outer layer describes the enqueueing of the record to the Producer's internal
+     *    buffer.
+     * 2. The inner layer describes receiving an acknowledgement from the broker for the
+     *    transmission of the record.
+     *
+     * It is usually recommended to not await the inner layer of every individual record,
+     * but enqueue a batch of records and await all of their acknowledgements at once. That
+     * amortizes the cost of sending requests to Kafka and increases throughput.
+     */
+    override def produce(record: ProducerRecord[K, V]): RIO[R with Blocking, Task[RecordMetadata]] =
+      for {
+        done             <- Promise.make[Throwable, RecordMetadata]
+        serializedRecord <- serialize(record)
+        runtime          <- ZIO.runtime[Blocking]
+        _ <- effectBlocking {
+              p.send(
+                serializedRecord,
+                new Callback {
+                  def onCompletion(metadata: RecordMetadata, err: Exception): Unit = {
+                    if (err != null) runtime.unsafeRun(done.fail(err))
+                    else runtime.unsafeRun(done.succeed(metadata))
+
+                    ()
+                  }
+                }
+              )
+            }
+      } yield done.await
+
+    /**
+     * Produces a chunk of records record. The effect returned from this method has two layers
+     * and describes the completion of two actions:
+     * 1. The outer layer describes the enqueueing of all the records to the Producer's
+     *    internal buffer.
+     * 2. The inner layer describes receiving an acknowledgement from the broker for the
+     *    transmission of the records.
+     *
+     * It is possible that for chunks that exceed the producer's internal buffer size, the
+     * outer layer will also signal the transmission of part of the chunk. Regardless,
+     * awaiting the inner layer guarantees the transmission of the entire chunk.
+     */
+    override def produceChunk(records: Chunk[ProducerRecord[K, V]]): RIO[R with Blocking, Task[Chunk[RecordMetadata]]] =
+      if (records.isEmpty) ZIO.succeed(Task.succeed(Chunk.empty))
+      else {
+        for {
+          done              <- Promise.make[Throwable, Chunk[RecordMetadata]]
+          runtime           <- ZIO.runtime[Blocking]
+          serializedRecords <- ZIO.traverse(records.toSeq)(serialize(_))
+          _ <- effectBlocking {
+                val it: Iterator[(ByteArrayProducerRecord, Int)] =
+                  serializedRecords.iterator.zipWithIndex
+                val res: Array[RecordMetadata] = new Array[RecordMetadata](records.length)
+                val count: AtomicLong          = new AtomicLong
+
+                while (it.hasNext) {
+                  val (rec, idx): (ByteArrayProducerRecord, Int) = it.next
+
+                  p.send(
+                    rec,
+                    new Callback {
+                      def onCompletion(metadata: RecordMetadata, err: Exception): Unit = {
+                        if (err != null) runtime.unsafeRun(done.fail(err))
+                        else {
+                          res(idx) = metadata
+                          if (count.incrementAndGet == records.length)
+                            runtime.unsafeRun(done.succeed(Chunk.fromArray(res)))
+                        }
+
+                        ()
+                      }
+                    }
+                  )
+                }
+              }
+        } yield done.await
+      }
+
+    /**
+     * Flushes the producer's internal buffer. This will guarantee that all records
+     * currently buffered will be transmitted to the broker.
+     */
+    override def flush: BlockingTask[Unit] = effectBlocking(p.flush())
+
+    private def serialize(
+      r: ProducerRecord[K, V]
+    ): RIO[R, ByteArrayProducerRecord] =
+      for {
+        key   <- keySerializer.serialize(r.topic, r.headers, r.key())
+        value <- valueSerializer.serialize(r.topic, r.headers, r.value())
+      } yield new ProducerRecord(r.topic, r.partition(), r.timestamp(), key, value, r.headers)
+  }
 }

--- a/src/main/scala/zio/kafka/client/SubscribedConsumer.scala
+++ b/src/main/scala/zio/kafka/client/SubscribedConsumer.scala
@@ -6,7 +6,7 @@ import zio.clock.Clock
 import zio.kafka.client.serde.Deserializer
 import zio.stream.{ ZStream, ZStreamChunk }
 
-class SubscribedConsumer(private val underlying: BlockingTask[Consumer]) {
+class SubscribedConsumer(private val underlying: BlockingTask[Consumer.Service]) {
 
   def partitionedStream[R, K, V](
     keyDeserializer: Deserializer[R, K],

--- a/src/main/scala/zio/kafka/client/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/client/internal/Runloop.scala
@@ -218,8 +218,8 @@ private[client] object Runloop {
                   }
                 )
               }
-            }.catchAll(
-              e => cont(Exit.fail(e)) <* deps.emitIfEnabledDiagnostic(DiagnosticEvent.Commit.Failure(offsets, e))
+            }.catchAll(e =>
+              cont(Exit.fail(e)) <* deps.emitIfEnabledDiagnostic(DiagnosticEvent.Commit.Failure(offsets, e))
             )
       } yield ()
 

--- a/src/main/scala/zio/kafka/client/package.scala
+++ b/src/main/scala/zio/kafka/client/package.scala
@@ -3,7 +3,7 @@ package zio.kafka
 import java.util.{ Map => JMap }
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
-import org.apache.kafka.clients.producer.{ KafkaProducer => JKafkaProducer, ProducerRecord }
+import org.apache.kafka.clients.producer.{ KafkaProducer, ProducerRecord }
 import org.apache.kafka.common.TopicPartition
 
 import zio.ZIO
@@ -16,6 +16,6 @@ package object client {
 
   type JOffsetMap = JMap[TopicPartition, OffsetAndMetadata]
 
-  type ByteArrayProducer       = JKafkaProducer[Array[Byte], Array[Byte]]
+  type ByteArrayProducer       = KafkaProducer[Array[Byte], Array[Byte]]
   type ByteArrayProducerRecord = ProducerRecord[Array[Byte], Array[Byte]]
 }

--- a/src/main/scala/zio/kafka/client/package.scala
+++ b/src/main/scala/zio/kafka/client/package.scala
@@ -3,7 +3,7 @@ package zio.kafka
 import java.util.{ Map => JMap }
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
-import org.apache.kafka.clients.producer.{ KafkaProducer, ProducerRecord }
+import org.apache.kafka.clients.producer.{ KafkaProducer => JKafkaProducer, ProducerRecord }
 import org.apache.kafka.common.TopicPartition
 
 import zio.ZIO
@@ -16,6 +16,6 @@ package object client {
 
   type JOffsetMap = JMap[TopicPartition, OffsetAndMetadata]
 
-  type ByteArrayProducer       = KafkaProducer[Array[Byte], Array[Byte]]
+  type ByteArrayProducer       = JKafkaProducer[Array[Byte], Array[Byte]]
   type ByteArrayProducerRecord = ProducerRecord[Array[Byte], Array[Byte]]
 }

--- a/src/test/scala/zio/kafka/client/ConsumerMock.scala
+++ b/src/test/scala/zio/kafka/client/ConsumerMock.scala
@@ -1,0 +1,87 @@
+package zio.kafka.client
+
+import zio.test.mock.Method
+import zio.test.mock.Mockable
+import zio.test.mock.Mock
+
+import org.apache.kafka.clients.consumer.{ OffsetAndMetadata, OffsetAndTimestamp }
+import org.apache.kafka.common.{ PartitionInfo, TopicPartition }
+import zio._
+import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.duration._
+import zio.kafka.client.serde.Deserializer
+import zio.stream._
+
+object ConsumerMock {
+  object assignment       extends Method[Consumer, Unit, Set[TopicPartition]]
+  object beginningOffsets extends Method[Consumer, (Set[TopicPartition], Duration), Map[TopicPartition, Long]]
+  object committed
+      extends Method[Consumer, (Set[TopicPartition], Duration), Map[TopicPartition, Option[OffsetAndMetadata]]]
+  object endOffsets      extends Method[Consumer, (Set[TopicPartition], Duration), Map[TopicPartition, Long]]
+  object stopConsumption extends Method[Consumer, Unit, Unit]
+  object listTopics      extends Method[Consumer, Duration, Map[String, List[PartitionInfo]]]
+  object offsetsForTimes
+      extends Method[Consumer, (Map[TopicPartition, Long], Duration), Map[TopicPartition, OffsetAndTimestamp]]
+  object partitionsFor   extends Method[Consumer, (String, Duration), List[PartitionInfo]]
+  object position        extends Method[Consumer, (TopicPartition, Duration), Long]
+  object seek            extends Method[Consumer, (TopicPartition, Long), Unit]
+  object seekToBeginning extends Method[Consumer, Set[TopicPartition], Unit]
+  object seekToEnd       extends Method[Consumer, Set[TopicPartition], Unit]
+  object subscribe       extends Method[Consumer, Subscription, Unit]
+  object subscription    extends Method[Consumer, Unit, Set[String]]
+  object unsubscribe     extends Method[Consumer, Unit, Unit]
+
+  implicit val mockable: Mockable[Consumer] = (mock: Mock) =>
+    new Consumer {
+      val consumer = new Consumer.Service {
+        def assignment: BlockingTask[Set[TopicPartition]] = mock(ConsumerMock.assignment)
+        def beginningOffsets(
+          partitions: Set[TopicPartition],
+          timeout: Duration
+        ): BlockingTask[Map[TopicPartition, Long]] = mock(ConsumerMock.beginningOffsets, partitions, timeout)
+        def committed(
+          partitions: Set[TopicPartition],
+          timeout: Duration
+        ): BlockingTask[Map[TopicPartition, Option[OffsetAndMetadata]]] =
+          mock(ConsumerMock.committed, partitions, timeout)
+        def endOffsets(
+          partitions: Set[TopicPartition],
+          timeout: Duration
+        ): BlockingTask[Map[TopicPartition, Long]] = mock(ConsumerMock.endOffsets, partitions, timeout)
+        def stopConsumption: UIO[Unit]             = mock(ConsumerMock.stopConsumption)
+        def listTopics(timeout: Duration): BlockingTask[Map[String, List[PartitionInfo]]] =
+          mock(ConsumerMock.listTopics, timeout)
+        def offsetsForTimes(
+          timestamps: Map[TopicPartition, Long],
+          timeout: Duration
+        ): BlockingTask[Map[TopicPartition, OffsetAndTimestamp]] =
+          mock(ConsumerMock.offsetsForTimes, timestamps, timeout)
+        def partitionedStream[R, K, V](
+          keyDeserializer: Deserializer[R, K],
+          valueDeserializer: Deserializer[R, V]
+        ): ZStream[
+          Clock with Blocking,
+          Throwable,
+          (TopicPartition, ZStreamChunk[R, Throwable, CommittableRecord[K, V]])
+        ] = ???
+        def partitionsFor(topic: String, timeout: Duration): BlockingTask[List[PartitionInfo]] =
+          mock(ConsumerMock.partitionsFor, topic, timeout)
+        def position(partition: TopicPartition, timeout: Duration): BlockingTask[Long] =
+          mock(ConsumerMock.position, partition, timeout)
+        def plainStream[R, K, V](
+          keyDeserializer: Deserializer[R, K],
+          valueDeserializer: Deserializer[R, V]
+        ): ZStreamChunk[R with Clock with Blocking, Throwable, CommittableRecord[K, V]] = ???
+        def seek(partition: TopicPartition, offset: Long): BlockingTask[Unit] =
+          mock(ConsumerMock.seek, partition, offset)
+        def seekToBeginning(partitions: Set[TopicPartition]): BlockingTask[Unit] =
+          mock(ConsumerMock.seekToBeginning, partitions)
+        def seekToEnd(partitions: Set[TopicPartition]): BlockingTask[Unit] = mock(ConsumerMock.seekToEnd, partitions)
+        def subscribe(subscription: Subscription): BlockingTask[Unit]      = mock(ConsumerMock.subscribe, subscription)
+        def subscribeAnd(subscription: Subscription): SubscribedConsumer   = ???
+        def subscription(): BlockingTask[Set[String]]                      = mock(ConsumerMock.subscription)
+        def unsubscribe(): BlockingTask[Unit]                              = mock(ConsumerMock.unsubscribe)
+      }
+    }
+}

--- a/src/test/scala/zio/kafka/client/ConsumerMock.scala
+++ b/src/test/scala/zio/kafka/client/ConsumerMock.scala
@@ -13,28 +13,34 @@ import zio.duration._
 import zio.kafka.client.serde.Deserializer
 import zio.stream._
 
-object ConsumerMock {
-  object assignment       extends Method[Consumer, Unit, Set[TopicPartition]]
-  object beginningOffsets extends Method[Consumer, (Set[TopicPartition], Duration), Map[TopicPartition, Long]]
-  object committed
-      extends Method[Consumer, (Set[TopicPartition], Duration), Map[TopicPartition, Option[OffsetAndMetadata]]]
-  object endOffsets      extends Method[Consumer, (Set[TopicPartition], Duration), Map[TopicPartition, Long]]
-  object stopConsumption extends Method[Consumer, Unit, Unit]
-  object listTopics      extends Method[Consumer, Duration, Map[String, List[PartitionInfo]]]
-  object offsetsForTimes
-      extends Method[Consumer, (Map[TopicPartition, Long], Duration), Map[TopicPartition, OffsetAndTimestamp]]
-  object partitionsFor   extends Method[Consumer, (String, Duration), List[PartitionInfo]]
-  object position        extends Method[Consumer, (TopicPartition, Duration), Long]
-  object seek            extends Method[Consumer, (TopicPartition, Long), Unit]
-  object seekToBeginning extends Method[Consumer, Set[TopicPartition], Unit]
-  object seekToEnd       extends Method[Consumer, Set[TopicPartition], Unit]
-  object subscribe       extends Method[Consumer, Subscription, Unit]
-  object subscription    extends Method[Consumer, Unit, Set[String]]
-  object unsubscribe     extends Method[Consumer, Unit, Unit]
+trait ConsumerMock extends Consumer {
+  val consumer: ConsumerMock.Service
+}
 
-  implicit val mockable: Mockable[Consumer] = (mock: Mock) =>
-    new Consumer {
-      val consumer = new Consumer.Service {
+object ConsumerMock {
+  trait Service extends Consumer.Service
+
+  object assignment       extends Method[ConsumerMock, Unit, Set[TopicPartition]]
+  object beginningOffsets extends Method[ConsumerMock, (Set[TopicPartition], Duration), Map[TopicPartition, Long]]
+  object committed
+      extends Method[ConsumerMock, (Set[TopicPartition], Duration), Map[TopicPartition, Option[OffsetAndMetadata]]]
+  object endOffsets      extends Method[ConsumerMock, (Set[TopicPartition], Duration), Map[TopicPartition, Long]]
+  object stopConsumption extends Method[ConsumerMock, Unit, Unit]
+  object listTopics      extends Method[ConsumerMock, Duration, Map[String, List[PartitionInfo]]]
+  object offsetsForTimes
+      extends Method[ConsumerMock, (Map[TopicPartition, Long], Duration), Map[TopicPartition, OffsetAndTimestamp]]
+  object partitionsFor   extends Method[ConsumerMock, (String, Duration), List[PartitionInfo]]
+  object position        extends Method[ConsumerMock, (TopicPartition, Duration), Long]
+  object seek            extends Method[ConsumerMock, (TopicPartition, Long), Unit]
+  object seekToBeginning extends Method[ConsumerMock, Set[TopicPartition], Unit]
+  object seekToEnd       extends Method[ConsumerMock, Set[TopicPartition], Unit]
+  object subscribe       extends Method[ConsumerMock, Subscription, Unit]
+  object subscription    extends Method[ConsumerMock, Unit, Set[String]]
+  object unsubscribe     extends Method[ConsumerMock, Unit, Unit]
+
+  implicit val mockable: Mockable[ConsumerMock] = (mock: Mock) =>
+    new ConsumerMock {
+      val consumer = new Service {
         def assignment: BlockingTask[Set[TopicPartition]] = mock(ConsumerMock.assignment)
         def beginningOffsets(
           partitions: Set[TopicPartition],

--- a/src/test/scala/zio/kafka/client/ConsumerMock.scala
+++ b/src/test/scala/zio/kafka/client/ConsumerMock.scala
@@ -38,8 +38,8 @@ object ConsumerMock {
   object subscription    extends Method[ConsumerMock, Unit, Set[String]]
   object unsubscribe     extends Method[ConsumerMock, Unit, Unit]
 
-  implicit val mockable: Mockable[ConsumerMock] = (mock: Mock) =>
-    new ConsumerMock {
+  implicit val mockable = new Mockable[ConsumerMock] {
+    override def environment(mock: Mock) = new ConsumerMock {
       val consumer = new Service {
         def assignment: BlockingTask[Set[TopicPartition]] = mock(ConsumerMock.assignment)
         def beginningOffsets(
@@ -90,4 +90,5 @@ object ConsumerMock {
         def unsubscribe(): BlockingTask[Unit]                              = mock(ConsumerMock.unsubscribe)
       }
     }
+  }
 }

--- a/src/test/scala/zio/kafka/client/ConsumerModuleTest.scala
+++ b/src/test/scala/zio/kafka/client/ConsumerModuleTest.scala
@@ -1,12 +1,12 @@
 package zio.kafka.client
 
-import zio.test.{ assertM, checkM, suite, testM, DefaultRunnableSpec, Gen }
-import zio.test.mock.Expectation.value
-import zio.Managed
-import zio.test.environment.TestEnvironment
-import zio.blocking.Blocking
 import org.apache.kafka.common.TopicPartition
+import zio.blocking.Blocking
+import zio.Managed
+import zio.test._
 import zio.test.Assertion.equalTo
+import zio.test.mock.Expectation.value
+import zio.test.environment.TestEnvironment
 
 object ConsumerModuleTestUtils {
   def makeEnv(managed: Managed[Nothing, Consumer]): Managed[Nothing, Consumer with Blocking] =

--- a/src/test/scala/zio/kafka/client/ConsumerModuleTest.scala
+++ b/src/test/scala/zio/kafka/client/ConsumerModuleTest.scala
@@ -1,12 +1,16 @@
 package zio.kafka.client
 
-import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.clients.consumer.{ OffsetAndMetadata, OffsetAndTimestamp }
+import org.apache.kafka.common.{ PartitionInfo, TopicPartition }
 import zio.blocking.Blocking
+import zio.duration._
 import zio.Managed
+import zio.random.Random
 import zio.test._
-import zio.test.Assertion.equalTo
+import zio.test.Assertion.{ equalTo, isUnit }
 import zio.test.mock.Expectation.value
 import zio.test.environment.TestEnvironment
+import zio.test.TestAspect.timeout
 
 object ConsumerModuleTestUtils {
   def makeEnv(managed: Managed[Nothing, Consumer]): Managed[Nothing, Consumer with Blocking] =
@@ -18,12 +22,63 @@ object ConsumerModuleTestUtils {
       val consumer = c.consumer
     }
 
-  lazy val assignmentsGen = Gen.sized { s =>
-    val inner = Gen.alphaNumericString <*> Gen.int(0, 100) map {
-      case (t, p) => new TopicPartition(t, p)
-    }
-    Gen.vectorOfN(s)(inner) map { _.toSet }
+  val anyPosLong = Gen.anyLong.filter(_ > 0)
+
+  val anyTopicPartition = Gen.alphaNumericString <*> Gen.int(0, 100) map {
+    case (t, p) => new TopicPartition(t, p)
   }
+
+  val anyDuration = anyPosLong.map(Duration.Finite.apply)
+
+  val anyOffset = anyTopicPartition <*> anyPosLong
+
+  val anyOffsetAndMetadata = anyPosLong <*> Gen.alphaNumericString map {
+    case (offset, meta) => new OffsetAndMetadata(offset, meta)
+  }
+
+  val anyTopicOffsetAndMetadata = anyTopicPartition <*> anyOffsetAndMetadata
+
+  // empty because the class is large and provides no `.equals()`
+  val anyPartitionInfo = Gen.const(List.empty[PartitionInfo])
+
+  val anyTopicInfo = Gen.alphaNumericString <*> anyPartitionInfo
+
+  val anyOffsetAndTimestamp = anyPosLong <*> anyPosLong map {
+    case (offset, ts) => new OffsetAndTimestamp(offset, ts)
+  }
+
+  val anyTopicOffsetAndTimestamp = anyTopicPartition <*> anyOffsetAndTimestamp
+
+  val anyTopicSubscription: Gen[Random with Sized, Subscription] =
+    Gen.listOf(Gen.alphaNumericString).map(x => Subscription.Topics(x.toSet))
+
+  val anyPatternSubscription: Gen[Random with Sized, Subscription] =
+    Gen.alphaNumericString.map(x => Subscription.Pattern(x.r))
+
+  val anyManualSubscription: Gen[Random with Sized, Subscription] =
+    Gen.listOf(anyTopicPartition).map(x => Subscription.Manual(x.toSet))
+
+  val anySubscription = Gen.oneOf(
+    anyTopicSubscription,
+    anyPatternSubscription,
+    anyManualSubscription
+  )
+
+  val topicPartitions = Gen.listOf(anyTopicPartition).map(_.toSet)
+
+  val offsets = Gen.listOf(anyOffset).map(_.toMap)
+
+  val topicOffsetsAndMetadata = Gen
+    .listOf(
+      anyTopicOffsetAndMetadata.map(t => (t._1, Option(t._2)))
+    )
+    .map(_.toMap)
+
+  val topicInfo = Gen.listOf(anyTopicInfo).map(_.toMap)
+
+  val topicOffsetAndTimestamps = Gen.listOf(anyTopicOffsetAndTimestamp).map(_.toMap)
+
+  val topicNames = Gen.listOf(Gen.alphaNumericString).map(_.toSet)
 }
 import ConsumerModuleTestUtils._
 
@@ -32,7 +87,7 @@ object ConsumerModuleTest
       suite("Consumer module")(
         suite("delegates")(
           testM("assignment")(
-            checkM(assignmentsGen) { a =>
+            checkM(topicPartitions) { a =>
               val eff  = Consumer.assignment
               val mock = ConsumerMock.assignment returns value(a)
               val env  = makeEnv(mock)
@@ -41,7 +96,169 @@ object ConsumerModuleTest
 
               assertM(result, equalTo(a))
             }
-          )
+          ),
+          testM("beginningOffsets")(
+            checkM(offsets <*> anyDuration) {
+              case (off, dur) =>
+                val p    = off.keySet
+                val eff  = Consumer.beginningOffsets(p, dur)
+                val mock = ConsumerMock.beginningOffsets(equalTo((p, dur))) returns value(off)
+                val env  = makeEnv(mock)
+
+                val result = eff.provideManaged(env)
+
+                assertM(result, equalTo(off))
+            }
+          ),
+          testM("committed")(
+            checkM(topicOffsetsAndMetadata <*> anyDuration) {
+              case (meta, dur) =>
+                val p    = meta.keySet
+                val eff  = Consumer.committed(p, dur)
+                val mock = ConsumerMock.committed(equalTo((p, dur))) returns value(meta)
+                val env  = makeEnv(mock)
+
+                val result = eff.provideManaged(env)
+
+                assertM(result, equalTo(meta))
+            }
+          ),
+          testM("endOffsets")(
+            checkM(offsets <*> anyDuration) {
+              case (off, dur) =>
+                val p    = off.keySet
+                val eff  = Consumer.endOffsets(p, dur)
+                val mock = ConsumerMock.endOffsets(equalTo((p, dur))) returns value(off)
+                val env  = makeEnv(mock)
+
+                val result = eff.provideManaged(env)
+
+                assertM(result, equalTo(off))
+            }
+          ),
+          testM("stopConsumption") {
+            val eff  = Consumer.stopConsumption
+            val mock = ConsumerMock.stopConsumption returns value(())
+            val env  = makeEnv(mock)
+
+            val result = eff.provideManaged(env)
+
+            assertM(result, isUnit)
+          },
+          testM("listTopics")(
+            checkM(anyDuration <*> topicInfo) {
+              case (dur, topics) =>
+                val eff  = Consumer.listTopics(dur)
+                val mock = ConsumerMock.listTopics(equalTo(dur)) returns value(topics)
+                val env  = makeEnv(mock)
+
+                val result = eff.provideManaged(env)
+
+                assertM(result, equalTo(topics))
+            }
+          ),
+          testM("offsetsForTimes")(
+            checkM(anyDuration <*> topicOffsetAndTimestamps) {
+              case (dur, res) =>
+                val ts   = res.view.mapValues(_.timestamp).toMap
+                val eff  = Consumer.offsetsForTimes(ts, dur)
+                val mock = ConsumerMock.offsetsForTimes(equalTo((ts, dur))) returns value(res)
+                val env  = makeEnv(mock)
+
+                val result = eff.provideManaged(env)
+
+                assertM(result, equalTo(res))
+            }
+          ),
+          testM("partitionsFor")(
+            checkM(Gen.alphaNumericString <*> anyDuration <*> anyPartitionInfo) {
+              case ((topic, dur), res) =>
+                val eff  = Consumer.partitionsFor(topic, dur)
+                val mock = ConsumerMock.partitionsFor(equalTo((topic, dur))) returns value(res)
+                val env  = makeEnv(mock)
+
+                val result = eff.provideManaged(env)
+
+                assertM(result, equalTo(res))
+            }
+          ),
+          testM("position")(
+            checkM(anyTopicPartition <*> anyDuration <*> anyPosLong) {
+              case ((tp, dur), pos) =>
+                val eff  = Consumer.position(tp, dur)
+                val mock = ConsumerMock.position(equalTo((tp, dur))) returns value(pos)
+                val env  = makeEnv(mock)
+
+                val result = eff.provideManaged(env)
+
+                assertM(result, equalTo(pos))
+            }
+          ),
+          testM("seek")(
+            checkM(anyTopicPartition <*> anyPosLong) {
+              case (tp, off) =>
+                val eff  = Consumer.seek(tp, off)
+                val mock = ConsumerMock.seek(equalTo((tp, off))) returns value(())
+                val env  = makeEnv(mock)
+
+                val result = eff.provideManaged(env)
+
+                assertM(result, isUnit)
+            }
+          ),
+          testM("seekToBeginning")(
+            checkM(topicPartitions) { tp =>
+              val eff  = Consumer.seekToBeginning(tp)
+              val mock = ConsumerMock.seekToBeginning(equalTo(tp)) returns value(())
+              val env  = makeEnv(mock)
+
+              val result = eff.provideManaged(env)
+
+              assertM(result, isUnit)
+            }
+          ),
+          testM("seekToEnd")(
+            checkM(topicPartitions) { tp =>
+              val eff  = Consumer.seekToEnd(tp)
+              val mock = ConsumerMock.seekToEnd(equalTo(tp)) returns value(())
+              val env  = makeEnv(mock)
+
+              val result = eff.provideManaged(env)
+
+              assertM(result, isUnit)
+            }
+          ),
+          testM("subscribe")(
+            checkM(anySubscription) { s =>
+              val eff  = Consumer.subscribe(s)
+              val mock = ConsumerMock.subscribe(equalTo(s)) returns value(())
+              val env  = makeEnv(mock)
+
+              val result = eff.provideManaged(env)
+
+              assertM(result, isUnit)
+            }
+          ),
+          testM("subscription")(
+            checkM(topicNames) { t =>
+              val eff  = Consumer.subscription()
+              val mock = ConsumerMock.subscription returns value(t)
+              val env  = makeEnv(mock)
+
+              val result = eff.provideManaged(env)
+
+              assertM(result, equalTo(t))
+            }
+          ),
+          testM("unsubscribe") {
+            val eff  = Consumer.unsubscribe()
+            val mock = ConsumerMock.unsubscribe returns value(())
+            val env  = makeEnv(mock)
+
+            val result = eff.provideManaged(env)
+
+            assertM(result, isUnit)
+          }
         )
-      )
+      ) @@ timeout(10.seconds)
     )

--- a/src/test/scala/zio/kafka/client/ConsumerModuleTest.scala
+++ b/src/test/scala/zio/kafka/client/ConsumerModuleTest.scala
@@ -260,5 +260,5 @@ object ConsumerModuleTest
             assertM(result, isUnit)
           }
         )
-      ) @@ timeout(10.seconds)
+      ) @@ timeout(30.seconds)
     )

--- a/src/test/scala/zio/kafka/client/ConsumerModuleTest.scala
+++ b/src/test/scala/zio/kafka/client/ConsumerModuleTest.scala
@@ -1,0 +1,44 @@
+package zio.kafka.client
+
+import zio.test.{ assertM, suite, testM }
+import zio.test.DefaultRunnableSpec
+import zio.test.mock.Expectation.value
+import zio.Managed
+import zio.test.environment.TestEnvironment
+import zio.blocking.Blocking
+import org.apache.kafka.common.TopicPartition
+import zio.test.Assertion.equalTo
+
+object ConsumerModuleTestUtils {
+  def makeEnv(managed: Managed[Nothing, Consumer]): Managed[Nothing, Consumer with Blocking] =
+    for {
+      testEnv <- TestEnvironment.Value
+      c       <- managed
+    } yield new Consumer with Blocking {
+      val blocking = testEnv.blocking
+      val consumer = c.consumer
+    }
+
+  lazy val cannedAssignments: Set[TopicPartition] = Set(
+    new TopicPartition("foobar", 1),
+    new TopicPartition("foobar", 3)
+  )
+}
+import ConsumerModuleTestUtils._
+
+object ConsumerModuleTest
+    extends DefaultRunnableSpec(
+      suite("Consumer module")(
+        suite("delegates")(
+          testM("assignment") {
+            val eff  = Consumer.assignment
+            val mock = ConsumerMock.assignment returns value(cannedAssignments)
+            val env  = makeEnv(mock)
+
+            val result = eff.provideManaged(env)
+
+            assertM(result, equalTo(cannedAssignments))
+          }
+        )
+      )
+    )

--- a/src/test/scala/zio/kafka/client/ConsumerModuleTest.scala
+++ b/src/test/scala/zio/kafka/client/ConsumerModuleTest.scala
@@ -12,6 +12,8 @@ import zio.test.mock.Expectation.value
 import zio.test.environment.TestEnvironment
 import zio.test.TestAspect.timeout
 
+import scala.collection.compat._
+
 object ConsumerModuleTestUtils {
   def makeEnv(managed: Managed[Nothing, Consumer]): Managed[Nothing, Consumer with Blocking] =
     for {

--- a/src/test/scala/zio/kafka/client/KafkaTestUtils.scala
+++ b/src/test/scala/zio/kafka/client/KafkaTestUtils.scala
@@ -178,7 +178,7 @@ object KafkaTestUtils {
     clientId: String,
     diagnostics: Diagnostics = Diagnostics.NoOp
   )(
-    r: Consumer => RIO[R, A]
+    r: Consumer.Service => RIO[R, A]
   ): RIO[KafkaTestEnvironment, A] =
     for {
       lcb <- Kafka.liveClockBlocking

--- a/src/test/scala/zio/kafka/client/KafkaTestUtils.scala
+++ b/src/test/scala/zio/kafka/client/KafkaTestUtils.scala
@@ -102,7 +102,7 @@ object KafkaTestUtils {
     )
 
   def withProducer[A, K, V](
-    r: Producer[Any, K, V] => RIO[Any with Clock with Kafka with Blocking, A],
+    r: Producer.Service[Any, K, V] => RIO[Any with Clock with Kafka with Blocking, A],
     kSerde: Serde[Any, K],
     vSerde: Serde[Any, V]
   ): RIO[KafkaTestEnvironment, A] =
@@ -115,7 +115,9 @@ object KafkaTestUtils {
                  }
     } yield produced
 
-  def withProducerStrings[A](r: Producer[Any, String, String] => RIO[Any with Clock with Kafka with Blocking, A]) =
+  def withProducerStrings[A](
+    r: Producer.Service[Any, String, String] => RIO[Any with Clock with Kafka with Blocking, A]
+  ) =
     withProducer(r, Serde.string, Serde.string)
 
   def produceOne(t: String, k: String, m: String) =

--- a/src/test/scala/zio/kafka/client/ProducerTest.scala
+++ b/src/test/scala/zio/kafka/client/ProducerTest.scala
@@ -31,8 +31,8 @@ object ProducerTest
               def withConsumer(subscription: Subscription, settings: ConsumerSettings) =
                 Consumer
                   .make(settings)
-                  .flatMap(
-                    c => c.subscribe(subscription).toManaged_ *> c.plainStream(Serde.string, Serde.string).toQueue()
+                  .flatMap(c =>
+                    c.subscribe(subscription).toManaged_ *> c.plainStream(Serde.string, Serde.string).toQueue()
                   )
 
               for {


### PR DESCRIPTION
Adds modules for the producer and consumer. Current implementation provides the trait + service value structure common to ZIO modules.

PR opened to collect comments & suggestions.

Below are some outstanding questions/thoughts for improving this implementation:

- `Producer` has type parameters `K` and `V` for the key and value deserializers, this violates the accessible/mockable constraint of having only one type parameter for the environment (commonly `R`)
- `Consumer` implementation has methods that don't return effects; this is fixable, but needs to be done in a way that doesn't break existing downstream code
- `Producer` has varying environment type for the effects it returns (some methods are using `R with Blocking` whereas some return a `BlockingTask`)

Fixes #106 