### PR TITLE
'makeManaged' for creating ZManaged live services

### DIFF
--- a/docs/annotatedTests.md
+++ b/docs/annotatedTests.md
@@ -133,7 +133,7 @@ withProducer creates settings and a ZManaged\[Producer\]. It then creates liveCl
 zio environment with the Live clock (which is essential when running code that
 uses scheduling or other timing features - as does much of zio-kafka)
 
-The actual poroducer operation function is simply wrapped in the producer.use
+The actual producer operation function is simply wrapped in the producer.use
 ```scala
               _ <- producer.produce(new ProducerRecord("topic", "boo", "baa"))
 ```

--- a/src/main/scala/zio/kafka/consumer/package.scala
+++ b/src/main/scala/zio/kafka/consumer/package.scala
@@ -265,28 +265,30 @@ package object consumer {
       ZSink.foldLeft[Offset, OffsetBatch](OffsetBatch.empty)(_ merge _)
 
     def live: ZLayer[Clock with Blocking with Has[ConsumerSettings] with Has[Diagnostics], Throwable, Consumer] =
-      ZLayer.fromManaged {
-        ZManaged
-          .accessManaged[Clock with Blocking with Has[ConsumerSettings] with Has[Diagnostics]] { env =>
-            val settings = env.get[ConsumerSettings]
-            for {
-              wrapper <- ConsumerAccess.make(settings)
-              runloop <- Runloop(
-                          wrapper,
-                          settings.pollInterval,
-                          settings.pollTimeout,
-                          env.get[Diagnostics],
-                          settings.offsetRetrieval
-                        )
-            } yield Live(wrapper, settings, runloop)
-          }
+      ZLayer.fromServicesManaged[ConsumerSettings, Diagnostics, Clock with Blocking, Throwable, Service] {
+        (settings, diagnostics) => makeManaged(settings, diagnostics)
       }
 
     def make(
       settings: ConsumerSettings,
       diagnostics: Diagnostics = Diagnostics.NoOp
     ): ZLayer[Clock with Blocking, Throwable, Consumer] =
-      ((ZLayer.requires[Clock with Blocking] ++ ZLayer.succeed(settings) ++ ZLayer.succeed(diagnostics)) >>> live)
+      ZLayer.fromManaged(makeManaged(settings, diagnostics))
+
+    def makeManaged(
+      settings: ConsumerSettings,
+      diagnostics: Diagnostics = Diagnostics.NoOp
+    ): ZManaged[Clock with Blocking, Throwable, Service] =
+      for {
+        wrapper <- ConsumerAccess.make(settings)
+        runloop <- Runloop(
+                    wrapper,
+                    settings.pollInterval,
+                    settings.pollTimeout,
+                    diagnostics,
+                    settings.offsetRetrieval
+                  )
+      } yield Live(wrapper, settings, runloop)
 
     def withConsumerService[R, A](
       r: Service => RIO[R with Blocking, A]
@@ -414,9 +416,7 @@ package object consumer {
       f: (K, V) => ZIO[R, Nothing, Unit]
     ): ZIO[R with R1 with Blocking with Clock, Throwable, Unit] =
       Consumer
-        .make(settings)
-        .build
-        .map(_.get[Service])
+        .makeManaged(settings)
         .use(_.consumeWith(subscription, keyDeserializer, valueDeserializer, commitRetryPolicy)(f))
 
     /**

--- a/src/main/scala/zio/kafka/consumer/package.scala
+++ b/src/main/scala/zio/kafka/consumer/package.scala
@@ -266,16 +266,10 @@ package object consumer {
 
     def live: ZLayer[Clock with Blocking with Has[ConsumerSettings] with Has[Diagnostics], Throwable, Consumer] =
       ZLayer.fromServicesManaged[ConsumerSettings, Diagnostics, Clock with Blocking, Throwable, Service] {
-        (settings, diagnostics) => makeManaged(settings, diagnostics)
+        (settings, diagnostics) => make(settings, diagnostics)
       }
 
     def make(
-      settings: ConsumerSettings,
-      diagnostics: Diagnostics = Diagnostics.NoOp
-    ): ZLayer[Clock with Blocking, Throwable, Consumer] =
-      ZLayer.fromManaged(makeManaged(settings, diagnostics))
-
-    def makeManaged(
       settings: ConsumerSettings,
       diagnostics: Diagnostics = Diagnostics.NoOp
     ): ZManaged[Clock with Blocking, Throwable, Service] =
@@ -416,7 +410,7 @@ package object consumer {
       f: (K, V) => ZIO[R, Nothing, Unit]
     ): ZIO[R with R1 with Blocking with Clock, Throwable, Unit] =
       Consumer
-        .makeManaged(settings)
+        .make(settings)
         .use(_.consumeWith(subscription, keyDeserializer, valueDeserializer, commitRetryPolicy)(f))
 
     /**

--- a/src/main/scala/zio/kafka/producer/package.scala
+++ b/src/main/scala/zio/kafka/producer/package.scala
@@ -135,29 +135,32 @@ package object producer {
     def live[R: Tagged, K: Tagged, V: Tagged]: ZLayer[Has[Serializer[R, K]] with Has[Serializer[R, V]] with Has[
       ProducerSettings
     ], Throwable, Producer[R, K, V]] =
-      ZLayer.fromManaged {
-        ZIO
-          .accessM[Has[Serializer[R, K]] with Has[Serializer[R, V]] with Has[ProducerSettings]] { env =>
-            val settings = env.get[ProducerSettings]
-            ZIO {
-              val props = settings.driverSettings.asJava
-              val rawProducer = new KafkaProducer[Array[Byte], Array[Byte]](
-                props,
-                new ByteArraySerializer(),
-                new ByteArraySerializer()
-              )
-              Live(rawProducer, settings, env.get[Serializer[R, K]], env.get[Serializer[R, V]])
-            }
-          }
-          .toManaged(_.close)
-      }
+      ZLayer
+        .fromServicesManaged[Serializer[R, K], Serializer[R, V], ProducerSettings, Any, Throwable, Service[R, K, V]] {
+          (keySerializer, valueSerializer, settings) => makeManaged(settings, keySerializer, valueSerializer)
+        }
 
     def make[R: Tagged, K: Tagged, V: Tagged](
       settings: ProducerSettings,
       keySerializer: Serializer[R, K],
       valueSerializer: Serializer[R, V]
     ): ZLayer[Any, Throwable, Producer[R, K, V]] =
-      (ZLayer.succeed(settings) ++ ZLayer.succeed(keySerializer) ++ ZLayer.succeed(valueSerializer)) >>> live[R, K, V]
+      ZLayer.fromManaged(makeManaged(settings, keySerializer, valueSerializer))
+
+    def makeManaged[R: Tagged, K: Tagged, V: Tagged](
+      settings: ProducerSettings,
+      keySerializer: Serializer[R, K],
+      valueSerializer: Serializer[R, V]
+    ): ZManaged[Any, Throwable, Service[R, K, V]] =
+      ZIO.effect {
+        val props = settings.driverSettings.asJava
+        val rawProducer = new KafkaProducer[Array[Byte], Array[Byte]](
+          props,
+          new ByteArraySerializer(),
+          new ByteArraySerializer()
+        )
+        Live(rawProducer, settings, keySerializer, valueSerializer)
+      }.toManaged(_.close)
 
     def withProducerService[R: Tagged, K: Tagged, V: Tagged, A](
       r: Producer.Service[R, K, V] => RIO[R with Blocking, A]

--- a/src/main/scala/zio/kafka/producer/package.scala
+++ b/src/main/scala/zio/kafka/producer/package.scala
@@ -137,17 +137,10 @@ package object producer {
     ], Throwable, Producer[R, K, V]] =
       ZLayer
         .fromServicesManaged[Serializer[R, K], Serializer[R, V], ProducerSettings, Any, Throwable, Service[R, K, V]] {
-          (keySerializer, valueSerializer, settings) => makeManaged(settings, keySerializer, valueSerializer)
+          (keySerializer, valueSerializer, settings) => make(settings, keySerializer, valueSerializer)
         }
 
-    def make[R: Tagged, K: Tagged, V: Tagged](
-      settings: ProducerSettings,
-      keySerializer: Serializer[R, K],
-      valueSerializer: Serializer[R, V]
-    ): ZLayer[Any, Throwable, Producer[R, K, V]] =
-      ZLayer.fromManaged(makeManaged(settings, keySerializer, valueSerializer))
-
-    def makeManaged[R: Tagged, K: Tagged, V: Tagged](
+    def make[R, K, V](
       settings: ProducerSettings,
       keySerializer: Serializer[R, K],
       valueSerializer: Serializer[R, V]

--- a/src/test/scala/Benchmarks.scala
+++ b/src/test/scala/Benchmarks.scala
@@ -26,12 +26,14 @@ object PopulateTopic extends App {
       .mapMPar(5)(_.flatMap(chunk => console.putStrLn(s"Wrote chunk of ${chunk.size}")))
       .runDrain
       .provideCustomLayer(
-        Producer.make(
-          ProducerSettings(List("localhost:9092"))
-            .withProperty(ProducerConfig.ACKS_CONFIG, "1")
-            .withProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4"),
-          Serde.string,
-          Serde.string
+        ZLayer.fromManaged(
+          Producer.make(
+            ProducerSettings(List("localhost:9092"))
+              .withProperty(ProducerConfig.ACKS_CONFIG, "1")
+              .withProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4"),
+            Serde.string,
+            Serde.string
+          )
         )
       )
       .fold(_ => 1, _ => 0)
@@ -112,7 +114,7 @@ object ZIOKafka extends App {
               )
             }
         })
-      .provideCustomLayer(Consumer.make(settings))
+      .provideCustomLayer(ZLayer.fromManaged(Consumer.make(settings)))
       .fold(_ => 1, _ => 0)
 
   }

--- a/src/test/scala/ProducerSpec.scala
+++ b/src/test/scala/ProducerSpec.scala
@@ -29,8 +29,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           List(new ProducerRecord(topic1, key1, value1), new ProducerRecord(topic2, key2, value2))
         )
         def withConsumer(subscription: Subscription, settings: ConsumerSettings) =
-          Consumer.make(settings).build.flatMap { service =>
-            val c = service.get
+          Consumer.make(settings).flatMap { c =>
             (c.subscribe(subscription).toManaged_ *> c.plainStream(Serde.string, Serde.string).toQueue())
           }
 


### PR DESCRIPTION
This adds `makeManaged` functions returning `ZManaged[Any, Throwable, Service[R, K, V]`  for `Producer` and `Consumer`.

One place where it's convenient manifests in this PR in `Consumer#consumeWith`.
I've also found out such pattern in my own project:
```scala
  def live: ZLayer[Has[Config], Throwable, KafkaEventPublisher] = {
    ZLayer.fromServiceManaged[Config, Any, Throwable, Service] { cfg =>
      Producer.make(ProducerSettings(cfg.bootstrapHosts), Serializer.string, Serializer.string).build.map {
        hasProducer => new LivePublisher(hasProducer.get, cfg.topic)
      }
    }
  }
```
Going through `build`, `map` and `get` is redundant if `ZManaged` is exposed.
I didn't change `make` signature, I see such function also has it's usablity. I decided to add `makeManaged` instead.