### PR TITLE
Producer and Consumer services as ZLayers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val scala213  = "2.13.1"
 lazy val mainScala = scala213
 lazy val allScala  = Seq(scala212, mainScala)
 
-lazy val zioVersion   = "1.0.0-RC17+396-b16c7e10-SNAPSHOT"
+lazy val zioVersion   = "1.0.0-RC17+443-06dfa39f-SNAPSHOT"
 lazy val kafkaVersion = "2.4.0"
 
 // Allows to silence scalac compilation warnings selectively by code block or file path

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val scala213  = "2.13.1"
 lazy val mainScala = scala213
 lazy val allScala  = Seq(scala212, mainScala)
 
-lazy val zioVersion   = "1.0.0-RC17+443-06dfa39f-SNAPSHOT"
+lazy val zioVersion   = "1.0.0-RC18"
 lazy val kafkaVersion = "2.4.0"
 
 // Allows to silence scalac compilation warnings selectively by code block or file path

--- a/src/main/scala/zio/kafka/client/Consumer.scala
+++ b/src/main/scala/zio/kafka/client/Consumer.scala
@@ -10,6 +10,7 @@ import zio.kafka.client.serde.Deserializer
 import zio.kafka.client.diagnostics.Diagnostics
 import zio.kafka.client.internal.{ ConsumerAccess, Runloop }
 import zio.stream._
+import scala.collection.compat._
 
 import scala.jdk.CollectionConverters._
 
@@ -118,6 +119,8 @@ object Consumer {
     ): ZIO[R with RC with Blocking with Clock, Throwable, Unit]
 
     def subscribe(subscription: Subscription): BlockingTask[Unit]
+
+    def unsubscribe: BlockingTask[Unit]
 
     def offsetsForTimes(
       timestamps: Map[TopicPartition, Long],
@@ -265,7 +268,7 @@ object Consumer {
         }
       }
 
-    private def unsubscribe: BlockingTask[Unit] =
+    override def unsubscribe: BlockingTask[Unit] =
       consumer.withConsumer(_.unsubscribe())
   }
 

--- a/src/main/scala/zio/kafka/client/Consumer.scala
+++ b/src/main/scala/zio/kafka/client/Consumer.scala
@@ -333,7 +333,7 @@ object Consumer {
   def assignment[R, K, V](
     implicit tsv: Tagged[Service[R, K, V]]
   ): RIO[R with Blocking with Consumer[R, K, V], Set[TopicPartition]] =
-    withConsumerService(_.assignment)
+    withConsumerService[R, Any, K, V, Set[TopicPartition]](_.assignment)
 
   /**
    * Accessor method for [[Service.beginningOffsets]]
@@ -342,7 +342,7 @@ object Consumer {
     partitions: Set[TopicPartition],
     timeout: Duration = Duration.Infinity
   )(implicit tsv: Tagged[Service[R, K, V]]): RIO[R with Blocking with Consumer[R, K, V], Map[TopicPartition, Long]] =
-    withConsumerService(_.beginningOffsets(partitions, timeout))
+    withConsumerService[R, Any, K, V, Map[TopicPartition, Long]](_.beginningOffsets(partitions, timeout))
 
   /**
    * Accessor method for [[Service.committed]]
@@ -353,7 +353,7 @@ object Consumer {
   )(
     implicit tsv: Tagged[Service[R, K, V]]
   ): RIO[R with Blocking with Consumer[R, K, V], Map[TopicPartition, Option[OffsetAndMetadata]]] =
-    withConsumerService(_.committed(partitions, timeout))
+    withConsumerService[R, Any, K, V, Map[TopicPartition, Option[OffsetAndMetadata]]](_.committed(partitions, timeout))
 
   /**
    * Accessor method for [[Service.endOffsets]]
@@ -362,7 +362,7 @@ object Consumer {
     partitions: Set[TopicPartition],
     timeout: Duration = Duration.Infinity
   )(implicit tsv: Tagged[Service[R, K, V]]): RIO[R with Blocking with Consumer[R, K, V], Map[TopicPartition, Long]] =
-    withConsumerService(_.endOffsets(partitions, timeout))
+    withConsumerService[R, Any, K, V, Map[TopicPartition, Long]](_.endOffsets(partitions, timeout))
 
   /**
    * Accessor method for [[Service.listTopics]]
@@ -370,7 +370,7 @@ object Consumer {
   def listTopics[R, K, V](timeout: Duration = Duration.Infinity)(
     implicit tsv: Tagged[Service[R, K, V]]
   ): RIO[R with Blocking with Consumer[R, K, V], Map[String, List[PartitionInfo]]] =
-    withConsumerService(_.listTopics(timeout))
+    withConsumerService[R, Any, K, V, Map[String, List[PartitionInfo]]](_.listTopics(timeout))
 
   /**
    * Accessor method for [[Service.partitionedStream]]
@@ -388,10 +388,7 @@ object Consumer {
   def plainStream[R, K, V](
     implicit tsv: Tagged[Service[R, K, V]]
   ): ZStreamChunk[R with Consumer[R, K, V] with Clock with Blocking, Throwable, CommittableRecord[K, V]] =
-    ZStreamChunk(
-      ZStream
-        .accessStream[R with Consumer[R, K, V] with Clock with Blocking](_.get[Service[R, K, V]].plainStream.chunks)
-    )
+    ZStreamChunk(ZStream.accessStream(_.get[Service[R, K, V]].plainStream.chunks))
 
   /**
    * Accessor method for [[Service.stopConsumption]]
@@ -420,7 +417,7 @@ object Consumer {
   def subscribe[R, K, V](subscription: Subscription)(
     implicit tsv: Tagged[Service[R, K, V]]
   ): RIO[R with Blocking with Consumer[R, K, V], Unit] =
-    withConsumerService(_.subscribe(subscription))
+    withConsumerService[R, Any, K, V, Unit](_.subscribe(subscription))
 
   /**
    * Accessor method for [[Service.unsubscribe]]
@@ -428,7 +425,7 @@ object Consumer {
   def unsubscribe[R, K, V](
     implicit tsv: Tagged[Service[R, K, V]]
   ): RIO[R with Blocking with Consumer[R, K, V], Unit] =
-    withConsumerService(_.unsubscribe)
+    withConsumerService[R, Any, K, V, Unit](_.unsubscribe)
 
   /**
    * Accessor method for [[Service.offsetsForTimes]]
@@ -439,7 +436,7 @@ object Consumer {
   )(
     implicit tsv: Tagged[Service[R, K, V]]
   ): RIO[R with Blocking with Consumer[R, K, V], Map[TopicPartition, OffsetAndTimestamp]] =
-    withConsumerService(_.offsetsForTimes(timestamps, timeout))
+    withConsumerService[R, Any, K, V, Map[TopicPartition, OffsetAndTimestamp]](_.offsetsForTimes(timestamps, timeout))
 
   /**
    * Accessor method for [[Service.partitionsFor]]
@@ -447,7 +444,7 @@ object Consumer {
   def partitionsFor[R, K, V](topic: String, timeout: Duration = Duration.Infinity)(
     implicit tsv: Tagged[Service[R, K, V]]
   ): RIO[R with Blocking with Consumer[R, K, V], List[PartitionInfo]] =
-    withConsumerService(_.partitionsFor(topic, timeout))
+    withConsumerService[R, Any, K, V, List[PartitionInfo]](_.partitionsFor(topic, timeout))
 
   /**
    * Accessor method for [[Service.position]]
@@ -455,7 +452,7 @@ object Consumer {
   def position[R, K, V](partition: TopicPartition, timeout: Duration = Duration.Infinity)(
     implicit tsv: Tagged[Service[R, K, V]]
   ): RIO[R with Blocking with Consumer[R, K, V], Long] =
-    withConsumerService(_.position(partition, timeout))
+    withConsumerService[R, Any, K, V, Long](_.position(partition, timeout))
 
   /**
    * Accessor method for [[Service.subscribeAnd]]
@@ -471,7 +468,7 @@ object Consumer {
   def subscription[R, K, V](
     implicit tsv: Tagged[Service[R, K, V]]
   ): RIO[R with Blocking with Consumer[R, K, V], Set[String]] =
-    withConsumerService(_.subscription)
+    withConsumerService[R, Any, K, V, Set[String]](_.subscription)
 
   sealed trait OffsetRetrieval
 

--- a/src/main/scala/zio/kafka/client/Consumer.scala
+++ b/src/main/scala/zio/kafka/client/Consumer.scala
@@ -6,277 +6,318 @@ import zio._
 import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.duration._
-import zio.kafka.client.Consumer.OffsetRetrieval
 import zio.kafka.client.serde.Deserializer
 import zio.kafka.client.diagnostics.Diagnostics
 import zio.kafka.client.internal.{ ConsumerAccess, Runloop }
 import zio.stream._
 
 import scala.jdk.CollectionConverters._
-import scala.collection.compat._
-
-class Consumer private (
-  private val consumer: ConsumerAccess,
-  private val settings: ConsumerSettings,
-  private val runloop: Runloop
-) {
-  self =>
-
-  /**
-   * Returns the topic-partitions that this consumer is currently assigned.
-   *
-   * This is subject to consumer rebalancing, unless using a manual subscription.
-   */
-  def assignment: BlockingTask[Set[TopicPartition]] =
-    consumer.withConsumer(_.assignment().asScala.toSet)
-
-  def beginningOffsets(
-    partitions: Set[TopicPartition],
-    timeout: Duration = Duration.Infinity
-  ): BlockingTask[Map[TopicPartition, Long]] =
-    consumer.withConsumer(
-      _.beginningOffsets(partitions.asJava, timeout.asJava).asScala.view.mapValues(_.longValue()).toMap
-    )
-
-  /**
-   * Retrieve the last committed offset for the given topic-partitions
-   */
-  def committed(
-    partitions: Set[TopicPartition],
-    timeout: Duration = Duration.Infinity
-  ): BlockingTask[Map[TopicPartition, Option[OffsetAndMetadata]]] =
-    consumer.withConsumer(
-      _.committed(partitions.asJava, timeout.asJava).asScala.toMap.view.mapValues(Option.apply).toMap
-    )
-
-  def endOffsets(
-    partitions: Set[TopicPartition],
-    timeout: Duration = Duration.Infinity
-  ): BlockingTask[Map[TopicPartition, Long]] =
-    consumer.withConsumer { eo =>
-      val offs = eo.endOffsets(partitions.asJava, timeout.asJava)
-      offs.asScala.view.mapValues(_.longValue()).toMap
-    }
-
-  /**
-   * Stops consumption of data, drains buffered records, and ends the attached
-   * streams while still serving commit requests.
-   */
-  def stopConsumption: UIO[Unit] =
-    runloop.deps.gracefulShutdown
-
-  def listTopics(timeout: Duration = Duration.Infinity): BlockingTask[Map[String, List[PartitionInfo]]] =
-    consumer.withConsumer(_.listTopics(timeout.asJava).asScala.view.mapValues(_.asScala.toList).toMap)
-
-  def offsetsForTimes(
-    timestamps: Map[TopicPartition, Long],
-    timeout: Duration = Duration.Infinity
-  ): BlockingTask[Map[TopicPartition, OffsetAndTimestamp]] =
-    consumer.withConsumer(
-      _.offsetsForTimes(timestamps.view.mapValues(Long.box).toMap.asJava, timeout.asJava).asScala.toMap
-    )
-
-  /**
-   * Create a stream with messages on the subscribed topic-partitions by topic-partition
-   *
-   * The top-level stream will emit new topic-partition streams for each topic-partition that is assigned
-   * to this consumer. This is subject to consumer rebalancing, unless a manual subscription
-   * was made. When rebalancing occurs, new topic-partition streams may be emitted and existing
-   * streams may be completed.
-   *
-   * All streams can be completed by calling [[stopConsumption]].
-   *
-   * @param keyDeserializer Deserializer for the record keys
-   * @param valueDeserializer Deserializer for the record values
-   * @tparam R Environment required by the serializers
-   * @tparam K Type of record keys
-   * @tparam V Type of record values
-   * @return
-   */
-  def partitionedStream[R, K, V](
-    keyDeserializer: Deserializer[R, K],
-    valueDeserializer: Deserializer[R, V]
-  ): ZStream[
-    Clock with Blocking,
-    Throwable,
-    (TopicPartition, ZStreamChunk[R, Throwable, CommittableRecord[K, V]])
-  ] =
-    ZStream
-      .fromQueue(runloop.deps.partitions)
-      .unTake
-      .map {
-        case (tp, partition) =>
-          val partitionStream =
-            if (settings.perPartitionChunkPrefetch <= 0) partition
-            else ZStreamChunk(partition.chunks.buffer(settings.perPartitionChunkPrefetch))
-
-          tp -> partitionStream.mapM(_.deserializeWith(keyDeserializer, valueDeserializer))
-      }
-
-  def partitionsFor(topic: String, timeout: Duration = Duration.Infinity): BlockingTask[List[PartitionInfo]] =
-    consumer.withConsumer(_.partitionsFor(topic, timeout.asJava).asScala.toList)
-
-  def position(partition: TopicPartition, timeout: Duration = Duration.Infinity): BlockingTask[Long] =
-    consumer.withConsumer(_.position(partition, timeout.asJava))
-
-  /**
-   * Create a stream with all messages on the subscribed topic-partitions
-   *
-   * The stream will emit messages from all topic-partitions interleaved. Per-partition
-   * record order is guaranteed, but the topic-partition interleaving is non-deterministic.
-   *
-   * The stream can be completed by calling [[stopConsumption]].
-   *
-   * @param keyDeserializer Deserializer for the record keys
-   * @param valueDeserializer Deserializer for the record values
-   * @tparam R Environment required by the serializers
-   * @tparam K Type of record keys
-   * @tparam V Type of record values
-   * @return
-   */
-  def plainStream[R, K, V](
-    keyDeserializer: Deserializer[R, K],
-    valueDeserializer: Deserializer[R, V]
-  ): ZStreamChunk[R with Clock with Blocking, Throwable, CommittableRecord[K, V]] =
-    ZStreamChunk(
-      partitionedStream[R, K, V](keyDeserializer, valueDeserializer)
-        .flatMapPar(n = Int.MaxValue)(_._2.chunks)
-    )
-
-  @deprecated("Use OffsetRetrieval.Manual", since = "0.5.0")
-  def seek(partition: TopicPartition, offset: Long): BlockingTask[Unit] =
-    consumer.withConsumer(_.seek(partition, offset))
-
-  @deprecated("Use OffsetRetrieval.Manual", since = "0.5.0")
-  def seekToBeginning(partitions: Set[TopicPartition]): BlockingTask[Unit] =
-    consumer.withConsumer(_.seekToBeginning(partitions.asJava))
-
-  @deprecated("Use OffsetRetrieval.Manual", since = "0.5.0")
-  def seekToEnd(partitions: Set[TopicPartition]): BlockingTask[Unit] =
-    consumer.withConsumer(_.seekToEnd(partitions.asJava))
-
-  def subscribe(subscription: Subscription): BlockingTask[Unit] =
-    consumer.withConsumerM { c =>
-      subscription match {
-        case Subscription.Pattern(pattern) => ZIO(c.subscribe(pattern.pattern, runloop.deps.rebalanceListener))
-        case Subscription.Topics(topics)   => ZIO(c.subscribe(topics.asJava, runloop.deps.rebalanceListener))
-
-        // For manual subscriptions we have to do some manual work before starting the run loop
-        case Subscription.Manual(topicPartitions) =>
-          ZIO(c.assign(topicPartitions.asJava)) *>
-            ZIO.foreach_(topicPartitions)(runloop.deps.newPartitionStream) *> {
-            settings.offsetRetrieval match {
-              case OffsetRetrieval.Manual(getOffsets) =>
-                getOffsets(topicPartitions).flatMap { offsets =>
-                  ZIO.foreach_(offsets) { case (tp, offset) => ZIO(c.seek(tp, offset)) }
-                }
-              case OffsetRetrieval.Auto(_) => ZIO.unit
-            }
-          }
-      }
-    }
-
-  def subscribeAnd(subscription: Subscription): SubscribedConsumer =
-    new SubscribedConsumer(subscribe(subscription).as(self))
-
-  def subscription: BlockingTask[Set[String]] =
-    consumer.withConsumer(_.subscription().asScala.toSet)
-
-  def unsubscribe: BlockingTask[Unit] =
-    consumer.withConsumer(_.unsubscribe())
-}
 
 object Consumer {
+  trait Service[R, K, V] {
+
+    /**
+     * Returns the topic-partitions that this consumer is currently assigned.
+     *
+     * This is subject to consumer rebalancing, unless using a manual subscription.
+     */
+    def assignment: BlockingTask[Set[TopicPartition]]
+
+    def beginningOffsets(
+      partitions: Set[TopicPartition],
+      timeout: Duration = Duration.Infinity
+    ): BlockingTask[Map[TopicPartition, Long]]
+
+    /**
+     * Retrieve the last committed offset for the given topic-partitions
+     */
+    def committed(
+      partitions: Set[TopicPartition],
+      timeout: Duration = Duration.Infinity
+    ): BlockingTask[Map[TopicPartition, Option[OffsetAndMetadata]]]
+
+    def endOffsets(
+      partitions: Set[TopicPartition],
+      timeout: Duration = Duration.Infinity
+    ): BlockingTask[Map[TopicPartition, Long]]
+
+    def listTopics(timeout: Duration = Duration.Infinity): BlockingTask[Map[String, List[PartitionInfo]]]
+
+    /**
+     * Create a stream with messages on the subscribed topic-partitions by topic-partition
+     *
+     * The top-level stream will emit new topic-partition streams for each topic-partition that is assigned
+     * to this consumer. This is subject to consumer rebalancing, unless a manual subscription
+     * was made. When rebalancing occurs, new topic-partition streams may be emitted and existing
+     * streams may be completed.
+     *
+     * All streams can be completed by calling [[stopConsumption]].
+     **/
+    def partitionedStream: ZStream[
+      Clock with Blocking,
+      Throwable,
+      (TopicPartition, ZStreamChunk[R, Throwable, CommittableRecord[K, V]])
+    ]
+
+    /**
+     * Create a stream with all messages on the subscribed topic-partitions
+     *
+     * The stream will emit messages from all topic-partitions interleaved. Per-partition
+     * record order is guaranteed, but the topic-partition interleaving is non-deterministic.
+     *
+     * The stream can be completed by calling [[stopConsumption]].
+     */
+    def plainStream: ZStreamChunk[R with Clock with Blocking, Throwable, CommittableRecord[K, V]]
+
+    /**
+     * Stops consumption of data, drains buffered records, and ends the attached
+     * streams while still serving commit requests.
+     */
+    def stopConsumption: UIO[Unit]
+
+    /**
+     * Execute an effect for each record and commit the offset after processing
+     *
+     * This method is the easiest way of processing messages on a Kafka topic.
+     *
+     * Messages on a single partition are processed sequentially, while the processing of
+     * multiple partitions happens in parallel.
+     *
+     * Offsets are committed after execution of the effect. They are batched when a commit action is in progress
+     * to avoid backpressuring the stream. When commits fail due to a org.apache.kafka.clients.consumer.RetriableCommitFailedException they are
+     * retried according to commitRetryPolicy
+     *
+     * The effect should absorb any failures. Failures should be handled by retries or ignoring the
+     * error, which will result in the Kafka message being skipped.
+     *
+     * Messages are processed with 'at least once' consistency: it is not guaranteed that every message
+     * that is processed by the effect has a corresponding offset commit before stream termination.
+     *
+     * Usage example:
+     *
+     * {{{
+     * val settings: ConsumerSettings = ???
+     * val subscription = Subscription.Topics(Set("my-kafka-topic"))
+     *
+     * val consumerIO = Consumer.consumeWith(settings, subscription, Serdes.string, Serdes.string) { case (key, value) =>
+     *   // Process the received record here
+     *   putStrLn(s"Received record: \${key}: \${value}")
+     * }
+     * }}}
+     *
+     * @tparam RC environment for the consuming effect
+     * @param commitRetryPolicy Retry commits that failed due to a RetriableCommitFailedException according to this schedule
+     * @param f Function that returns the effect to execute for each message. It is passed the key and value
+     * @return Effect that completes with a unit value only when interrupted. May fail when the [[Consumer]] fails.
+     */
+    def consumeWith[RC](
+      subscription: Subscription,
+      commitRetryPolicy: Schedule[Clock, Any, Any] = Schedule.exponential(1.second) && Schedule.recurs(3)
+    )(
+      f: (K, V) => URIO[RC, Unit]
+    ): ZIO[R with RC with Blocking with Clock, Throwable, Unit]
+
+    def subscribe(subscription: Subscription): BlockingTask[Unit]
+
+    def offsetsForTimes(
+      timestamps: Map[TopicPartition, Long],
+      timeout: Duration = Duration.Infinity
+    ): BlockingTask[Map[TopicPartition, OffsetAndTimestamp]]
+
+    def partitionsFor(topic: String, timeout: Duration = Duration.Infinity): BlockingTask[List[PartitionInfo]]
+
+    def position(partition: TopicPartition, timeout: Duration = Duration.Infinity): BlockingTask[Long]
+
+    def subscribeAnd(subscription: Subscription): SubscribedConsumer[R, K, V]
+
+    def subscription: BlockingTask[Set[String]]
+  }
+
+  final case class Live[R, K, V](
+    private val consumer: ConsumerAccess,
+    private val settings: ConsumerSettings,
+    private val runloop: Runloop,
+    keyDeserializer: Deserializer[R, K],
+    valueDeserializer: Deserializer[R, V]
+  ) extends Service[R, K, V] {
+
+    override def assignment: BlockingTask[Set[TopicPartition]] =
+      consumer.withConsumer(_.assignment().asScala.toSet)
+
+    override def beginningOffsets(
+      partitions: Set[TopicPartition],
+      timeout: Duration = Duration.Infinity
+    ): BlockingTask[Map[TopicPartition, Long]] =
+      consumer.withConsumer(
+        _.beginningOffsets(partitions.asJava, timeout.asJava).asScala.view.mapValues(_.longValue()).toMap
+      )
+
+    override def committed(
+      partitions: Set[TopicPartition],
+      timeout: Duration = Duration.Infinity
+    ): BlockingTask[Map[TopicPartition, Option[OffsetAndMetadata]]] =
+      consumer.withConsumer(
+        _.committed(partitions.asJava, timeout.asJava).asScala.toMap.view.mapValues(Option.apply).toMap
+      )
+
+    override def endOffsets(
+      partitions: Set[TopicPartition],
+      timeout: Duration = Duration.Infinity
+    ): BlockingTask[Map[TopicPartition, Long]] =
+      consumer.withConsumer { eo =>
+        val offs = eo.endOffsets(partitions.asJava, timeout.asJava)
+        offs.asScala.view.mapValues(_.longValue()).toMap
+      }
+
+    /**
+     * Stops consumption of data, drains buffered records, and ends the attached
+     * streams while still serving commit requests.
+     */
+    override def stopConsumption: UIO[Unit] =
+      runloop.deps.gracefulShutdown
+
+    override def listTopics(timeout: Duration = Duration.Infinity): BlockingTask[Map[String, List[PartitionInfo]]] =
+      consumer.withConsumer(_.listTopics(timeout.asJava).asScala.view.mapValues(_.asScala.toList).toMap)
+
+    override def offsetsForTimes(
+      timestamps: Map[TopicPartition, Long],
+      timeout: Duration = Duration.Infinity
+    ): BlockingTask[Map[TopicPartition, OffsetAndTimestamp]] =
+      consumer.withConsumer(
+        _.offsetsForTimes(timestamps.view.mapValues(Long.box).toMap.asJava, timeout.asJava).asScala.toMap
+      )
+
+    override def partitionedStream: ZStream[
+      Clock with Blocking,
+      Throwable,
+      (TopicPartition, ZStreamChunk[R, Throwable, CommittableRecord[K, V]])
+    ] =
+      ZStream
+        .fromQueue(runloop.deps.partitions)
+        .unTake
+        .map {
+          case (tp, partition) =>
+            val partitionStream =
+              if (settings.perPartitionChunkPrefetch <= 0) partition
+              else ZStreamChunk(partition.chunks.buffer(settings.perPartitionChunkPrefetch))
+
+            tp -> partitionStream.mapM(_.deserializeWith(keyDeserializer, valueDeserializer))
+        }
+
+    override def partitionsFor(
+      topic: String,
+      timeout: Duration = Duration.Infinity
+    ): BlockingTask[List[PartitionInfo]] =
+      consumer.withConsumer(_.partitionsFor(topic, timeout.asJava).asScala.toList)
+
+    override def position(partition: TopicPartition, timeout: Duration = Duration.Infinity): BlockingTask[Long] =
+      consumer.withConsumer(_.position(partition, timeout.asJava))
+
+    override def plainStream: ZStreamChunk[R with Clock with Blocking, Throwable, CommittableRecord[K, V]] =
+      ZStreamChunk(partitionedStream.flatMapPar(n = Int.MaxValue)(_._2.chunks))
+
+    override def subscribeAnd(subscription: Subscription): SubscribedConsumer[R, K, V] =
+      new SubscribedConsumer(subscribe(subscription).as(this))
+
+    override def subscription: BlockingTask[Set[String]] =
+      consumer.withConsumer(_.subscription().asScala.toSet)
+
+    override def consumeWith[RC](
+      subscription: Subscription,
+      commitRetryPolicy: Schedule[Clock, Any, Any] = Schedule.exponential(1.second) && Schedule.recurs(3)
+    )(
+      f: (K, V) => URIO[RC, Unit]
+    ): ZIO[R with RC with Blocking with Clock, Throwable, Unit] =
+      ZStream
+        .fromEffect(subscribe(subscription))
+        .flatMap { _ =>
+          partitionedStream
+            .flatMapPar(Int.MaxValue, outputBuffer = settings.perPartitionChunkPrefetch) {
+              case (_, partitionStream) =>
+                partitionStream.mapM {
+                  case CommittableRecord(record, offset) =>
+                    f(record.key(), record.value()).as(offset)
+                }.flattenChunks
+            }
+        }
+        .aggregateAsync(offsetBatches)
+        .mapM(_.commitOrRetry(commitRetryPolicy))
+        .runDrain
+
+    override def subscribe(subscription: Subscription): BlockingTask[Unit] =
+      consumer.withConsumerM { c =>
+        subscription match {
+          case Subscription.Pattern(pattern) => ZIO(c.subscribe(pattern.pattern, runloop.deps.rebalanceListener))
+          case Subscription.Topics(topics)   => ZIO(c.subscribe(topics.asJava, runloop.deps.rebalanceListener))
+
+          // For manual subscriptions we have to do some manual work before starting the run loop
+          case Subscription.Manual(topicPartitions) =>
+            ZIO(c.assign(topicPartitions.asJava)) *>
+              ZIO.foreach_(topicPartitions)(runloop.deps.newPartitionStream) *> {
+              settings.offsetRetrieval match {
+                case OffsetRetrieval.Manual(getOffsets) =>
+                  getOffsets(topicPartitions).flatMap { offsets =>
+                    ZIO.foreach_(offsets) { case (tp, offset) => ZIO(c.seek(tp, offset)) }
+                  }
+                case OffsetRetrieval.Auto(_) => ZIO.unit
+              }
+            }
+        }
+      }
+
+    private def unsubscribe: BlockingTask[Unit] =
+      consumer.withConsumer(_.unsubscribe())
+  }
+
   val offsetBatches: ZSink[Any, Nothing, Nothing, Offset, OffsetBatch] =
     ZSink.foldLeft[Offset, OffsetBatch](OffsetBatch.empty)(_ merge _)
 
-  def make(
-    settings: ConsumerSettings,
-    diagnostics: Diagnostics = Diagnostics.NoOp
-  ): ZManaged[Clock with Blocking, Throwable, Consumer] =
-    for {
-      wrapper <- ConsumerAccess.make(settings)
-      deps <- Runloop.Deps.make(
-               wrapper,
-               settings.pollInterval,
-               settings.pollTimeout,
-               diagnostics,
-               settings.offsetRetrieval
-             )
-      runloop <- Runloop(deps)
-    } yield new Consumer(wrapper, settings, runloop)
+  def live[R, K, V](
+    implicit tkd: Tagged[Deserializer[R, K]],
+    tvd: Tagged[Deserializer[R, V]],
+    ts: Tagged[Service[R, K, V]]
+  ): ZLayer[Clock with Blocking with Has[Deserializer[R, K]] with Has[Deserializer[R, V]] with Has[ConsumerSettings] with Has[
+    Diagnostics
+  ], Throwable, Consumer[R, K, V]] =
+    ZLayer.fromManaged {
+      ZManaged
+        .accessManaged[Clock with Blocking with Has[Deserializer[R, K]] with Has[Deserializer[R, V]] with Has[
+          ConsumerSettings
+        ] with Has[
+          Diagnostics
+        ]] { env =>
+          val settings = env.get[ConsumerSettings]
+          for {
+            wrapper <- ConsumerAccess.make(settings)
+            deps <- Runloop.Deps.make(
+                     wrapper,
+                     settings.pollInterval,
+                     settings.pollTimeout,
+                     env.get[Diagnostics],
+                     settings.offsetRetrieval
+                   )
+            runloop <- Runloop(deps)
+          } yield Live(wrapper, settings, runloop, env.get[Deserializer[R, K]], env.get[Deserializer[R, V]])
+        }
+    }
 
-  /**
-   * Execute an effect for each record and commit the offset after processing
-   *
-   * This method is the easiest way of processing messages on a Kafka topic.
-   *
-   * Messages on a single partition are processed sequentially, while the processing of
-   * multiple partitions happens in parallel.
-   *
-   * Offsets are committed after execution of the effect. They are batched when a commit action is in progress
-   * to avoid backpressuring the stream. When commits fail due to a org.apache.kafka.clients.consumer.RetriableCommitFailedException they are
-   * retried according to commitRetryPolicy
-   *
-   * The effect should absorb any failures. Failures should be handled by retries or ignoring the
-   * error, which will result in the Kafka message being skipped.
-   *
-   * Messages are processed with 'at least once' consistency: it is not guaranteed that every message
-   * that is processed by the effect has a corresponding offset commit before stream termination.
-   *
-   * Usage example:
-   *
-   * {{{
-   * val settings: ConsumerSettings = ???
-   * val subscription = Subscription.Topics(Set("my-kafka-topic"))
-   *
-   * val consumerIO = Consumer.consumeWith(settings, subscription, Serdes.string, Serdes.string) { case (key, value) =>
-   *   // Process the received record here
-   *   putStrLn(s"Received record: \${key}: \${value}")
-   * }
-   * }}}
-   *
-   * @param settings Settings for creating a [[Consumer]]
-   * @param subscription Topic subscription parameters
-   * @param keyDeserializer Deserializer for the key of the messages
-   * @param valueDeserializer Deserializer for the value of the messages
-   * @param commitRetryPolicy Retry commits that failed due to a RetriableCommitFailedException according to this schedule
-   * @param f Function that returns the effect to execute for each message. It is passed the key and value
-   * @tparam R Environment for the consuming effect
-   * @tparam R1 Environment for the deserializers
-   * @tparam K Type of keys (an implicit `Deserializer` should be in scope)
-   * @tparam V Type of values (an implicit `Deserializer` should be in scope)
-   * @return Effect that completes with a unit value only when interrupted. May fail when the [[Consumer]] fails.
-   */
-  def consumeWith[R, R1, K, V](
+  def make[R, K, V](
     settings: ConsumerSettings,
-    subscription: Subscription,
-    keyDeserializer: Deserializer[R1, K],
-    valueDeserializer: Deserializer[R1, V],
-    commitRetryPolicy: Schedule[Clock, Any, Any] = Schedule.exponential(1.second) && Schedule.recurs(3)
+    keyDeserializer: Deserializer[R, K],
+    valueDeserializer: Deserializer[R, V],
+    diagnostics: Diagnostics = Diagnostics.NoOp
   )(
-    f: (K, V) => ZIO[R, Nothing, Unit]
-  ): ZIO[R with R1 with Blocking with Clock, Throwable, Unit] =
-    ZStream
-      .managed(Consumer.make(settings))
-      .flatMap { consumer =>
-        ZStream
-          .fromEffect(consumer.subscribe(subscription))
-          .flatMap { _ =>
-            consumer
-              .partitionedStream[R1, K, V](keyDeserializer, valueDeserializer)
-              .flatMapPar(Int.MaxValue, outputBuffer = settings.perPartitionChunkPrefetch) {
-                case (_, partitionStream) =>
-                  partitionStream.mapM {
-                    case CommittableRecord(record, offset) =>
-                      f(record.key(), record.value()).as(offset)
-                  }.flattenChunks
-              }
-          }
-      }
-      .aggregateAsync(offsetBatches)
-      .mapM(_.commitOrRetry(commitRetryPolicy))
-      .runDrain
+    implicit tkd: Tagged[Deserializer[R, K]],
+    thkd: Tagged[Has[Deserializer[R, K]]],
+    tvd: Tagged[Deserializer[R, V]],
+    thvd: Tagged[Has[Deserializer[R, V]]],
+    ts: Tagged[Service[R, K, V]]
+  ): ZLayer[Clock with Blocking, Throwable, Consumer[R, K, V]] =
+    ((ZLayer.requires[Clock] ++ ZLayer
+      .requires[Blocking] ++ ZLayer.succeed(settings) ++ ZLayer.succeed(diagnostics) ++ ZLayer.succeed(keyDeserializer) ++ ZLayer
+      .succeed(
+        valueDeserializer
+      )) >>> live[R, K, V])
 
   sealed trait OffsetRetrieval
 

--- a/src/main/scala/zio/kafka/client/Consumer.scala
+++ b/src/main/scala/zio/kafka/client/Consumer.scala
@@ -99,7 +99,7 @@ object Consumer {
      * val settings: ConsumerSettings = ???
      * val subscription = Subscription.Topics(Set("my-kafka-topic"))
      *
-     * val consumerIO = Consumer.consumeWith(settings, subscription, Serdes.string, Serdes.string) { case (key, value) =>
+     * val consumerIO = Consumer.make(settings, Serdes.string, Serdes.string).consumeWith(subscription) { case (key, value) =>
      *   // Process the received record here
      *   putStrLn(s"Received record: \${key}: \${value}")
      * }

--- a/src/main/scala/zio/kafka/client/Producer.scala
+++ b/src/main/scala/zio/kafka/client/Producer.scala
@@ -2,6 +2,7 @@ package zio.kafka.client
 
 import java.util.concurrent.atomic.AtomicLong
 
+import izreflect.fundamentals.reflection.Tags.Tag
 import org.apache.kafka.clients.producer.{ Callback, KafkaProducer, ProducerRecord, RecordMetadata }
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import zio._
@@ -11,126 +12,114 @@ import zio.stream.ZSink
 
 import scala.jdk.CollectionConverters._
 
-class Producer[-R, K, V] private (
-  p: ByteArrayProducer,
-  keySerializer: Serializer[R, K],
-  valueSerializer: Serializer[R, V]
-) {
-
-  /**
-   * Produce a single record. The effect returned from this method has two layers and
-   * describes the completion of two actions:
-   * 1. The outer layer describes the enqueueing of the record to the Producer's internal
-   *    buffer.
-   * 2. The inner layer describes receiving an acknowledgement from the broker for the
-   *    transmission of the record.
-   *
-   * It is usually recommended to not await the inner layer of every individual record,
-   * but enqueue a batch of records and await all of their acknowledgements at once. That
-   * amortizes the cost of sending requests to Kafka and increases throughput.
-   */
-  def produce(record: ProducerRecord[K, V]): RIO[R with Blocking, Task[RecordMetadata]] =
-    for {
-      done             <- Promise.make[Throwable, RecordMetadata]
-      serializedRecord <- serialize(record)
-      runtime          <- ZIO.runtime[Blocking]
-      _ <- effectBlocking {
-            p.send(
-              serializedRecord,
-              new Callback {
-                def onCompletion(metadata: RecordMetadata, err: Exception): Unit = {
-                  if (err != null) runtime.unsafeRun(done.fail(err))
-                  else runtime.unsafeRun(done.succeed(metadata))
-
-                  ()
-                }
-              }
-            )
-          }
-    } yield done.await
-
-  /**
-   * Produces a chunk of records record. The effect returned from this method has two layers
-   * and describes the completion of two actions:
-   * 1. The outer layer describes the enqueueing of all the records to the Producer's
-   *    internal buffer.
-   * 2. The inner layer describes receiving an acknowledgement from the broker for the
-   *    transmission of the records.
-   *
-   * It is possible that for chunks that exceed the producer's internal buffer size, the
-   * outer layer will also signal the transmission of part of the chunk. Regardless,
-   * awaiting the inner layer guarantees the transmission of the entire chunk.
-   */
-  def produceChunk(records: Chunk[ProducerRecord[K, V]]): RIO[R with Blocking, Task[Chunk[RecordMetadata]]] =
-    if (records.isEmpty) ZIO.succeed(Task.succeed(Chunk.empty))
-    else {
-      for {
-        done              <- Promise.make[Throwable, Chunk[RecordMetadata]]
-        runtime           <- ZIO.runtime[Blocking]
-        serializedRecords <- ZIO.foreach(records.toSeq)(serialize(_))
-        _ <- effectBlocking {
-              val it: Iterator[(ByteArrayProducerRecord, Int)] =
-                serializedRecords.iterator.zipWithIndex
-              val res: Array[RecordMetadata] = new Array[RecordMetadata](records.length)
-              val count: AtomicLong          = new AtomicLong
-
-              while (it.hasNext) {
-                val (rec, idx): (ByteArrayProducerRecord, Int) = it.next
-
-                p.send(
-                  rec,
-                  new Callback {
-                    def onCompletion(metadata: RecordMetadata, err: Exception): Unit = {
-                      if (err != null) runtime.unsafeRun(done.fail(err))
-                      else {
-                        res(idx) = metadata
-                        if (count.incrementAndGet == records.length)
-                          runtime.unsafeRun(done.succeed(Chunk.fromArray(res)))
-                      }
-
-                      ()
-                    }
-                  }
-                )
-              }
-            }
-      } yield done.await
-    }
-
-  /**
-   * Flushes the producer's internal buffer. This will guarantee that all records
-   * currently buffered will be transmitted to the broker.
-   */
-  def flush: BlockingTask[Unit] = effectBlocking(p.flush())
-
-  private def serialize(
-    r: ProducerRecord[K, V]
-  ): RIO[R, ByteArrayProducerRecord] =
-    for {
-      key   <- keySerializer.serialize(r.topic, r.headers, r.key())
-      value <- valueSerializer.serialize(r.topic, r.headers, r.value())
-    } yield new ProducerRecord(r.topic, r.partition(), r.timestamp(), key, value, r.headers)
-}
-
 object Producer {
 
-  /**
-   * Create a new Producer for records of some type
-   *
-   * @param settings Producer settings
-   * @param keySerializer Serializer for the record keys
-   * @param valueSerializer Serializer for the record values
-   * @tparam R Environment required by the serializers
-   * @tparam K Type of record keys
-   * @tparam V Type of record values
-   * @return Producer as a Managed resource that will be closed automatically after use.
-   */
-  def make[R, K, V](
+  trait Service[R, K, V] {
+    def produce(record: ProducerRecord[K, V]): RIO[Blocking with R, Task[RecordMetadata]]
+    def produceChunk(records: Chunk[ProducerRecord[K, V]]): RIO[R with Blocking, Task[Chunk[RecordMetadata]]]
+    def stream: ZSink[R with Blocking, Throwable, Nothing, Chunk[ProducerRecord[K, V]], Unit] =
+      ZSink.drain.contramapM(produceChunk)
+  }
+
+  class Live[R, K, V](
+    p: KafkaProducer[Array[Byte], Array[Byte]],
+    keySerializer: Serializer[R, K],
+    valueSerializer: Serializer[R, V]
+  ) extends Service[R, K, V] {
+
+    override def produce(record: ProducerRecord[K, V]): RIO[Blocking with R, Task[RecordMetadata]] =
+      for {
+        done             <- Promise.make[Throwable, RecordMetadata]
+        serializedRecord <- serialize(record)
+        runtime          <- ZIO.runtime[Blocking]
+        _ <- effectBlocking {
+              p.send(
+                serializedRecord,
+                new Callback {
+                  def onCompletion(metadata: RecordMetadata, err: Exception): Unit = {
+                    if (err != null) runtime.unsafeRun(done.fail(err))
+                    else runtime.unsafeRun(done.succeed(metadata))
+
+                    ()
+                  }
+                }
+              )
+            }
+      } yield done.await
+
+    /**
+     * Produces a chunk of records record. The effect returned from this method has two layers
+     * and describes the completion of two actions:
+     * 1. The outer layer describes the enqueueing of all the records to the Producer's
+     *    internal buffer.
+     * 2. The inner layer describes receiving an acknowledgement from the broker for the
+     *    transmission of the records.
+     *
+     * It is possible that for chunks that exceed the producer's internal buffer size, the
+     * outer layer will also signal the transmission of part of the chunk. Regardless,
+     * awaiting the inner layer guarantees the transmission of the entire chunk.
+     */
+    override def produceChunk(records: Chunk[ProducerRecord[K, V]]): RIO[R with Blocking, Task[Chunk[RecordMetadata]]] =
+      if (records.isEmpty) ZIO.succeed(Task.succeed(Chunk.empty))
+      else {
+        for {
+          done              <- Promise.make[Throwable, Chunk[RecordMetadata]]
+          runtime           <- ZIO.runtime[Blocking]
+          serializedRecords <- ZIO.foreach(records.toSeq)(serialize)
+          _ <- effectBlocking {
+                val it: Iterator[(ByteArrayProducerRecord, Int)] =
+                  serializedRecords.iterator.zipWithIndex
+                val res: Array[RecordMetadata] = new Array[RecordMetadata](records.length)
+                val count: AtomicLong          = new AtomicLong
+
+                while (it.hasNext) {
+                  val (rec, idx): (ByteArrayProducerRecord, Int) = it.next
+
+                  p.send(
+                    rec,
+                    new Callback {
+                      def onCompletion(metadata: RecordMetadata, err: Exception): Unit = {
+                        if (err != null) runtime.unsafeRun(done.fail(err))
+                        else {
+                          res(idx) = metadata
+                          if (count.incrementAndGet == records.length)
+                            runtime.unsafeRun(done.succeed(Chunk.fromArray(res)))
+                        }
+
+                        ()
+                      }
+                    }
+                  )
+                }
+              }
+        } yield done.await
+      }
+
+    /**
+     * Flushes the producer's internal buffer. This will guarantee that all records
+     * currently buffered will be transmitted to the broker.
+     */
+    def flush: BlockingTask[Unit] = effectBlocking(p.flush())
+
+    private def serialize(r: ProducerRecord[K, V]): RIO[R, ByteArrayProducerRecord] =
+      for {
+        key   <- keySerializer.serialize(r.topic, r.headers, r.key())
+        value <- valueSerializer.serialize(r.topic, r.headers, r.value())
+      } yield new ProducerRecord(r.topic, r.partition(), r.timestamp(), key, value, r.headers)
+  }
+
+  private def createLive[R, K, V](
+    p: KafkaProducer[Array[Byte], Array[Byte]],
+    keySerializer: Serializer[R, K],
+    valueSerializer: Serializer[R, V]
+  ): Live[R, K, V] = new Live(p, keySerializer, valueSerializer)
+
+  def producer[R: Tag, K: Tag, V: Tag](
     settings: ProducerSettings,
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V]
-  ): ZManaged[Blocking, Throwable, Producer[R, K, V]] = {
-    val p = ZIO {
+  ): ZLayer.NoDeps[Throwable, HasProducer[R, K, V]] = {
+    val p: Task[KafkaProducer[Array[Byte], Array[Byte]]] = ZIO {
       val props = settings.driverSettings.asJava
       new KafkaProducer[Array[Byte], Array[Byte]](
         props,
@@ -139,24 +128,9 @@ object Producer {
       )
     }
 
-    p.toManaged(p => UIO(p.close(settings.closeTimeout.asJava)))
-      .map(new Producer[R, K, V](_, keySerializer, valueSerializer))
+    ZLayer.fromManaged(
+      p.toManaged(p => UIO(p.close(settings.closeTimeout.asJava)))
+        .map(producer => createLive(producer, keySerializer, valueSerializer))
+    )
   }
-
-  /**
-   * Sink that produces records to Kafka in chunks
-   *
-   * @param settings
-   * @tparam K
-   * @tparam V
-   * @return
-   */
-  def sink[R, K, V](
-    settings: ProducerSettings,
-    keySerializer: Serializer[R, K],
-    valueSerializer: Serializer[R, V]
-  ): ZManaged[Blocking, Throwable, ZSink[R with Blocking, Throwable, Nothing, Chunk[ProducerRecord[K, V]], Unit]] =
-    make[R, K, V](settings, keySerializer, valueSerializer).map { producer =>
-      ZSink.drain.contramapM(producer.produceChunk)
-    }
 }

--- a/src/main/scala/zio/kafka/client/Producer.scala
+++ b/src/main/scala/zio/kafka/client/Producer.scala
@@ -132,7 +132,7 @@ object Producer {
     tsv: Tagged[Service[R, K, V]]
   ): ZLayer[Has[Serializer[R, K]] with Has[Serializer[R, V]] with Has[ProducerSettings], Throwable, Producer[R, K, V]] =
     ZLayer.fromManaged {
-      val z = ZIO
+      ZIO
         .accessM[Has[Serializer[R, K]] with Has[Serializer[R, V]] with Has[ProducerSettings]] { env =>
           val settings = env.get[ProducerSettings]
           ZIO {
@@ -145,7 +145,7 @@ object Producer {
             Live(rawProducer, settings, env.get[Serializer[R, K]], env.get[Serializer[R, V]])
           }
         }
-      z.toManaged(_.close)
+        .toManaged(_.close)
     }
 
   def make[R, K, V](

--- a/src/main/scala/zio/kafka/client/Producer.scala
+++ b/src/main/scala/zio/kafka/client/Producer.scala
@@ -27,7 +27,7 @@ object Producer {
      * but enqueue a batch of records and await all of their acknowledgements at once. That
      * amortizes the cost of sending requests to Kafka and increases throughput.
      */
-    def produce(record: ProducerRecord[K, V]): RIO[Blocking with R, Task[RecordMetadata]]
+    def produce(record: ProducerRecord[K, V]): RIO[R with Blocking, Task[RecordMetadata]]
 
     /**
      * Produces a chunk of records record. The effect returned from this method has two layers
@@ -43,17 +43,23 @@ object Producer {
      */
     def produceChunk(records: Chunk[ProducerRecord[K, V]]): RIO[R with Blocking, Task[Chunk[RecordMetadata]]]
 
+    /**
+     * Flushes the producer's internal buffer. This will guarantee that all records
+     * currently buffered will be transmitted to the broker.
+     */
+    def flush: BlockingTask[Unit]
+
     final def stream: ZSink[R with Blocking, Throwable, Nothing, Chunk[ProducerRecord[K, V]], Unit] =
       ZSink.drain.contramapM(produceChunk)
   }
 
-  class Live[R, K, V](
+  final case class Live[R, K, V](
     p: KafkaProducer[Array[Byte], Array[Byte]],
+    producerSettings: ProducerSettings,
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V]
   ) extends Service[R, K, V] {
-
-    override def produce(record: ProducerRecord[K, V]): RIO[Blocking with R, Task[RecordMetadata]] =
+    override def produce(record: ProducerRecord[K, V]): RIO[R with Blocking, Task[RecordMetadata]] =
       for {
         done             <- Promise.make[Throwable, RecordMetadata]
         serializedRecord <- serialize(record)
@@ -109,42 +115,49 @@ object Producer {
         } yield done.await
       }
 
-    /**
-     * Flushes the producer's internal buffer. This will guarantee that all records
-     * currently buffered will be transmitted to the broker.
-     */
-    def flush: BlockingTask[Unit] = effectBlocking(p.flush())
+    override def flush: BlockingTask[Unit] = effectBlocking(p.flush())
 
     private def serialize(r: ProducerRecord[K, V]): RIO[R, ByteArrayProducerRecord] =
       for {
         key   <- keySerializer.serialize(r.topic, r.headers, r.key())
         value <- valueSerializer.serialize(r.topic, r.headers, r.value())
       } yield new ProducerRecord(r.topic, r.partition(), r.timestamp(), key, value, r.headers)
+
+    private[client] def close: UIO[Unit] = UIO(p.close(producerSettings.closeTimeout.asJava))
   }
 
-  private def createLive[R, K, V](
-    p: KafkaProducer[Array[Byte], Array[Byte]],
-    keySerializer: Serializer[R, K],
-    valueSerializer: Serializer[R, V]
-  ): Live[R, K, V] = new Live(p, keySerializer, valueSerializer)
+  def live[R, K, V](
+    implicit ts: Tagged[Serializer[R, K]],
+    td: Tagged[Serializer[R, V]],
+    tsv: Tagged[Service[R, K, V]]
+  ): ZLayer[Has[Serializer[R, K]] with Has[Serializer[R, V]] with Has[ProducerSettings], Throwable, Producer[R, K, V]] =
+    ZLayer.fromManaged {
+      val z = ZIO
+        .accessM[Has[Serializer[R, K]] with Has[Serializer[R, V]] with Has[ProducerSettings]] { env =>
+          val settings = env.get[ProducerSettings]
+          ZIO {
+            val props = settings.driverSettings.asJava
+            val rawProducer = new KafkaProducer[Array[Byte], Array[Byte]](
+              props,
+              new ByteArraySerializer(),
+              new ByteArraySerializer()
+            )
+            Live(rawProducer, settings, env.get[Serializer[R, K]], env.get[Serializer[R, V]])
+          }
+        }
+      z.toManaged(_.close)
+    }
 
-  def producer[R, K, V](
+  def make[R, K, V](
     settings: ProducerSettings,
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V]
-  )(implicit tagged: Tagged[Service[R, K, V]]): ZLayer.NoDeps[Throwable, Producer[R, K, V]] = {
-    val p: Task[KafkaProducer[Array[Byte], Array[Byte]]] = ZIO {
-      val props = settings.driverSettings.asJava
-      new KafkaProducer[Array[Byte], Array[Byte]](
-        props,
-        new ByteArraySerializer(),
-        new ByteArraySerializer()
-      )
-    }
-
-    ZLayer.fromManaged(
-      p.toManaged(p => UIO(p.close(settings.closeTimeout.asJava)))
-        .map(producer => createLive(producer, keySerializer, valueSerializer))
-    )
-  }
+  )(
+    implicit ts: Tagged[Serializer[R, K]],
+    td: Tagged[Serializer[R, V]],
+    tsh: Tagged[Has[Serializer[R, K]]],
+    trv: Tagged[Has[Serializer[R, V]]],
+    tsv: Tagged[Service[R, K, V]]
+  ): ZLayer.NoDeps[Throwable, Producer[R, K, V]] =
+    (ZLayer.succeed(settings) ++ ZLayer.succeed(keySerializer) ++ ZLayer.succeed(valueSerializer)) >>> live[R, K, V]
 }

--- a/src/main/scala/zio/kafka/client/Producer.scala
+++ b/src/main/scala/zio/kafka/client/Producer.scala
@@ -160,4 +160,33 @@ object Producer {
     tsv: Tagged[Service[R, K, V]]
   ): ZLayer.NoDeps[Throwable, Producer[R, K, V]] =
     (ZLayer.succeed(settings) ++ ZLayer.succeed(keySerializer) ++ ZLayer.succeed(valueSerializer)) >>> live[R, K, V]
+
+  def withProducerService[R, K, V, A](
+    r: Producer.Service[R, K, V] => RIO[R with Blocking, A]
+  )(implicit tsv: Tagged[Service[R, K, V]]): RIO[R with Blocking with Producer[R, K, V], A] =
+    ZIO.accessM(env => r(env.get[Producer.Service[R, K, V]]))
+
+  /**
+   * Accessor method for [[Service.produce]]
+   */
+  def produce[R, K, V](
+    record: ProducerRecord[K, V]
+  )(implicit tsv: Tagged[Service[R, K, V]]): RIO[R with Blocking with Producer[R, K, V], Task[RecordMetadata]] =
+    withProducerService(_.produce(record))
+
+  /**
+   * Accessor method for [[Service.produceChunk]]
+   */
+  def produceChunk[R, K, V](
+    records: Chunk[ProducerRecord[K, V]]
+  )(implicit tsv: Tagged[Service[R, K, V]]): RIO[R with Blocking with Producer[R, K, V], Task[Chunk[RecordMetadata]]] =
+    withProducerService(_.produceChunk(records))
+
+  /**
+   * Accessor method for [[Service.flush]]
+   */
+  def flush[R, K, V](
+    implicit tsv: Tagged[Service[R, K, V]]
+  ): ZIO[R with Blocking with Producer[R, K, V], Throwable, Unit] =
+    withProducerService(_.flush)
 }

--- a/src/main/scala/zio/kafka/client/SubscribedConsumer.scala
+++ b/src/main/scala/zio/kafka/client/SubscribedConsumer.scala
@@ -3,25 +3,15 @@ package zio.kafka.client
 import org.apache.kafka.common.TopicPartition
 import zio.blocking.Blocking
 import zio.clock.Clock
-import zio.kafka.client.serde.Deserializer
+import zio.kafka.client.Consumer.Service
 import zio.stream.{ ZStream, ZStreamChunk }
 
-class SubscribedConsumer(private val underlying: BlockingTask[Consumer]) {
+class SubscribedConsumer[R, K, V](private val underlying: BlockingTask[Service[R, K, V]]) {
 
-  def partitionedStream[R, K, V](
-    keyDeserializer: Deserializer[R, K],
-    valueDeserializer: Deserializer[R, V]
-  ): ZStream[Clock with Blocking, Throwable, (TopicPartition, ZStreamChunk[R, Throwable, CommittableRecord[K, V]])] =
-    ZStream.fromEffect(underlying).flatMap(_.partitionedStream(keyDeserializer, valueDeserializer))
+  def partitionedStream
+    : ZStream[Clock with Blocking, Throwable, (TopicPartition, ZStreamChunk[R, Throwable, CommittableRecord[K, V]])] =
+    ZStream.fromEffect(underlying).flatMap(_.partitionedStream)
 
-  def plainStream[R, K, V](
-    keyDeserializer: Deserializer[R, K],
-    valueDeserializer: Deserializer[R, V]
-  ): ZStreamChunk[R with Clock with Blocking, Throwable, CommittableRecord[K, V]] =
-    ZStreamChunk(
-      partitionedStream[R, K, V](keyDeserializer, valueDeserializer).flatMapPar(n = Int.MaxValue)(
-        _._2.chunks
-      )
-    )
-
+  def plainStream: ZStreamChunk[R with Clock with Blocking, Throwable, CommittableRecord[K, V]] =
+    ZStreamChunk(partitionedStream.flatMapPar(n = Int.MaxValue)(_._2.chunks))
 }

--- a/src/main/scala/zio/kafka/client/package.scala
+++ b/src/main/scala/zio/kafka/client/package.scala
@@ -5,8 +5,8 @@ import java.util.{ Map => JMap }
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.{ KafkaProducer, ProducerRecord }
 import org.apache.kafka.common.TopicPartition
-
-import zio.ZIO
+import zio.{ Has, ZIO }
+import zio._
 import zio.blocking.Blocking
 
 package object client {
@@ -18,4 +18,6 @@ package object client {
 
   type ByteArrayProducer       = KafkaProducer[Array[Byte], Array[Byte]]
   type ByteArrayProducerRecord = ProducerRecord[Array[Byte], Array[Byte]]
+
+  type HasProducer[R, K, V] = Has[Producer.Service[R, K, V]]
 }

--- a/src/main/scala/zio/kafka/client/package.scala
+++ b/src/main/scala/zio/kafka/client/package.scala
@@ -6,7 +6,6 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.{ KafkaProducer, ProducerRecord }
 import org.apache.kafka.common.TopicPartition
 import zio.{ Has, ZIO }
-import zio._
 import zio.blocking.Blocking
 
 package object client {
@@ -19,5 +18,5 @@ package object client {
   type ByteArrayProducer       = KafkaProducer[Array[Byte], Array[Byte]]
   type ByteArrayProducerRecord = ProducerRecord[Array[Byte], Array[Byte]]
 
-  type HasProducer[R, K, V] = Has[Producer.Service[R, K, V]]
+  type Producer[R, K, V] = Has[Producer.Service[R, K, V]]
 }

--- a/src/main/scala/zio/kafka/client/package.scala
+++ b/src/main/scala/zio/kafka/client/package.scala
@@ -19,4 +19,5 @@ package object client {
   type ByteArrayProducerRecord = ProducerRecord[Array[Byte], Array[Byte]]
 
   type Producer[R, K, V] = Has[Producer.Service[R, K, V]]
+  type Consumer[R, K, V] = Has[Consumer.Service[R, K, V]]
 }

--- a/src/test/scala/zio/kafka/client/ConsumerSpec.scala
+++ b/src/test/scala/zio/kafka/client/ConsumerSpec.scala
@@ -1,449 +1,434 @@
 package zio.kafka.client
 
-import net.manub.embeddedkafka.EmbeddedKafka
-import org.apache.kafka.common.TopicPartition
-import zio._
-import zio.clock.Clock
-import zio.duration._
-import zio.kafka.client.Consumer.OffsetRetrieval
-import zio.kafka.client.KafkaTestUtils._
-import zio.kafka.client.embedded.Kafka
-import zio.kafka.client.diagnostics.{ DiagnosticEvent, Diagnostics }
-import zio.kafka.client.serde.Serde
-import zio.stream.{ ZSink, ZStream }
-import zio.test.Assertion._
-import zio.test.TestAspect._
-import zio.test.environment._
-import zio.test.{ DefaultRunnableSpec, _ }
-
-object ConsumerSpec extends DefaultRunnableSpec {
-  override def spec: ZSpec[TestEnvironment, Throwable] =
-    suite("Consumer Streaming")(
-      testM("plainStream emits messages for a topic subscription") {
-        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
-        for {
-          _ <- produceMany("topic150", kvs)
-
-          records <- withConsumer("group150", "client150") { consumer =>
-                      consumer
-                        .subscribeAnd(Subscription.Topics(Set("topic150")))
-                        .plainStream(Serde.string, Serde.string)
-                        .flattenChunks
-                        .take(5)
-                        .runCollect
-                    }
-          kvOut = records.map { r =>
-            (r.record.key, r.record.value)
-          }
-        } yield assert(kvOut)(equalTo(kvs))
-      },
-      testM("plainStream emits messages for a pattern subscription") {
-        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
-        for {
-          _ <- produceMany("pattern150", kvs)
-          records <- withConsumer("group150", "client150") { consumer =>
-                      consumer
-                        .subscribeAnd(Subscription.Pattern("pattern[0-9]+".r))
-                        .plainStream(Serde.string, Serde.string)
-                        .flattenChunks
-                        .take(5)
-                        .runCollect
-                    }
-          kvOut = records.map { r =>
-            (r.record.key, r.record.value)
-          }
-        } yield assert(kvOut)(equalTo(kvs))
-      },
-      testM("receive only messages from the subscribed topic-partition when creating a manual subscription") {
-        val nrPartitions = 5
-        val topic        = "manual-topic"
-
-        for {
-          _ <- ZIO.effectTotal(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-          _ <- ZIO.foreach(1 to nrPartitions) { i =>
-                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
-              }
-          record <- withConsumer("group150", "client150") { consumer =>
-                     consumer
-                       .subscribeAnd(Subscription.manual(topic, partition = 2))
-                       .plainStream(Serde.string, Serde.string)
-                       .flattenChunks
-                       .take(1)
-                       .runHead
-                   }
-          kvOut = record.map(r => (r.record.key, r.record.value))
-        } yield assert(kvOut)(isSome(equalTo("key2" -> "msg2")))
-      },
-      testM("receive from the right offset when creating a manual subscription with manual seeking") {
-        val nrPartitions = 5
-        val topic        = "manual-topic"
-
-        val manualOffsetSeek = 3
-
-        for {
-          _ <- ZIO.effectTotal(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-          _ <- ZIO.foreach(1 to nrPartitions) { i =>
-                produceMany(topic, partition = i % nrPartitions, kvs = (1 to 10).map(j => s"key$i-$j" -> s"msg$i-$j"))
-              }
-          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
-          record <- withConsumer("group150", "client150", offsetRetrieval = offsetRetrieval) { consumer =>
-                     consumer
-                       .subscribeAnd(Subscription.manual(topic, partition = 2))
-                       .plainStream(
-                         Serde.string,
-                         Serde.string
-                       )
-                       .flattenChunks
-                       .take(1)
-                       .runHead
-                   }
-          kvOut = record.map(r => (r.record.key, r.record.value))
-        } yield assert(kvOut)(isSome(equalTo("key2-3" -> "msg2-3")))
-      },
-      testM("restart from the committed position") {
-        val data = (1 to 10).toList.map(i => s"key$i" -> s"msg$i")
-        for {
-          _ <- produceMany("topic1", 0, data)
-          firstResults <- withConsumer("group1", "first") {
-                           consumer =>
-                             for {
-                               results <- consumer
-                                           .subscribeAnd(Subscription.Topics(Set("topic1")))
-                                           .partitionedStream(Serde.string, Serde.string)
-                                           .filter(_._1 == new TopicPartition("topic1", 0))
-                                           .flatMap(_._2.flattenChunks)
-                                           .take(5)
-                                           .transduce(ZSink.collectAll[CommittableRecord[String, String]])
-                                           .mapConcatM { committableRecords =>
-                                             val records = committableRecords.map(_.record)
-                                             val offsetBatch =
-                                               committableRecords.foldLeft(OffsetBatch.empty)(_ merge _.offset)
-
-                                             offsetBatch.commit.as(records)
-                                           }
-                                           .runCollect
-                             } yield results
-                         }
-          secondResults <- withConsumer("group1", "second") {
-                            consumer =>
-                              for {
-                                results <- consumer
-                                            .subscribeAnd(Subscription.Topics(Set("topic1")))
-                                            .partitionedStream(Serde.string, Serde.string)
-                                            .flatMap(_._2.flattenChunks)
-                                            .take(5)
-                                            .transduce(ZSink.collectAll[CommittableRecord[String, String]])
-                                            .mapConcatM { committableRecords =>
-                                              val records = committableRecords.map(_.record)
-                                              val offsetBatch =
-                                                committableRecords.foldLeft(OffsetBatch.empty)(_ merge _.offset)
-
-                                              offsetBatch.commit.as(records)
-                                            }
-                                            .runCollect
-                              } yield results
-                          }
-        } yield assert((firstResults ++ secondResults).map(rec => rec.key() -> rec.value()))(equalTo(data))
-      },
-      testM("partitionedStream emits messages for each partition in a separate stream") {
-        val nrMessages   = 50
-        val nrPartitions = 5
-
-        for {
-          // Produce messages on several partitions
-          topic <- randomTopic
-          group <- randomGroup
-          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-          _ <- ZIO.foreach(1 to nrMessages) { i =>
-                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
-              }
-
-          // Consume messages
-          messagesReceived <- ZIO.foreach(0 until nrPartitions)(i => Ref.make[Int](0).map(i -> _)).map(_.toMap)
-          subscription     = Subscription.topics(topic)
-          fib <- withConsumer(group, "client3") { consumer =>
-                  consumer
-                    .subscribeAnd(subscription)
-                    .partitionedStream(Serde.string, Serde.string)
-                    .flatMapPar(nrPartitions) {
-                      case (_, partition) =>
-                        partition.mapM { record =>
-                          messagesReceived(record.partition).update(_ + 1).as(record)
-                        }.flattenChunks
-                    }
-                    .take(nrMessages.toLong)
-                    .runDrain
-                }.fork
-          _                    <- fib.join
-          messagesPerPartition <- ZIO.foreach(messagesReceived.values)(_.get)
-
-        } yield assert(messagesPerPartition)(forall(equalTo(nrMessages / nrPartitions)))
-      },
-      testM("fail when the consuming effect produces a failure") {
-        val topic        = "consumeWith3"
-        val subscription = Subscription.Topics(Set(topic))
-        val nrMessages   = 10
-        val messages     = (1 to nrMessages).toList.map(i => (s"key$i", s"msg$i"))
-
-        for {
-          _ <- produceMany(topic, messages)
-          consumeResult <- consumeWithStrings("group3", "client3", subscription) {
-                            case (_, _) =>
-                              ZIO.fail(new IllegalArgumentException("consumeWith failure")).orDie
-                          }.run
-        } yield consumeResult.fold(
-          _ => assertCompletes,
-          _ => assert("result")(equalTo("Expected consumeWith to fail"))
-        )
-      } @@ timeout(10.seconds),
-      testM("stopConsumption must stop the stream") {
-        val kvs = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
-        for {
-          topic            <- randomTopic
-          group            <- randomGroup
-          _                <- produceMany(topic, kvs)
-          messagesReceived <- Ref.make[Int](0)
-          _ <- withConsumer(group, "client150") { consumer =>
-                consumer
-                  .subscribeAnd(Subscription.topics(topic))
-                  .plainStream(Serde.string, Serde.string)
-                  .mapM { _ =>
-                    for {
-                      nr <- messagesReceived.updateAndGet(_ + 1)
-                      _  <- consumer.stopConsumption.when(nr == 3)
-                    } yield ()
-                  }
-                  .flattenChunks
-                  .runDrain
-              }
-          nr <- messagesReceived.get
-        } yield assert(nr)(isLessThanEqualTo(10)) // NOTE this depends on a max_poll_records setting of 10
-      },
-      testM("process outstanding commits after a graceful shutdown") {
-        val kvs   = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
-        val topic = "test-outstanding-commits"
-        for {
-          group            <- randomGroup
-          _                <- produceMany(topic, kvs)
-          messagesReceived <- Ref.make[Int](0)
-          offset <- withConsumer(group, "client150") { consumer =>
-                     consumer
-                       .subscribeAnd(Subscription.topics(topic))
-                       .plainStream(Serde.string, Serde.string)
-                       .mapM { record =>
-                         for {
-                           nr <- messagesReceived.updateAndGet(_ + 1)
-                           _  <- consumer.stopConsumption.when(nr == 1)
-                         } yield record.offset
-                       }
-                       .flattenChunks
-                       .aggregate(Consumer.offsetBatches)
-                       .mapM(_.commit)
-                       .runDrain *>
-                       consumer.committed(Set(new TopicPartition(topic, 0))).map(_.values.head)
-                   }
-        } yield assert(offset.map(_.offset))(isSome(isLessThanEqualTo(10L))) // NOTE this depends on a max_poll_records setting of 10
-      },
-      testM("offset batching collects the latest offset for all partitions") {
-        val nrMessages   = 50
-        val nrPartitions = 5
-
-        for {
-          // Produce messages on several partitions
-          topic <- randomTopic
-          group <- randomGroup
-          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-          _ <- ZIO.foreach(1 to nrMessages) { i =>
-                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
-              }
-
-          // Consume messages
-          messagesReceived <- ZIO.foreach(0 until nrPartitions)(i => Ref.make[Int](0).map(i -> _)).map(_.toMap)
-          subscription     = Subscription.topics(topic)
-          offsets <- withConsumer(group, "client3") { consumer =>
-                      consumer
-                        .subscribeAnd(subscription)
-                        .partitionedStream(Serde.string, Serde.string)
-                        .flatMapPar(nrPartitions)(_._2.map(_.offset).flattenChunks)
-                        .take(nrMessages.toLong)
-                        .aggregate(Consumer.offsetBatches)
-                        .take(1)
-                        .mapM(_.commit)
-                        .runDrain *>
-                        consumer.committed((0 until nrPartitions).map(new TopicPartition(topic, _)).toSet)
-                    }
-        } yield assert(offsets.values.map(_.map(_.offset)))(forall(isSome(equalTo(nrMessages.toLong / nrPartitions))))
-      },
-      testM("handle rebalancing by completing topic-partition streams") {
-        val nrMessages   = 50
-        val nrPartitions = 6
-
-        for {
-          // Produce messages on several partitions
-          topic <- randomTopic
-          group <- randomGroup
-          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-          _ <- ZIO.foreach(1 to nrMessages) { i =>
-                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
-              }
-
-          // Consume messages
-          subscription = Subscription.topics(topic)
-          consumer1 <- withConsumer(group, "client1") { consumer =>
-                        consumer
-                          .subscribeAnd(subscription)
-                          .partitionedStream(Serde.string, Serde.string)
-                          .flatMapPar(nrPartitions) {
-                            case (tp, partition) =>
-                              ZStream
-                                .fromEffect(partition.flattenChunks.runDrain)
-                                .as(tp)
-                          }
-                          .take(nrPartitions.toLong / 2)
-                          .runDrain
-                      }.fork
-          _ <- Live.live(ZIO.sleep(5.seconds))
-          consumer2 <- withConsumer(group, "client2") { consumer =>
-                        consumer
-                          .subscribeAnd(subscription)
-                          .partitionedStream(Serde.string, Serde.string)
-                          .take(nrPartitions.toLong / 2)
-                          .runDrain
-                      }.fork
-          _ <- consumer1.join
-          _ <- consumer2.join
-        } yield assertCompletes
-      },
-      testM("produce diagnostic events when rebalancing") {
-        val nrMessages   = 50
-        val nrPartitions = 6
-
-        Diagnostics.SlidingQueue
-          .make()
-          .use {
-            diagnostics =>
-              for {
-                // Produce messages on several partitions
-                topic <- randomTopic
-                group <- randomGroup
-                _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-                _ <- ZIO.foreach(1 to nrMessages) { i =>
-                      produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
-                    }
-
-                // Consume messages
-                subscription = Subscription.topics(topic)
-                consumer1 <- withConsumer(group, "client1", diagnostics) { consumer =>
-                              consumer
-                                .subscribeAnd(subscription)
-                                .partitionedStream(Serde.string, Serde.string)
-                                .flatMapPar(nrPartitions) {
-                                  case (tp, partition) =>
-                                    ZStream
-                                      .fromEffect(partition.flattenChunks.runDrain)
-                                      .as(tp)
-                                }
-                                .take(nrPartitions.toLong / 2)
-                                .runDrain
-                            }.fork
-                diagnosticStream <- ZStream
-                                     .fromQueue(diagnostics.queue)
-                                     .collect { case rebalance: DiagnosticEvent.Rebalance => rebalance }
-                                     .runCollect
-                                     .fork
-                _ <- ZIO.sleep(5.seconds)
-                consumer2 <- withConsumer(group, "client2") { consumer =>
-                              consumer
-                                .subscribeAnd(subscription)
-                                .partitionedStream(Serde.string, Serde.string)
-                                .take(nrPartitions.toLong / 2)
-                                .runDrain
-                            }.fork
-                _ <- consumer1.join
-                _ <- consumer1.join
-                _ <- consumer2.join
-              } yield diagnosticStream.join
-          }
-          .flatten
-          .map { diagnosticEvents =>
-            assert(diagnosticEvents.size)(isGreaterThanEqualTo(2))
-          }
-      },
-      testM("support manual seeking") {
-        val nrRecords        = 10
-        val data             = (1 to nrRecords).toList.map(i => s"key$i" -> s"msg$i")
-        val manualOffsetSeek = 3
-
-        for {
-          topic <- randomTopic
-          _     <- produceMany(topic, 0, data)
-          // Consume 5 records to have the offset committed at 5
-          _ <- withConsumer("group1", "client1") {
-                consumer =>
-                  consumer
-                    .subscribeAnd(Subscription.topics(topic))
-                    .plainStream(Serde.string, Serde.string)
-                    .flattenChunks
-                    .take(5)
-                    .transduce(ZSink.collectAll[CommittableRecord[String, String]])
-                    .mapConcatM { committableRecords =>
-                      val records = committableRecords.map(_.record)
-                      val offsetBatch =
-                        committableRecords.foldLeft(OffsetBatch.empty)(_ merge _.offset)
-
-                      offsetBatch.commit.as(records)
-                    }
-                    .runCollect
-              }
-          // Start a new consumer with manual offset before the committed offset
-          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
-          secondResults <- withConsumer("group1", "client2", offsetRetrieval = offsetRetrieval) { consumer =>
-                            consumer
-                              .subscribeAnd(Subscription.topics(topic))
-                              .plainStream(Serde.string, Serde.string)
-                              .take(nrRecords - manualOffsetSeek)
-                              .map(_.record)
-                              .runCollect
-                          }
-          // Check that we only got the records starting from the manually seek'd offset
-        } yield assert(secondResults.map(rec => rec.key() -> rec.value()))(equalTo(data.drop(manualOffsetSeek)))
-      },
-      testM("commit offsets for all consumed messages") {
-        val topic        = "consumeWith2"
-        val subscription = Subscription.Topics(Set(topic))
-        val nrMessages   = 50
-        val messages     = (1 to nrMessages).toList.map(i => (s"key$i", s"msg$i"))
-
-        def consumeIt(messagesReceived: Ref[List[(String, String)]], done: Promise[Nothing, Unit]) =
-          consumeWithStrings("group3", "client3", subscription)({ (key, value) =>
-            (for {
-              messagesSoFar <- messagesReceived.updateAndGet(_ :+ (key -> value))
-              _             <- Task.when(messagesSoFar.size == nrMessages)(done.succeed(()))
-            } yield ()).orDie
-          }).fork
-
-        for {
-          done             <- Promise.make[Nothing, Unit]
-          messagesReceived <- Ref.make(List.empty[(String, String)])
-          _                <- produceMany(topic, messages)
-          fib              <- consumeIt(messagesReceived, done)
-          _ <- done.await *> Live
-                .live(ZIO.sleep(3.seconds)) // TODO the sleep is necessary for the outstanding commits to be flushed. Maybe we can fix that another way
-          _ <- fib.interrupt
-          _ <- produceOne(topic, "key-new", "msg-new")
-          newMessage <- withConsumer("group3", "client3") { c =>
-                         c.subscribe(subscription) *> c
-                           .plainStream(Serde.string, Serde.string)
-                           .take(1)
-                           .flattenChunks
-                           .map(r => (r.record.key(), r.record.value()))
-                           .run(ZSink.collectAll[(String, String)])
-                           .map(_.head)
-                       }.orDie
-          consumedMessages <- messagesReceived.get
-        } yield assert(consumedMessages)(contains(newMessage).negate)
-      }
-    ).provideSomeLayerShared[TestEnvironment](
-      Kafka.embedded.mapError(TestFailure.fail) ++ Clock.live
-    ) @@ timeout(180.seconds)
-}
+object ConsumerSpec {}
+//object ConsumerSpec extends DefaultRunnableSpec {
+//  override def spec: ZSpec[TestEnvironment, Throwable] =
+//    suite("Consumer Streaming")(
+//      testM("plainStream emits messages for a topic subscription") {
+//        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
+//        for {
+//          _ <- produceMany("topic150", kvs)
+//
+//          records <- withConsumer("group150", "client150") { consumer =>
+//                      consumer
+//                        .subscribeAnd(Subscription.Topics(Set("topic150")))
+//                        .plainStream(Serde.string, Serde.string)
+//                        .flattenChunks
+//                        .take(5)
+//                        .runCollect
+//                    }
+//          kvOut = records.map { r =>
+//            (r.record.key, r.record.value)
+//          }
+//        } yield assert(kvOut)(equalTo(kvs))
+//      },
+//      testM("plainStream emits messages for a pattern subscription") {
+//        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
+//        for {
+//          _ <- produceMany("pattern150", kvs)
+//          records <- withConsumer("group150", "client150") { consumer =>
+//                      consumer
+//                        .subscribeAnd(Subscription.Pattern("pattern[0-9]+".r))
+//                        .plainStream(Serde.string, Serde.string)
+//                        .flattenChunks
+//                        .take(5)
+//                        .runCollect
+//                    }
+//          kvOut = records.map { r =>
+//            (r.record.key, r.record.value)
+//          }
+//        } yield assert(kvOut)(equalTo(kvs))
+//      },
+//      testM("receive only messages from the subscribed topic-partition when creating a manual subscription") {
+//        val nrPartitions = 5
+//        val topic        = "manual-topic"
+//
+//        for {
+//          _ <- ZIO.effectTotal(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+//          _ <- ZIO.foreach(1 to nrPartitions) { i =>
+//                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
+//              }
+//          record <- withConsumer("group150", "client150") { consumer =>
+//                     consumer
+//                       .subscribeAnd(Subscription.manual(topic, partition = 2))
+//                       .plainStream(Serde.string, Serde.string)
+//                       .flattenChunks
+//                       .take(1)
+//                       .runHead
+//                   }
+//          kvOut = record.map(r => (r.record.key, r.record.value))
+//        } yield assert(kvOut)(isSome(equalTo("key2" -> "msg2")))
+//      },
+//      testM("receive from the right offset when creating a manual subscription with manual seeking") {
+//        val nrPartitions = 5
+//        val topic        = "manual-topic"
+//
+//        val manualOffsetSeek = 3
+//
+//        for {
+//          _ <- ZIO.effectTotal(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+//          _ <- ZIO.foreach(1 to nrPartitions) { i =>
+//                produceMany(topic, partition = i % nrPartitions, kvs = (1 to 10).map(j => s"key$i-$j" -> s"msg$i-$j"))
+//              }
+//          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
+//          record <- withConsumer("group150", "client150", offsetRetrieval = offsetRetrieval) { consumer =>
+//                     consumer
+//                       .subscribeAnd(Subscription.manual(topic, partition = 2))
+//                       .plainStream(
+//                         Serde.string,
+//                         Serde.string
+//                       )
+//                       .flattenChunks
+//                       .take(1)
+//                       .runHead
+//                   }
+//          kvOut = record.map(r => (r.record.key, r.record.value))
+//        } yield assert(kvOut)(isSome(equalTo("key2-3" -> "msg2-3")))
+//      },
+//      testM("restart from the committed position") {
+//        val data = (1 to 10).toList.map(i => s"key$i" -> s"msg$i")
+//        for {
+//          _ <- produceMany("topic1", 0, data)
+//          firstResults <- withConsumer("group1", "first") {
+//                           consumer =>
+//                             for {
+//                               results <- consumer
+//                                           .subscribeAnd(Subscription.Topics(Set("topic1")))
+//                                           .partitionedStream(Serde.string, Serde.string)
+//                                           .filter(_._1 == new TopicPartition("topic1", 0))
+//                                           .flatMap(_._2.flattenChunks)
+//                                           .take(5)
+//                                           .transduce(ZSink.collectAll[CommittableRecord[String, String]])
+//                                           .mapConcatM { committableRecords =>
+//                                             val records = committableRecords.map(_.record)
+//                                             val offsetBatch =
+//                                               committableRecords.foldLeft(OffsetBatch.empty)(_ merge _.offset)
+//
+//                                             offsetBatch.commit.as(records)
+//                                           }
+//                                           .runCollect
+//                             } yield results
+//                         }
+//          secondResults <- withConsumer("group1", "second") {
+//                            consumer =>
+//                              for {
+//                                results <- consumer
+//                                            .subscribeAnd(Subscription.Topics(Set("topic1")))
+//                                            .partitionedStream(Serde.string, Serde.string)
+//                                            .flatMap(_._2.flattenChunks)
+//                                            .take(5)
+//                                            .transduce(ZSink.collectAll[CommittableRecord[String, String]])
+//                                            .mapConcatM { committableRecords =>
+//                                              val records = committableRecords.map(_.record)
+//                                              val offsetBatch =
+//                                                committableRecords.foldLeft(OffsetBatch.empty)(_ merge _.offset)
+//
+//                                              offsetBatch.commit.as(records)
+//                                            }
+//                                            .runCollect
+//                              } yield results
+//                          }
+//        } yield assert((firstResults ++ secondResults).map(rec => rec.key() -> rec.value()))(equalTo(data))
+//      },
+//      testM("partitionedStream emits messages for each partition in a separate stream") {
+//        val nrMessages   = 50
+//        val nrPartitions = 5
+//
+//        for {
+//          // Produce messages on several partitions
+//          topic <- randomTopic
+//          group <- randomGroup
+//          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+//          _ <- ZIO.foreach(1 to nrMessages) { i =>
+//                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
+//              }
+//
+//          // Consume messages
+//          messagesReceived <- ZIO.foreach(0 until nrPartitions)(i => Ref.make[Int](0).map(i -> _)).map(_.toMap)
+//          subscription     = Subscription.topics(topic)
+//          fib <- withConsumer(group, "client3") { consumer =>
+//                  consumer
+//                    .subscribeAnd(subscription)
+//                    .partitionedStream(Serde.string, Serde.string)
+//                    .flatMapPar(nrPartitions) {
+//                      case (_, partition) =>
+//                        partition.mapM { record =>
+//                          messagesReceived(record.partition).update(_ + 1).as(record)
+//                        }.flattenChunks
+//                    }
+//                    .take(nrMessages.toLong)
+//                    .runDrain
+//                }.fork
+//          _                    <- fib.join
+//          messagesPerPartition <- ZIO.foreach(messagesReceived.values)(_.get)
+//
+//        } yield assert(messagesPerPartition)(forall(equalTo(nrMessages / nrPartitions)))
+//      },
+//      testM("fail when the consuming effect produces a failure") {
+//        val topic        = "consumeWith3"
+//        val subscription = Subscription.Topics(Set(topic))
+//        val nrMessages   = 10
+//        val messages     = (1 to nrMessages).toList.map(i => (s"key$i", s"msg$i"))
+//
+//        for {
+//          _ <- produceMany(topic, messages)
+//          consumeResult <- consumeWithStrings("group3", "client3", subscription) {
+//                            case (_, _) =>
+//                              ZIO.fail(new IllegalArgumentException("consumeWith failure")).orDie
+//                          }.run
+//        } yield consumeResult.fold(
+//          _ => assertCompletes,
+//          _ => assert("result")(equalTo("Expected consumeWith to fail"))
+//        )
+//      } @@ timeout(10.seconds),
+//      testM("stopConsumption must stop the stream") {
+//        val kvs = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
+//        for {
+//          topic            <- randomTopic
+//          group            <- randomGroup
+//          _                <- produceMany(topic, kvs)
+//          messagesReceived <- Ref.make[Int](0)
+//          _ <- withConsumer(group, "client150") { consumer =>
+//                consumer
+//                  .subscribeAnd(Subscription.topics(topic))
+//                  .plainStream(Serde.string, Serde.string)
+//                  .mapM { _ =>
+//                    for {
+//                      nr <- messagesReceived.updateAndGet(_ + 1)
+//                      _  <- consumer.stopConsumption.when(nr == 3)
+//                    } yield ()
+//                  }
+//                  .flattenChunks
+//                  .runDrain
+//              }
+//          nr <- messagesReceived.get
+//        } yield assert(nr)(isLessThanEqualTo(10)) // NOTE this depends on a max_poll_records setting of 10
+//      },
+//      testM("process outstanding commits after a graceful shutdown") {
+//        val kvs   = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
+//        val topic = "test-outstanding-commits"
+//        for {
+//          group            <- randomGroup
+//          _                <- produceMany(topic, kvs)
+//          messagesReceived <- Ref.make[Int](0)
+//          offset <- withConsumer(group, "client150") { consumer =>
+//                     consumer
+//                       .subscribeAnd(Subscription.topics(topic))
+//                       .plainStream(Serde.string, Serde.string)
+//                       .mapM { record =>
+//                         for {
+//                           nr <- messagesReceived.updateAndGet(_ + 1)
+//                           _  <- consumer.stopConsumption.when(nr == 1)
+//                         } yield record.offset
+//                       }
+//                       .flattenChunks
+//                       .aggregate(Consumer.offsetBatches)
+//                       .mapM(_.commit)
+//                       .runDrain *>
+//                       consumer.committed(Set(new TopicPartition(topic, 0))).map(_.values.head)
+//                   }
+//        } yield assert(offset.map(_.offset))(isSome(isLessThanEqualTo(10L))) // NOTE this depends on a max_poll_records setting of 10
+//      },
+//      testM("offset batching collects the latest offset for all partitions") {
+//        val nrMessages   = 50
+//        val nrPartitions = 5
+//
+//        for {
+//          // Produce messages on several partitions
+//          topic <- randomTopic
+//          group <- randomGroup
+//          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+//          _ <- ZIO.foreach(1 to nrMessages) { i =>
+//                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
+//              }
+//
+//          // Consume messages
+//          messagesReceived <- ZIO.foreach(0 until nrPartitions)(i => Ref.make[Int](0).map(i -> _)).map(_.toMap)
+//          subscription     = Subscription.topics(topic)
+//          offsets <- withConsumer(group, "client3") { consumer =>
+//                      consumer
+//                        .subscribeAnd(subscription)
+//                        .partitionedStream(Serde.string, Serde.string)
+//                        .flatMapPar(nrPartitions)(_._2.map(_.offset).flattenChunks)
+//                        .take(nrMessages.toLong)
+//                        .aggregate(Consumer.offsetBatches)
+//                        .take(1)
+//                        .mapM(_.commit)
+//                        .runDrain *>
+//                        consumer.committed((0 until nrPartitions).map(new TopicPartition(topic, _)).toSet)
+//                    }
+//        } yield assert(offsets.values.map(_.map(_.offset)))(forall(isSome(equalTo(nrMessages.toLong / nrPartitions))))
+//      },
+//      testM("handle rebalancing by completing topic-partition streams") {
+//        val nrMessages   = 50
+//        val nrPartitions = 6
+//
+//        for {
+//          // Produce messages on several partitions
+//          topic <- randomTopic
+//          group <- randomGroup
+//          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+//          _ <- ZIO.foreach(1 to nrMessages) { i =>
+//                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
+//              }
+//
+//          // Consume messages
+//          subscription = Subscription.topics(topic)
+//          consumer1 <- withConsumer(group, "client1") { consumer =>
+//                        consumer
+//                          .subscribeAnd(subscription)
+//                          .partitionedStream(Serde.string, Serde.string)
+//                          .flatMapPar(nrPartitions) {
+//                            case (tp, partition) =>
+//                              ZStream
+//                                .fromEffect(partition.flattenChunks.runDrain)
+//                                .as(tp)
+//                          }
+//                          .take(nrPartitions.toLong / 2)
+//                          .runDrain
+//                      }.fork
+//          _ <- Live.live(ZIO.sleep(5.seconds))
+//          consumer2 <- withConsumer(group, "client2") { consumer =>
+//                        consumer
+//                          .subscribeAnd(subscription)
+//                          .partitionedStream(Serde.string, Serde.string)
+//                          .take(nrPartitions.toLong / 2)
+//                          .runDrain
+//                      }.fork
+//          _ <- consumer1.join
+//          _ <- consumer2.join
+//        } yield assertCompletes
+//      },
+//      testM("produce diagnostic events when rebalancing") {
+//        val nrMessages   = 50
+//        val nrPartitions = 6
+//
+//        Diagnostics.SlidingQueue
+//          .make()
+//          .use {
+//            diagnostics =>
+//              for {
+//                // Produce messages on several partitions
+//                topic <- randomTopic
+//                group <- randomGroup
+//                _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+//                _ <- ZIO.foreach(1 to nrMessages) { i =>
+//                      produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
+//                    }
+//
+//                // Consume messages
+//                subscription = Subscription.topics(topic)
+//                consumer1 <- withConsumer(group, "client1", diagnostics) { consumer =>
+//                              consumer
+//                                .subscribeAnd(subscription)
+//                                .partitionedStream(Serde.string, Serde.string)
+//                                .flatMapPar(nrPartitions) {
+//                                  case (tp, partition) =>
+//                                    ZStream
+//                                      .fromEffect(partition.flattenChunks.runDrain)
+//                                      .as(tp)
+//                                }
+//                                .take(nrPartitions.toLong / 2)
+//                                .runDrain
+//                            }.fork
+//                diagnosticStream <- ZStream
+//                                     .fromQueue(diagnostics.queue)
+//                                     .collect { case rebalance: DiagnosticEvent.Rebalance => rebalance }
+//                                     .runCollect
+//                                     .fork
+//                _ <- ZIO.sleep(5.seconds)
+//                consumer2 <- withConsumer(group, "client2") { consumer =>
+//                              consumer
+//                                .subscribeAnd(subscription)
+//                                .partitionedStream(Serde.string, Serde.string)
+//                                .take(nrPartitions.toLong / 2)
+//                                .runDrain
+//                            }.fork
+//                _ <- consumer1.join
+//                _ <- consumer1.join
+//                _ <- consumer2.join
+//              } yield diagnosticStream.join
+//          }
+//          .flatten
+//          .map { diagnosticEvents =>
+//            assert(diagnosticEvents.size)(isGreaterThanEqualTo(2))
+//          }
+//      },
+//      testM("support manual seeking") {
+//        val nrRecords        = 10
+//        val data             = (1 to nrRecords).toList.map(i => s"key$i" -> s"msg$i")
+//        val manualOffsetSeek = 3
+//
+//        for {
+//          topic <- randomTopic
+//          _     <- produceMany(topic, 0, data)
+//          // Consume 5 records to have the offset committed at 5
+//          _ <- withConsumer("group1", "client1") {
+//                consumer =>
+//                  consumer
+//                    .subscribeAnd(Subscription.topics(topic))
+//                    .plainStream(Serde.string, Serde.string)
+//                    .flattenChunks
+//                    .take(5)
+//                    .transduce(ZSink.collectAll[CommittableRecord[String, String]])
+//                    .mapConcatM { committableRecords =>
+//                      val records = committableRecords.map(_.record)
+//                      val offsetBatch =
+//                        committableRecords.foldLeft(OffsetBatch.empty)(_ merge _.offset)
+//
+//                      offsetBatch.commit.as(records)
+//                    }
+//                    .runCollect
+//              }
+//          // Start a new consumer with manual offset before the committed offset
+//          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
+//          secondResults <- withConsumer("group1", "client2", offsetRetrieval = offsetRetrieval) { consumer =>
+//                            consumer
+//                              .subscribeAnd(Subscription.topics(topic))
+//                              .plainStream(Serde.string, Serde.string)
+//                              .take(nrRecords - manualOffsetSeek)
+//                              .map(_.record)
+//                              .runCollect
+//                          }
+//          // Check that we only got the records starting from the manually seek'd offset
+//        } yield assert(secondResults.map(rec => rec.key() -> rec.value()))(equalTo(data.drop(manualOffsetSeek)))
+//      },
+//      testM("commit offsets for all consumed messages") {
+//        val topic        = "consumeWith2"
+//        val subscription = Subscription.Topics(Set(topic))
+//        val nrMessages   = 50
+//        val messages     = (1 to nrMessages).toList.map(i => (s"key$i", s"msg$i"))
+//
+//        def consumeIt(messagesReceived: Ref[List[(String, String)]], done: Promise[Nothing, Unit]) =
+//          consumeWithStrings("group3", "client3", subscription)({ (key, value) =>
+//            (for {
+//              messagesSoFar <- messagesReceived.updateAndGet(_ :+ (key -> value))
+//              _             <- Task.when(messagesSoFar.size == nrMessages)(done.succeed(()))
+//            } yield ()).orDie
+//          }).fork
+//
+//        for {
+//          done             <- Promise.make[Nothing, Unit]
+//          messagesReceived <- Ref.make(List.empty[(String, String)])
+//          _                <- produceMany(topic, messages)
+//          fib              <- consumeIt(messagesReceived, done)
+//          _ <- done.await *> Live
+//                .live(ZIO.sleep(3.seconds)) // TODO the sleep is necessary for the outstanding commits to be flushed. Maybe we can fix that another way
+//          _ <- fib.interrupt
+//          _ <- produceOne(topic, "key-new", "msg-new")
+//          newMessage <- withConsumer("group3", "client3") { c =>
+//                         c.subscribe(subscription) *> c
+//                           .plainStream(Serde.string, Serde.string)
+//                           .take(1)
+//                           .flattenChunks
+//                           .map(r => (r.record.key(), r.record.value()))
+//                           .run(ZSink.collectAll[(String, String)])
+//                           .map(_.head)
+//                       }.orDie
+//          consumedMessages <- messagesReceived.get
+//        } yield assert(consumedMessages)(contains(newMessage).negate)
+//      }
+//    ).provideSomeLayerShared[TestEnvironment](
+//      Kafka.embedded.mapError(TestFailure.fail) ++ Clock.live
+//    ) @@ timeout(180.seconds)
+//}

--- a/src/test/scala/zio/kafka/client/ConsumerSpec.scala
+++ b/src/test/scala/zio/kafka/client/ConsumerSpec.scala
@@ -1,434 +1,443 @@
 package zio.kafka.client
 
-object ConsumerSpec {}
-//object ConsumerSpec extends DefaultRunnableSpec {
-//  override def spec: ZSpec[TestEnvironment, Throwable] =
-//    suite("Consumer Streaming")(
-//      testM("plainStream emits messages for a topic subscription") {
-//        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
-//        for {
-//          _ <- produceMany("topic150", kvs)
-//
-//          records <- withConsumer("group150", "client150") { consumer =>
-//                      consumer
-//                        .subscribeAnd(Subscription.Topics(Set("topic150")))
-//                        .plainStream(Serde.string, Serde.string)
-//                        .flattenChunks
-//                        .take(5)
-//                        .runCollect
-//                    }
-//          kvOut = records.map { r =>
-//            (r.record.key, r.record.value)
-//          }
-//        } yield assert(kvOut)(equalTo(kvs))
-//      },
-//      testM("plainStream emits messages for a pattern subscription") {
-//        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
-//        for {
-//          _ <- produceMany("pattern150", kvs)
-//          records <- withConsumer("group150", "client150") { consumer =>
-//                      consumer
-//                        .subscribeAnd(Subscription.Pattern("pattern[0-9]+".r))
-//                        .plainStream(Serde.string, Serde.string)
-//                        .flattenChunks
-//                        .take(5)
-//                        .runCollect
-//                    }
-//          kvOut = records.map { r =>
-//            (r.record.key, r.record.value)
-//          }
-//        } yield assert(kvOut)(equalTo(kvs))
-//      },
-//      testM("receive only messages from the subscribed topic-partition when creating a manual subscription") {
-//        val nrPartitions = 5
-//        val topic        = "manual-topic"
-//
-//        for {
-//          _ <- ZIO.effectTotal(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-//          _ <- ZIO.foreach(1 to nrPartitions) { i =>
-//                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
-//              }
-//          record <- withConsumer("group150", "client150") { consumer =>
-//                     consumer
-//                       .subscribeAnd(Subscription.manual(topic, partition = 2))
-//                       .plainStream(Serde.string, Serde.string)
-//                       .flattenChunks
-//                       .take(1)
-//                       .runHead
-//                   }
-//          kvOut = record.map(r => (r.record.key, r.record.value))
-//        } yield assert(kvOut)(isSome(equalTo("key2" -> "msg2")))
-//      },
-//      testM("receive from the right offset when creating a manual subscription with manual seeking") {
-//        val nrPartitions = 5
-//        val topic        = "manual-topic"
-//
-//        val manualOffsetSeek = 3
-//
-//        for {
-//          _ <- ZIO.effectTotal(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-//          _ <- ZIO.foreach(1 to nrPartitions) { i =>
-//                produceMany(topic, partition = i % nrPartitions, kvs = (1 to 10).map(j => s"key$i-$j" -> s"msg$i-$j"))
-//              }
-//          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
-//          record <- withConsumer("group150", "client150", offsetRetrieval = offsetRetrieval) { consumer =>
-//                     consumer
-//                       .subscribeAnd(Subscription.manual(topic, partition = 2))
-//                       .plainStream(
-//                         Serde.string,
-//                         Serde.string
-//                       )
-//                       .flattenChunks
-//                       .take(1)
-//                       .runHead
-//                   }
-//          kvOut = record.map(r => (r.record.key, r.record.value))
-//        } yield assert(kvOut)(isSome(equalTo("key2-3" -> "msg2-3")))
-//      },
-//      testM("restart from the committed position") {
-//        val data = (1 to 10).toList.map(i => s"key$i" -> s"msg$i")
-//        for {
-//          _ <- produceMany("topic1", 0, data)
-//          firstResults <- withConsumer("group1", "first") {
-//                           consumer =>
-//                             for {
-//                               results <- consumer
-//                                           .subscribeAnd(Subscription.Topics(Set("topic1")))
-//                                           .partitionedStream(Serde.string, Serde.string)
-//                                           .filter(_._1 == new TopicPartition("topic1", 0))
-//                                           .flatMap(_._2.flattenChunks)
-//                                           .take(5)
-//                                           .transduce(ZSink.collectAll[CommittableRecord[String, String]])
-//                                           .mapConcatM { committableRecords =>
-//                                             val records = committableRecords.map(_.record)
-//                                             val offsetBatch =
-//                                               committableRecords.foldLeft(OffsetBatch.empty)(_ merge _.offset)
-//
-//                                             offsetBatch.commit.as(records)
-//                                           }
-//                                           .runCollect
-//                             } yield results
-//                         }
-//          secondResults <- withConsumer("group1", "second") {
-//                            consumer =>
-//                              for {
-//                                results <- consumer
-//                                            .subscribeAnd(Subscription.Topics(Set("topic1")))
-//                                            .partitionedStream(Serde.string, Serde.string)
-//                                            .flatMap(_._2.flattenChunks)
-//                                            .take(5)
-//                                            .transduce(ZSink.collectAll[CommittableRecord[String, String]])
-//                                            .mapConcatM { committableRecords =>
-//                                              val records = committableRecords.map(_.record)
-//                                              val offsetBatch =
-//                                                committableRecords.foldLeft(OffsetBatch.empty)(_ merge _.offset)
-//
-//                                              offsetBatch.commit.as(records)
-//                                            }
-//                                            .runCollect
-//                              } yield results
-//                          }
-//        } yield assert((firstResults ++ secondResults).map(rec => rec.key() -> rec.value()))(equalTo(data))
-//      },
-//      testM("partitionedStream emits messages for each partition in a separate stream") {
-//        val nrMessages   = 50
-//        val nrPartitions = 5
-//
-//        for {
-//          // Produce messages on several partitions
-//          topic <- randomTopic
-//          group <- randomGroup
-//          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-//          _ <- ZIO.foreach(1 to nrMessages) { i =>
-//                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
-//              }
-//
-//          // Consume messages
-//          messagesReceived <- ZIO.foreach(0 until nrPartitions)(i => Ref.make[Int](0).map(i -> _)).map(_.toMap)
-//          subscription     = Subscription.topics(topic)
-//          fib <- withConsumer(group, "client3") { consumer =>
-//                  consumer
-//                    .subscribeAnd(subscription)
-//                    .partitionedStream(Serde.string, Serde.string)
-//                    .flatMapPar(nrPartitions) {
-//                      case (_, partition) =>
-//                        partition.mapM { record =>
-//                          messagesReceived(record.partition).update(_ + 1).as(record)
-//                        }.flattenChunks
-//                    }
-//                    .take(nrMessages.toLong)
-//                    .runDrain
-//                }.fork
-//          _                    <- fib.join
-//          messagesPerPartition <- ZIO.foreach(messagesReceived.values)(_.get)
-//
-//        } yield assert(messagesPerPartition)(forall(equalTo(nrMessages / nrPartitions)))
-//      },
-//      testM("fail when the consuming effect produces a failure") {
-//        val topic        = "consumeWith3"
-//        val subscription = Subscription.Topics(Set(topic))
-//        val nrMessages   = 10
-//        val messages     = (1 to nrMessages).toList.map(i => (s"key$i", s"msg$i"))
-//
-//        for {
-//          _ <- produceMany(topic, messages)
-//          consumeResult <- consumeWithStrings("group3", "client3", subscription) {
-//                            case (_, _) =>
-//                              ZIO.fail(new IllegalArgumentException("consumeWith failure")).orDie
-//                          }.run
-//        } yield consumeResult.fold(
-//          _ => assertCompletes,
-//          _ => assert("result")(equalTo("Expected consumeWith to fail"))
-//        )
-//      } @@ timeout(10.seconds),
-//      testM("stopConsumption must stop the stream") {
-//        val kvs = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
-//        for {
-//          topic            <- randomTopic
-//          group            <- randomGroup
-//          _                <- produceMany(topic, kvs)
-//          messagesReceived <- Ref.make[Int](0)
-//          _ <- withConsumer(group, "client150") { consumer =>
-//                consumer
-//                  .subscribeAnd(Subscription.topics(topic))
-//                  .plainStream(Serde.string, Serde.string)
-//                  .mapM { _ =>
-//                    for {
-//                      nr <- messagesReceived.updateAndGet(_ + 1)
-//                      _  <- consumer.stopConsumption.when(nr == 3)
-//                    } yield ()
-//                  }
-//                  .flattenChunks
-//                  .runDrain
-//              }
-//          nr <- messagesReceived.get
-//        } yield assert(nr)(isLessThanEqualTo(10)) // NOTE this depends on a max_poll_records setting of 10
-//      },
-//      testM("process outstanding commits after a graceful shutdown") {
-//        val kvs   = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
-//        val topic = "test-outstanding-commits"
-//        for {
-//          group            <- randomGroup
-//          _                <- produceMany(topic, kvs)
-//          messagesReceived <- Ref.make[Int](0)
-//          offset <- withConsumer(group, "client150") { consumer =>
-//                     consumer
-//                       .subscribeAnd(Subscription.topics(topic))
-//                       .plainStream(Serde.string, Serde.string)
-//                       .mapM { record =>
-//                         for {
-//                           nr <- messagesReceived.updateAndGet(_ + 1)
-//                           _  <- consumer.stopConsumption.when(nr == 1)
-//                         } yield record.offset
-//                       }
-//                       .flattenChunks
-//                       .aggregate(Consumer.offsetBatches)
-//                       .mapM(_.commit)
-//                       .runDrain *>
-//                       consumer.committed(Set(new TopicPartition(topic, 0))).map(_.values.head)
-//                   }
-//        } yield assert(offset.map(_.offset))(isSome(isLessThanEqualTo(10L))) // NOTE this depends on a max_poll_records setting of 10
-//      },
-//      testM("offset batching collects the latest offset for all partitions") {
-//        val nrMessages   = 50
-//        val nrPartitions = 5
-//
-//        for {
-//          // Produce messages on several partitions
-//          topic <- randomTopic
-//          group <- randomGroup
-//          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-//          _ <- ZIO.foreach(1 to nrMessages) { i =>
-//                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
-//              }
-//
-//          // Consume messages
-//          messagesReceived <- ZIO.foreach(0 until nrPartitions)(i => Ref.make[Int](0).map(i -> _)).map(_.toMap)
-//          subscription     = Subscription.topics(topic)
-//          offsets <- withConsumer(group, "client3") { consumer =>
-//                      consumer
-//                        .subscribeAnd(subscription)
-//                        .partitionedStream(Serde.string, Serde.string)
-//                        .flatMapPar(nrPartitions)(_._2.map(_.offset).flattenChunks)
-//                        .take(nrMessages.toLong)
-//                        .aggregate(Consumer.offsetBatches)
-//                        .take(1)
-//                        .mapM(_.commit)
-//                        .runDrain *>
-//                        consumer.committed((0 until nrPartitions).map(new TopicPartition(topic, _)).toSet)
-//                    }
-//        } yield assert(offsets.values.map(_.map(_.offset)))(forall(isSome(equalTo(nrMessages.toLong / nrPartitions))))
-//      },
-//      testM("handle rebalancing by completing topic-partition streams") {
-//        val nrMessages   = 50
-//        val nrPartitions = 6
-//
-//        for {
-//          // Produce messages on several partitions
-//          topic <- randomTopic
-//          group <- randomGroup
-//          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-//          _ <- ZIO.foreach(1 to nrMessages) { i =>
-//                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
-//              }
-//
-//          // Consume messages
-//          subscription = Subscription.topics(topic)
-//          consumer1 <- withConsumer(group, "client1") { consumer =>
-//                        consumer
-//                          .subscribeAnd(subscription)
-//                          .partitionedStream(Serde.string, Serde.string)
-//                          .flatMapPar(nrPartitions) {
-//                            case (tp, partition) =>
-//                              ZStream
-//                                .fromEffect(partition.flattenChunks.runDrain)
-//                                .as(tp)
-//                          }
-//                          .take(nrPartitions.toLong / 2)
-//                          .runDrain
-//                      }.fork
-//          _ <- Live.live(ZIO.sleep(5.seconds))
-//          consumer2 <- withConsumer(group, "client2") { consumer =>
-//                        consumer
-//                          .subscribeAnd(subscription)
-//                          .partitionedStream(Serde.string, Serde.string)
-//                          .take(nrPartitions.toLong / 2)
-//                          .runDrain
-//                      }.fork
-//          _ <- consumer1.join
-//          _ <- consumer2.join
-//        } yield assertCompletes
-//      },
-//      testM("produce diagnostic events when rebalancing") {
-//        val nrMessages   = 50
-//        val nrPartitions = 6
-//
-//        Diagnostics.SlidingQueue
-//          .make()
-//          .use {
-//            diagnostics =>
-//              for {
-//                // Produce messages on several partitions
-//                topic <- randomTopic
-//                group <- randomGroup
-//                _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-//                _ <- ZIO.foreach(1 to nrMessages) { i =>
-//                      produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
-//                    }
-//
-//                // Consume messages
-//                subscription = Subscription.topics(topic)
-//                consumer1 <- withConsumer(group, "client1", diagnostics) { consumer =>
-//                              consumer
-//                                .subscribeAnd(subscription)
-//                                .partitionedStream(Serde.string, Serde.string)
-//                                .flatMapPar(nrPartitions) {
-//                                  case (tp, partition) =>
-//                                    ZStream
-//                                      .fromEffect(partition.flattenChunks.runDrain)
-//                                      .as(tp)
-//                                }
-//                                .take(nrPartitions.toLong / 2)
-//                                .runDrain
-//                            }.fork
-//                diagnosticStream <- ZStream
-//                                     .fromQueue(diagnostics.queue)
-//                                     .collect { case rebalance: DiagnosticEvent.Rebalance => rebalance }
-//                                     .runCollect
-//                                     .fork
-//                _ <- ZIO.sleep(5.seconds)
-//                consumer2 <- withConsumer(group, "client2") { consumer =>
-//                              consumer
-//                                .subscribeAnd(subscription)
-//                                .partitionedStream(Serde.string, Serde.string)
-//                                .take(nrPartitions.toLong / 2)
-//                                .runDrain
-//                            }.fork
-//                _ <- consumer1.join
-//                _ <- consumer1.join
-//                _ <- consumer2.join
-//              } yield diagnosticStream.join
-//          }
-//          .flatten
-//          .map { diagnosticEvents =>
-//            assert(diagnosticEvents.size)(isGreaterThanEqualTo(2))
-//          }
-//      },
-//      testM("support manual seeking") {
-//        val nrRecords        = 10
-//        val data             = (1 to nrRecords).toList.map(i => s"key$i" -> s"msg$i")
-//        val manualOffsetSeek = 3
-//
-//        for {
-//          topic <- randomTopic
-//          _     <- produceMany(topic, 0, data)
-//          // Consume 5 records to have the offset committed at 5
-//          _ <- withConsumer("group1", "client1") {
-//                consumer =>
-//                  consumer
-//                    .subscribeAnd(Subscription.topics(topic))
-//                    .plainStream(Serde.string, Serde.string)
-//                    .flattenChunks
-//                    .take(5)
-//                    .transduce(ZSink.collectAll[CommittableRecord[String, String]])
-//                    .mapConcatM { committableRecords =>
-//                      val records = committableRecords.map(_.record)
-//                      val offsetBatch =
-//                        committableRecords.foldLeft(OffsetBatch.empty)(_ merge _.offset)
-//
-//                      offsetBatch.commit.as(records)
-//                    }
-//                    .runCollect
-//              }
-//          // Start a new consumer with manual offset before the committed offset
-//          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
-//          secondResults <- withConsumer("group1", "client2", offsetRetrieval = offsetRetrieval) { consumer =>
-//                            consumer
-//                              .subscribeAnd(Subscription.topics(topic))
-//                              .plainStream(Serde.string, Serde.string)
-//                              .take(nrRecords - manualOffsetSeek)
-//                              .map(_.record)
-//                              .runCollect
-//                          }
-//          // Check that we only got the records starting from the manually seek'd offset
-//        } yield assert(secondResults.map(rec => rec.key() -> rec.value()))(equalTo(data.drop(manualOffsetSeek)))
-//      },
-//      testM("commit offsets for all consumed messages") {
-//        val topic        = "consumeWith2"
-//        val subscription = Subscription.Topics(Set(topic))
-//        val nrMessages   = 50
-//        val messages     = (1 to nrMessages).toList.map(i => (s"key$i", s"msg$i"))
-//
-//        def consumeIt(messagesReceived: Ref[List[(String, String)]], done: Promise[Nothing, Unit]) =
-//          consumeWithStrings("group3", "client3", subscription)({ (key, value) =>
-//            (for {
-//              messagesSoFar <- messagesReceived.updateAndGet(_ :+ (key -> value))
-//              _             <- Task.when(messagesSoFar.size == nrMessages)(done.succeed(()))
-//            } yield ()).orDie
-//          }).fork
-//
-//        for {
-//          done             <- Promise.make[Nothing, Unit]
-//          messagesReceived <- Ref.make(List.empty[(String, String)])
-//          _                <- produceMany(topic, messages)
-//          fib              <- consumeIt(messagesReceived, done)
-//          _ <- done.await *> Live
-//                .live(ZIO.sleep(3.seconds)) // TODO the sleep is necessary for the outstanding commits to be flushed. Maybe we can fix that another way
-//          _ <- fib.interrupt
-//          _ <- produceOne(topic, "key-new", "msg-new")
-//          newMessage <- withConsumer("group3", "client3") { c =>
-//                         c.subscribe(subscription) *> c
-//                           .plainStream(Serde.string, Serde.string)
-//                           .take(1)
-//                           .flattenChunks
-//                           .map(r => (r.record.key(), r.record.value()))
-//                           .run(ZSink.collectAll[(String, String)])
-//                           .map(_.head)
-//                       }.orDie
-//          consumedMessages <- messagesReceived.get
-//        } yield assert(consumedMessages)(contains(newMessage).negate)
-//      }
-//    ).provideSomeLayerShared[TestEnvironment](
-//      Kafka.embedded.mapError(TestFailure.fail) ++ Clock.live
-//    ) @@ timeout(180.seconds)
-//}
+import net.manub.embeddedkafka.EmbeddedKafka
+import org.apache.kafka.common.TopicPartition
+import zio.{ Promise, Ref, Task, ZIO }
+import zio.clock.Clock
+import zio.duration._
+import zio.kafka.client.Consumer.OffsetRetrieval
+import zio.kafka.client.KafkaTestUtils._
+import zio.kafka.client.diagnostics.{ DiagnosticEvent, Diagnostics }
+import zio.kafka.client.embedded.Kafka
+import zio.stream.{ ZSink, ZStream }
+import zio.test.Assertion._
+import zio.test.TestAspect._
+import zio.test.environment._
+import zio.test.{ DefaultRunnableSpec, _ }
+
+object ConsumerSpec extends DefaultRunnableSpec {
+  override def spec: ZSpec[TestEnvironment, Throwable] =
+    suite("Consumer Streaming")(
+      testM("plainStream emits messages for a topic subscription") {
+        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          _ <- produceMany("topic150", kvs)
+
+          records <- withConsumerStrings("group150", "client150") { consumer =>
+                      consumer
+                        .subscribeAnd(Subscription.Topics(Set("topic150")))
+                        .plainStream
+                        .flattenChunks
+                        .take(5)
+                        .runCollect
+                    }
+          kvOut = records.map { r =>
+            (r.record.key, r.record.value)
+          }
+        } yield assert(kvOut)(equalTo(kvs))
+      },
+      testM("plainStream emits messages for a pattern subscription") {
+        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          _ <- produceMany("pattern150", kvs)
+          records <- withConsumerStrings("group150", "client150") { consumer =>
+                      consumer
+                        .subscribeAnd(Subscription.Pattern("pattern[0-9]+".r))
+                        .plainStream
+                        .flattenChunks
+                        .take(5)
+                        .runCollect
+                    }
+          kvOut = records.map { r =>
+            (r.record.key, r.record.value)
+          }
+        } yield assert(kvOut)(equalTo(kvs))
+      },
+      testM("receive only messages from the subscribed topic-partition when creating a manual subscription") {
+        val nrPartitions = 5
+        val topic        = "manual-topic"
+
+        for {
+          _ <- ZIO.effectTotal(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+          _ <- ZIO.foreach(1 to nrPartitions) { i =>
+                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
+              }
+          record <- withConsumerStrings("group150", "client150") { consumer =>
+                     consumer
+                       .subscribeAnd(Subscription.manual(topic, partition = 2))
+                       .plainStream
+                       .flattenChunks
+                       .take(1)
+                       .runHead
+                   }
+          kvOut = record.map(r => (r.record.key, r.record.value))
+        } yield assert(kvOut)(isSome(equalTo("key2" -> "msg2")))
+      },
+      testM("receive from the right offset when creating a manual subscription with manual seeking") {
+        val nrPartitions = 5
+        val topic        = "manual-topic"
+
+        val manualOffsetSeek = 3
+
+        for {
+          _ <- ZIO.effectTotal(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+          _ <- ZIO.foreach(1 to nrPartitions) { i =>
+                produceMany(topic, partition = i % nrPartitions, kvs = (1 to 10).map(j => s"key$i-$j" -> s"msg$i-$j"))
+              }
+          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
+          record <- withConsumerStrings("group150", "client150", offsetRetrieval = offsetRetrieval) { consumer =>
+                     consumer
+                       .subscribeAnd(Subscription.manual(topic, partition = 2))
+                       .plainStream
+                       .flattenChunks
+                       .take(1)
+                       .runHead
+                   }
+          kvOut = record.map(r => (r.record.key, r.record.value))
+        } yield assert(kvOut)(isSome(equalTo("key2-3" -> "msg2-3")))
+      },
+      testM("restart from the committed position") {
+        val data = (1 to 10).toList.map(i => s"key$i" -> s"msg$i")
+        for {
+          _ <- produceMany("topic1", 0, data)
+          firstResults <- withConsumerStrings("group1", "first") {
+                           consumer =>
+                             for {
+                               results <- consumer
+                                           .subscribeAnd(Subscription.Topics(Set("topic1")))
+                                           .partitionedStream
+                                           .filter(_._1 == new TopicPartition("topic1", 0))
+                                           .flatMap(_._2.flattenChunks)
+                                           .take(5)
+                                           .transduce(ZSink.collectAll[CommittableRecord[String, String]])
+                                           .mapConcatM { committableRecords =>
+                                             val records = committableRecords.map(_.record)
+                                             val offsetBatch =
+                                               committableRecords.foldLeft(OffsetBatch.empty)(_ merge _.offset)
+
+                                             offsetBatch.commit.as(records)
+                                           }
+                                           .runCollect
+                             } yield results
+                         }
+          secondResults <- withConsumerStrings("group1", "second") {
+                            consumer =>
+                              for {
+                                results <- consumer
+                                            .subscribeAnd(Subscription.Topics(Set("topic1")))
+                                            .partitionedStream
+                                            .flatMap(_._2.flattenChunks)
+                                            .take(5)
+                                            .transduce(ZSink.collectAll[CommittableRecord[String, String]])
+                                            .mapConcatM { committableRecords =>
+                                              val records = committableRecords.map(_.record)
+                                              val offsetBatch =
+                                                committableRecords.foldLeft(OffsetBatch.empty)(_ merge _.offset)
+
+                                              offsetBatch.commit.as(records)
+                                            }
+                                            .runCollect
+                              } yield results
+                          }
+        } yield assert((firstResults ++ secondResults).map(rec => rec.key() -> rec.value()))(equalTo(data))
+      },
+      testM("partitionedStream emits messages for each partition in a separate stream") {
+        val nrMessages   = 50
+        val nrPartitions = 5
+
+        for {
+          // Produce messages on several partitions
+          topic <- randomTopic
+          group <- randomGroup
+          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+          _ <- ZIO.foreach(1 to nrMessages) { i =>
+                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
+              }
+
+          // Consume messages
+          messagesReceived <- ZIO.foreach(0 until nrPartitions)(i => Ref.make[Int](0).map(i -> _)).map(_.toMap)
+          subscription     = Subscription.topics(topic)
+          fib <- withConsumerStrings(group, "client3") { consumer =>
+                  consumer
+                    .subscribeAnd(subscription)
+                    .partitionedStream
+                    .flatMapPar(nrPartitions) {
+                      case (_, partition) =>
+                        partition.mapM { record =>
+                          messagesReceived(record.partition).update(_ + 1).as(record)
+                        }.flattenChunks
+                    }
+                    .take(nrMessages.toLong)
+                    .runDrain
+                }.fork
+          _                    <- fib.join
+          messagesPerPartition <- ZIO.foreach(messagesReceived.values)(_.get)
+
+        } yield assert(messagesPerPartition)(forall(equalTo(nrMessages / nrPartitions)))
+      },
+      testM("fail when the consuming effect produces a failure") {
+        val topic        = "consumeWith3"
+        val subscription = Subscription.Topics(Set(topic))
+        val nrMessages   = 10
+        val messages     = (1 to nrMessages).toList.map(i => (s"key$i", s"msg$i"))
+
+        for {
+          _ <- produceMany(topic, messages)
+          consumeResult <- consumeWithStrings("group3", "client3", subscription) {
+                            case (_, _) =>
+                              ZIO.fail(new IllegalArgumentException("consumeWith failure")).orDie
+                          }.run
+        } yield consumeResult.fold(
+          _ => assertCompletes,
+          _ => assert("result")(equalTo("Expected consumeWith to fail"))
+        )
+      } @@ timeout(10.seconds),
+      testM("stopConsumption must stop the stream") {
+        val kvs = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          topic            <- randomTopic
+          group            <- randomGroup
+          _                <- produceMany(topic, kvs)
+          messagesReceived <- Ref.make[Int](0)
+          _ <- withConsumerStrings(group, "client150") { consumer =>
+                consumer
+                  .subscribeAnd(Subscription.topics(topic))
+                  .plainStream
+                  .mapM { _ =>
+                    for {
+                      nr <- messagesReceived.updateAndGet(_ + 1)
+                      _  <- consumer.stopConsumption.when(nr == 3)
+                    } yield ()
+                  }
+                  .flattenChunks
+                  .runDrain
+              }
+          nr <- messagesReceived.get
+        } yield assert(nr)(isLessThanEqualTo(10)) // NOTE this depends on a max_poll_records setting of 10
+      },
+      testM("process outstanding commits after a graceful shutdown") {
+        val kvs   = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
+        val topic = "test-outstanding-commits"
+        for {
+          group            <- randomGroup
+          _                <- produceMany(topic, kvs)
+          messagesReceived <- Ref.make[Int](0)
+          offset <- withConsumerStrings(group, "client150") { consumer =>
+                     consumer
+                       .subscribeAnd(Subscription.topics(topic))
+                       .plainStream
+                       .mapM { record =>
+                         for {
+                           nr <- messagesReceived.updateAndGet(_ + 1)
+                           _  <- consumer.stopConsumption.when(nr == 1)
+                         } yield record.offset
+                       }
+                       .flattenChunks
+                       .aggregate(Consumer.offsetBatches)
+                       .mapM(_.commit)
+                       .runDrain *>
+                       consumer.committed(Set(new TopicPartition(topic, 0))).map(_.values.head)
+                   }
+        } yield assert(offset.map(_.offset))(isSome(isLessThanEqualTo(10L))) // NOTE this depends on a max_poll_records setting of 10
+      },
+      testM("offset batching collects the latest offset for all partitions") {
+        val nrMessages   = 50
+        val nrPartitions = 5
+
+        for {
+          // Produce messages on several partitions
+          topic <- randomTopic
+          group <- randomGroup
+          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+          _ <- ZIO.foreach(1 to nrMessages) { i =>
+                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
+              }
+
+          // Consume messages
+          messagesReceived <- ZIO.foreach(0 until nrPartitions)(i => Ref.make[Int](0).map(i -> _)).map(_.toMap)
+          subscription     = Subscription.topics(topic)
+          offsets <- withConsumerStrings(group, "client3") { consumer =>
+                      consumer
+                        .subscribeAnd(subscription)
+                        .partitionedStream
+                        .flatMapPar(nrPartitions)(_._2.map(_.offset).flattenChunks)
+                        .take(nrMessages.toLong)
+                        .aggregate(Consumer.offsetBatches)
+                        .take(1)
+                        .mapM(_.commit)
+                        .runDrain *>
+                        consumer.committed((0 until nrPartitions).map(new TopicPartition(topic, _)).toSet)
+                    }
+        } yield assert(offsets.values.map(_.map(_.offset)))(forall(isSome(equalTo(nrMessages.toLong / nrPartitions))))
+      },
+      testM("handle rebalancing by completing topic-partition streams") {
+        val nrMessages   = 50
+        val nrPartitions = 6
+
+        for {
+          // Produce messages on several partitions
+          topic <- randomTopic
+          group <- randomGroup
+          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+          _ <- ZIO.foreach(1 to nrMessages) { i =>
+                produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
+              }
+
+          // Consume messages
+          subscription = Subscription.topics(topic)
+          consumer1 <- withConsumerStrings(group, "client1") { consumer =>
+                        consumer
+                          .subscribeAnd(subscription)
+                          .partitionedStream
+                          .flatMapPar(nrPartitions) {
+                            case (tp, partition) =>
+                              ZStream
+                                .fromEffect(partition.flattenChunks.runDrain)
+                                .as(tp)
+                          }
+                          .take(nrPartitions.toLong / 2)
+                          .runDrain
+                      }.fork
+          _ <- Live.live(ZIO.sleep(5.seconds))
+          consumer2 <- withConsumerStrings(group, "client2") { consumer =>
+                        consumer
+                          .subscribeAnd(subscription)
+                          .partitionedStream
+                          .take(nrPartitions.toLong / 2)
+                          .runDrain
+                      }.fork
+          _ <- consumer1.join
+          _ <- consumer2.join
+        } yield assertCompletes
+      },
+      testM("produce diagnostic events when rebalancing") {
+        val nrMessages   = 50
+        val nrPartitions = 6
+
+        Diagnostics.SlidingQueue
+          .make()
+          .use {
+            diagnostics =>
+              for {
+                // Produce messages on several partitions
+                topic <- randomTopic
+                group <- randomGroup
+                _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+                _ <- ZIO.foreach(1 to nrMessages) { i =>
+                      produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
+                    }
+
+                // Consume messages
+                subscription = Subscription.topics(topic)
+                consumer1 <- withConsumerStrings(group, "client1", diagnostics) { consumer =>
+                              consumer
+                                .subscribeAnd(subscription)
+                                .partitionedStream
+                                .flatMapPar(nrPartitions) {
+                                  case (tp, partition) =>
+                                    ZStream
+                                      .fromEffect(partition.flattenChunks.runDrain)
+                                      .as(tp)
+                                }
+                                .take(nrPartitions.toLong / 2)
+                                .runDrain
+                            }.fork
+                diagnosticStream <- ZStream
+                                     .fromQueue(diagnostics.queue)
+                                     .collect { case rebalance: DiagnosticEvent.Rebalance => rebalance }
+                                     .runCollect
+                                     .fork
+                _ <- ZIO.sleep(5.seconds)
+                consumer2 <- withConsumerStrings(group, "client2") { consumer =>
+                              consumer
+                                .subscribeAnd(subscription)
+                                .partitionedStream
+                                .take(nrPartitions.toLong / 2)
+                                .runDrain
+                            }.fork
+                _ <- consumer1.join
+                _ <- consumer1.join
+                _ <- consumer2.join
+              } yield diagnosticStream.join
+          }
+          .flatten
+          .map { diagnosticEvents =>
+            assert(diagnosticEvents.size)(isGreaterThanEqualTo(2))
+          }
+      },
+      testM("support manual seeking") {
+        val nrRecords        = 10
+        val data             = (1 to nrRecords).toList.map(i => s"key$i" -> s"msg$i")
+        val manualOffsetSeek = 3
+
+        for {
+          topic <- randomTopic
+          _     <- produceMany(topic, 0, data)
+          // Consume 5 records to have the offset committed at 5
+          _ <- withConsumerStrings("group1", "client1") { consumer =>
+                consumer
+                  .subscribeAnd(Subscription.topics(topic))
+                  .plainStream
+                  .flattenChunks
+                  .take(5)
+                  .transduce(ZSink.collectAll[CommittableRecord[String, String]])
+                  .mapConcatM { committableRecords =>
+                    val records = committableRecords.map(_.record)
+                    val offsetBatch =
+                      committableRecords.foldLeft(OffsetBatch.empty)(_ merge _.offset)
+
+                    offsetBatch.commit.as(records)
+                  }
+                  .runCollect
+              }
+          // Start a new consumer with manual offset before the committed offset
+          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
+          secondResults <- withConsumerStrings("group1", "client2", offsetRetrieval = offsetRetrieval) { consumer =>
+                            consumer
+                              .subscribeAnd(Subscription.topics(topic))
+                              .plainStream
+                              .take(nrRecords - manualOffsetSeek)
+                              .map(_.record)
+                              .runCollect
+                          }
+          // Check that we only got the records starting from the manually seek'd offset
+        } yield assert(secondResults.map(rec => rec.key() -> rec.value()))(equalTo(data.drop(manualOffsetSeek)))
+      },
+      testM("commit offsets for all consumed messages") {
+        val topic        = "consumeWith2"
+        val subscription = Subscription.Topics(Set(topic))
+        val nrMessages   = 50
+        val messages     = (1 to nrMessages).toList.map(i => (s"key$i", s"msg$i"))
+
+        def consumeIt(messagesReceived: Ref[List[(String, String)]], done: Promise[Nothing, Unit]) =
+          consumeWithStrings("group3", "client3", subscription)({ (key, value) =>
+            (for {
+              messagesSoFar <- messagesReceived.updateAndGet(_ :+ (key -> value))
+              _             <- Task.when(messagesSoFar.size == nrMessages)(done.succeed(()))
+            } yield ()).orDie
+          }).fork
+
+        for {
+          done             <- Promise.make[Nothing, Unit]
+          messagesReceived <- Ref.make(List.empty[(String, String)])
+          _                <- produceMany(topic, messages)
+          fib              <- consumeIt(messagesReceived, done)
+          _ <- done.await *> Live
+                .live(ZIO.sleep(3.seconds)) // TODO the sleep is necessary for the outstanding commits to be flushed. Maybe we can fix that another way
+          _ <- fib.interrupt
+          _ <- produceOne(topic, "key-new", "msg-new")
+          newMessage <- withConsumerStrings("group3", "client3") { c =>
+                         c.subscribe(subscription) *> c.plainStream
+                           .take(1)
+                           .flattenChunks
+                           .map(r => (r.record.key(), r.record.value()))
+                           .run(ZSink.collectAll[(String, String)])
+                           .map(_.head)
+                       }.orDie
+          consumedMessages <- messagesReceived.get
+        } yield assert(consumedMessages)(contains(newMessage).negate)
+      }
+    ).provideSomeLayerShared[TestEnvironment](
+      ((Kafka.embedded >>> testProducer) ++ Kafka.embedded).mapError(TestFailure.fail) ++ Clock.live
+    ) @@ timeout(180.seconds)
+}

--- a/src/test/scala/zio/kafka/client/KafkaTestUtils.scala
+++ b/src/test/scala/zio/kafka/client/KafkaTestUtils.scala
@@ -27,7 +27,7 @@ object KafkaTestUtils {
 
   def withProducerStrings[R: Tag, A: Tag](
     r: Producer.Service[Any, String, String] => RIO[R, A]
-  ): ZIO[R with StringProducer with Blocking, Throwable, A] =
+  ): ZIO[R with StringProducer, Throwable, A] =
     ZLayer.fromService(r).build.use(_.get)
 
   def produceOne(t: String, k: String, m: String): ZIO[Blocking with StringProducer, Throwable, RecordMetadata] =

--- a/src/test/scala/zio/kafka/client/KafkaTestUtils.scala
+++ b/src/test/scala/zio/kafka/client/KafkaTestUtils.scala
@@ -12,15 +12,16 @@ import zio.kafka.client.Consumer.OffsetRetrieval
 import zio.kafka.client.Producer.Service
 import zio.kafka.client.diagnostics.Diagnostics
 import zio.kafka.client.embedded.Kafka
-import zio.kafka.client.serde.{ Serde, Serializer }
+import zio.kafka.client.serde.{ Deserializer, Serde, Serializer }
 
 object KafkaTestUtils {
   def producerSettings: ZIO[Kafka, Nothing, ProducerSettings] =
     ZIO.access[Kafka](_.get[Kafka.Service].bootstrapServers).map(ProducerSettings(_))
 
   type StringProducer = Producer[Any, String, String]
+  type StringConsumer = Consumer[Any, String, String]
 
-  val testProducer: ZLayer[Kafka, Throwable, Producer[Any, String, String]] =
+  val testProducer: ZLayer[Kafka, Throwable, StringProducer] =
     (ZLayer.fromEffect(producerSettings) ++ ZLayer.succeed(Serde.string: Serializer[Any, String])) >>>
       Producer.live[Any, String, String]
 
@@ -74,25 +75,26 @@ object KafkaTestUtils {
           .withOffsetRetrieval(offsetRetrieval)
       )
 
-  def consumeWithStrings[R](groupId: String, clientId: String, subscription: Subscription)(
-    r: (String, String) => URIO[R, Unit]
-  ): RIO[R with Blocking with Clock with Kafka, Unit] =
-    for {
-      settings <- consumerSettings(groupId, clientId)
-      consumed <- Consumer.consumeWith(settings, subscription, Serde.string, Serde.string)(r)
-    } yield consumed
-
-  def withConsumer[R, A](
+  def withConsumerStrings[RC, A](
     groupId: String,
     clientId: String,
     diagnostics: Diagnostics = Diagnostics.NoOp,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto()
-  )(r: Consumer => RIO[R, A]) =
-    for {
-      settings <- consumerSettings(groupId, clientId, offsetRetrieval)
-      consumer = Consumer.make(settings, diagnostics)
-      consumed <- consumer.use(r)
-    } yield consumed
+  )(
+    r: Consumer.Service[Any, String, String] => RIO[RC, A]
+  ): ZIO[RC with Clock with Blocking with Kafka, Throwable, A] = {
+    val layers = (ZLayer.requires[Clock] ++ ZLayer
+      .requires[Blocking] ++ ZLayer.succeed(diagnostics) ++
+      ZLayer.succeed(Serde.string: Deserializer[Any, String]) ++ consumerSettings(groupId, clientId, offsetRetrieval).toLayer) >>> Consumer.live
+    layers.build.use { consumer =>
+      r(consumer.get)
+    }
+  }
+
+  def consumeWithStrings[RC](groupId: String, clientId: String, subscription: Subscription)(
+    r: (String, String) => URIO[RC, Unit]
+  ): RIO[RC with Blocking with Clock with Kafka, Unit] =
+    withConsumerStrings(groupId, clientId)(_.consumeWith(subscription)(r))
 
   def adminSettings =
     ZIO.access[Kafka](_.get[Kafka.Service].bootstrapServers).map(AdminClientSettings(_))

--- a/src/test/scala/zio/kafka/client/KafkaTestUtils.scala
+++ b/src/test/scala/zio/kafka/client/KafkaTestUtils.scala
@@ -9,7 +9,6 @@ import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.duration._
 import zio.kafka.client.Consumer.OffsetRetrieval
-import zio.kafka.client.Producer.Service
 import zio.kafka.client.diagnostics.Diagnostics
 import zio.kafka.client.embedded.Kafka
 import zio.kafka.client.serde.{ Deserializer, Serde, Serializer }
@@ -30,13 +29,8 @@ object KafkaTestUtils {
   ): ZIO[R with StringProducer, Throwable, A] =
     ZIO.accessM(env => r(env.get))
 
-  def produce[R, K, V](
-    record: ProducerRecord[K, V]
-  )(implicit ts: Tagged[Service[R, K, V]]): RIO[R with Producer[R, K, V] with Blocking, Task[RecordMetadata]] =
-    ZIO.accessM(_.get.produce(record))
-
   def produceOne(t: String, k: String, m: String): ZIO[Blocking with StringProducer, Throwable, RecordMetadata] =
-    produce[Any, String, String](new ProducerRecord(t, k, m)).flatten
+    Producer.produce[Any, String, String](new ProducerRecord(t, k, m)).flatten
 
   def produceMany(t: String, kvs: Iterable[(String, String)]) =
     withProducerStrings { p =>

--- a/src/test/scala/zio/kafka/client/ProducerSpec.scala
+++ b/src/test/scala/zio/kafka/client/ProducerSpec.scala
@@ -1,15 +1,13 @@
 package zio.kafka.client
 
-import zio.test._
-import zio.test.environment.TestEnvironment
-import KafkaTestUtils._
 import org.apache.kafka.clients.producer.ProducerRecord
 import zio._
-import zio.kafka.client.serde.Serde
-import zio.kafka.client.embedded.Kafka
-import zio.stream.Take
-import zio.test.Assertion._
 import zio.clock.Clock
+import zio.kafka.client.KafkaTestUtils._
+import zio.kafka.client.embedded.Kafka
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestEnvironment
 
 object ProducerSpec extends DefaultRunnableSpec {
   override def spec =
@@ -21,47 +19,48 @@ object ProducerSpec extends DefaultRunnableSpec {
           } yield assertCompletes
         }
       },
-      testM("a non-empty chunk of records") {
-        withProducerStrings {
-          producer =>
-            import Subscription._
-
-            val (topic1, key1, value1) = ("topic1", "boo", "baa")
-            val (topic2, key2, value2) = ("topic2", "baa", "boo")
-            val chunks = Chunk.fromIterable(
-              List(new ProducerRecord(topic1, key1, value1), new ProducerRecord(topic2, key2, value2))
-            )
-            def withConsumer(subscription: Subscription, settings: ConsumerSettings) =
-              Consumer
-                .make(settings)
-                .flatMap(c =>
-                  c.subscribe(subscription).toManaged_ *> c.plainStream(Serde.string, Serde.string).toQueue()
-                )
-
-            for {
-              outcome  <- producer.produceChunk(chunks).flatten
-              settings <- consumerSettings("testGroup", "testClient")
-              record1 <- withConsumer(Topics(Set(topic1)), settings).use { consumer =>
-                          for {
-                            messages <- Take.option(consumer.take).someOrFail(new NoSuchElementException)
-                            record = messages
-                              .filter(rec => rec.record.key == key1 && rec.record.value == value1)
-                              .toSeq
-                          } yield record
-                        }
-              record2 <- withConsumer(Topics(Set(topic2)), settings).use { consumer =>
-                          for {
-                            messages <- Take.option(consumer.take).someOrFail(new NoSuchElementException)
-                            record   = messages.filter(rec => rec.record.key == key2 && rec.record.value == value2)
-                          } yield record
-                        }
-            } yield {
-              assert(outcome.length)(equalTo(2)) &&
-              assert(record1)(isNonEmpty) &&
-              assert(record2.length)(isGreaterThan(0))
-            }
-        }
-      },
+//      testM("a non-empty chunk of records") {
+//        withProducerStrings {
+//          producer =>
+//            import Subscription._
+//
+//            val (topic1, key1, value1) = ("topic1", "boo", "baa")
+//            val (topic2, key2, value2) = ("topic2", "baa", "boo")
+//            val chunks = Chunk.fromIterable(
+//              List(new ProducerRecord(topic1, key1, value1), new ProducerRecord(topic2, key2, value2))
+//            )
+//
+//            def withConsumer(subscription: Subscription, settings: ConsumerSettings) =
+//              Consumer
+//                .make(settings)
+//                .flatMap(c =>
+//                  c.subscribe(subscription).toManaged_ *> c.plainStream(Serde.string, Serde.string).toQueue()
+//                )
+//
+//            for {
+//              outcome  <- producer.produceChunk(chunks).flatten
+//              settings <- consumerSettings("testGroup", "testClient")
+//              record1 <- withConsumer(Topics(Set(topic1)), settings).use { consumer =>
+//                          for {
+//                            messages <- Take.option(consumer.take).someOrFail(new NoSuchElementException)
+//                            record = messages
+//                              .filter(rec => rec.record.key == key1 && rec.record.value == value1)
+//                              .toSeq
+//                          } yield record
+//                        }
+//              record2 <- withConsumer(Topics(Set(topic2)), settings).use { consumer =>
+//                          for {
+//                            messages <- Take.option(consumer.take).someOrFail(new NoSuchElementException)
+//                            record   = messages.filter(rec => rec.record.key == key2 && rec.record.value == value2)
+//                          } yield record
+//                        }
+//            } yield {
+//              assert(outcome.length)(equalTo(2)) &&
+//              assert(record1)(isNonEmpty) &&
+//              assert(record2.length)(isGreaterThan(0))
+//            }
+//        }
+//      },
       testM("an empty chunk of records") {
         withProducerStrings { producer =>
           val chunks = Chunk.fromIterable(List.empty)
@@ -70,5 +69,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           } yield assert(outcome.length)(equalTo(0))
         }
       }
-    ).provideSomeLayerShared[TestEnvironment](Kafka.embedded.mapError(TestFailure.fail) ++ Clock.live)
+    ).provideSomeLayerShared[TestEnvironment](
+      (Kafka.embedded >>> testProducer).mapError(TestFailure.fail) ++ Clock.live
+    )
 }

--- a/src/test/scala/zio/kafka/client/ProducerSpec.scala
+++ b/src/test/scala/zio/kafka/client/ProducerSpec.scala
@@ -5,6 +5,8 @@ import zio._
 import zio.clock.Clock
 import zio.kafka.client.KafkaTestUtils._
 import zio.kafka.client.embedded.Kafka
+import zio.kafka.client.serde.Serde
+import zio.stream.Take
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestEnvironment
@@ -19,48 +21,46 @@ object ProducerSpec extends DefaultRunnableSpec {
           } yield assertCompletes
         }
       },
-//      testM("a non-empty chunk of records") {
-//        withProducerStrings {
-//          producer =>
-//            import Subscription._
-//
-//            val (topic1, key1, value1) = ("topic1", "boo", "baa")
-//            val (topic2, key2, value2) = ("topic2", "baa", "boo")
-//            val chunks = Chunk.fromIterable(
-//              List(new ProducerRecord(topic1, key1, value1), new ProducerRecord(topic2, key2, value2))
-//            )
-//
-//            def withConsumer(subscription: Subscription, settings: ConsumerSettings) =
-//              Consumer
-//                .make(settings)
-//                .flatMap(c =>
-//                  c.subscribe(subscription).toManaged_ *> c.plainStream(Serde.string, Serde.string).toQueue()
-//                )
-//
-//            for {
-//              outcome  <- producer.produceChunk(chunks).flatten
-//              settings <- consumerSettings("testGroup", "testClient")
-//              record1 <- withConsumer(Topics(Set(topic1)), settings).use { consumer =>
-//                          for {
-//                            messages <- Take.option(consumer.take).someOrFail(new NoSuchElementException)
-//                            record = messages
-//                              .filter(rec => rec.record.key == key1 && rec.record.value == value1)
-//                              .toSeq
-//                          } yield record
-//                        }
-//              record2 <- withConsumer(Topics(Set(topic2)), settings).use { consumer =>
-//                          for {
-//                            messages <- Take.option(consumer.take).someOrFail(new NoSuchElementException)
-//                            record   = messages.filter(rec => rec.record.key == key2 && rec.record.value == value2)
-//                          } yield record
-//                        }
-//            } yield {
-//              assert(outcome.length)(equalTo(2)) &&
-//              assert(record1)(isNonEmpty) &&
-//              assert(record2.length)(isGreaterThan(0))
-//            }
-//        }
-//      },
+      testM("a non-empty chunk of records") {
+        withProducerStrings {
+          producer =>
+            import Subscription._
+
+            val (topic1, key1, value1) = ("topic1", "boo", "baa")
+            val (topic2, key2, value2) = ("topic2", "baa", "boo")
+            val chunks = Chunk.fromIterable(
+              List(new ProducerRecord(topic1, key1, value1), new ProducerRecord(topic2, key2, value2))
+            )
+            def withConsumer(subscription: Subscription, settings: ConsumerSettings) =
+              Consumer.make(settings, Serde.string, Serde.string).build.flatMap { service =>
+                val c = service.get
+                (c.subscribe(subscription).toManaged_ *> c.plainStream.toQueue())
+              }
+
+            for {
+              outcome  <- producer.produceChunk(chunks).flatten
+              settings <- consumerSettings("testGroup", "testClient")
+              record1 <- withConsumer(Topics(Set(topic1)), settings).use { consumer =>
+                          for {
+                            messages <- Take.option(consumer.take).someOrFail(new NoSuchElementException)
+                            record = messages
+                              .filter(rec => rec.record.key == key1 && rec.record.value == value1)
+                              .toSeq
+                          } yield record
+                        }
+              record2 <- withConsumer(Topics(Set(topic2)), settings).use { consumer =>
+                          for {
+                            messages <- Take.option(consumer.take).someOrFail(new NoSuchElementException)
+                            record   = messages.filter(rec => rec.record.key == key2 && rec.record.value == value2)
+                          } yield record
+                        }
+            } yield {
+              assert(outcome.length)(equalTo(2)) &&
+              assert(record1)(isNonEmpty) &&
+              assert(record2.length)(isGreaterThan(0))
+            }
+        }
+      },
       testM("an empty chunk of records") {
         withProducerStrings { producer =>
           val chunks = Chunk.fromIterable(List.empty)
@@ -70,6 +70,6 @@ object ProducerSpec extends DefaultRunnableSpec {
         }
       }
     ).provideSomeLayerShared[TestEnvironment](
-      (Kafka.embedded >>> testProducer).mapError(TestFailure.fail) ++ Clock.live
+      ((Kafka.embedded >>> testProducer) ++ Kafka.embedded).mapError(TestFailure.fail) ++ Clock.live
     )
 }

--- a/src/test/scala/zio/kafka/client/embedded/package.scala
+++ b/src/test/scala/zio/kafka/client/embedded/package.scala
@@ -26,10 +26,7 @@ package object embedded {
       implicit val embeddedKafkaConfig = EmbeddedKafkaConfig(
         customBrokerProperties = Map("group.min.session.timeout.ms" -> "500", "group.initial.rebalance.delay.ms" -> "0")
       )
-
-      ZManaged
-        .make(ZIO.effect(EmbeddedKafkaService(EmbeddedKafka.start())))(_.stop())
-        .map(Has(_))
+      ZManaged.make(ZIO.effect(EmbeddedKafkaService(EmbeddedKafka.start())))(_.stop())
     }
 
     val local: ZLayer.NoDeps[Nothing, Kafka] = ZLayer.succeed(DefaultLocal)


### PR DESCRIPTION
This PR exposes producer and consumer interfaces as ZLayers. Top-level types are:
```scala
  type Producer[R, K, V] = Has[Producer.Service[R, K, V]]
  type Consumer[R, K, V] = Has[Consumer.Service[R, K, V]]
```
where:
* `R` is the environment required for serialization/deserialization
* `K` is the type of keys
* `V` is the type of values

Public API for creating service layers:
```scala
val pLayer: NoDeps[Throwable, Producer[R, K, V]] = Producer.make(settings, keySerde, valSerde)
val cLayer: NoDeps[Throwable, Consumer[R, K, V]] = Consumer.make(settings, keySerde, valSerde)
```
and from this point layers can be used as dependencies of programs.
It may be worth adding some additional aliases/methods for common use cases:
- cases without the `R` parameter for cases when serialization and deserialization don't have dependencies
- cases where keys and values are `String` or `Array[Byte]`