### PR TITLE
Handle null TopicDescription.authorizedOperations

### DIFF
--- a/src/main/scala/zio/kafka/client/AdminClient.scala
+++ b/src/main/scala/zio/kafka/client/AdminClient.scala
@@ -176,12 +176,14 @@ object AdminClient {
     name: String,
     internal: Boolean,
     partitions: List[TopicPartitionInfo],
-    authorizedOperations: Set[AclOperation]
+    authorizedOperations: Option[Set[AclOperation]]
   )
 
   object TopicDescription {
-    def apply(jt: JTopicDescription): TopicDescription =
-      TopicDescription(jt.name, jt.isInternal, jt.partitions.asScala.toList, jt.authorizedOperations.asScala.toSet)
+    def apply(jt: JTopicDescription): TopicDescription = {
+      val authorizedOperations = Option(jt.authorizedOperations).map(_.asScala.toSet)
+      TopicDescription(jt.name, jt.isInternal, jt.partitions.asScala.toList, authorizedOperations)
+    }
   }
 
   case class KafkaAdminClientConfig(


### PR DESCRIPTION
According to the Javadoc, the `authorizedOperations` method on
`TopicDescription` can return `null` if the authorized operations are
not known.