### PR TITLE
Introduce 'Serializers' to avoid clash of key and value serializers.

### DIFF
--- a/src/test/scala/zio/kafka/KafkaTestUtils.scala
+++ b/src/test/scala/zio/kafka/KafkaTestUtils.scala
@@ -13,7 +13,7 @@ import zio.kafka.consumer.Consumer.OffsetRetrieval
 import zio.kafka.consumer._
 import zio.kafka.consumer.diagnostics.Diagnostics
 import zio.kafka.embedded.Kafka
-import zio.kafka.serde.{ Deserializer, Serde, Serializer }
+import zio.kafka.serde.{ Deserializer, Serde }
 import zio.kafka.producer._
 
 object KafkaTestUtils {
@@ -23,7 +23,7 @@ object KafkaTestUtils {
     ZIO.access[Kafka](_.get[Kafka.Service].bootstrapServers).map(ProducerSettings(_))
 
   val stringProducer: ZLayer[Kafka, Throwable, StringProducer] =
-    (ZLayer.fromEffect(producerSettings) ++ ZLayer.succeed(Serde.string: Serializer[Any, String])) >>>
+    (ZLayer.fromEffect(producerSettings) ++ ZLayer.succeed(Serializers(Serde.string, Serde.string))) >>>
       Producer.live[Any, String, String]
 
   def produceOne(


### PR DESCRIPTION
This targets #162 I reported.
Scenario of failure is:
```scala
val keySer: Serializer[Any, String] = <some implementation>
val valueSer: Serializer[Any, String] = <other implementation>
Producer.make(someProducerSettings, keySer, valueSer)
```
Created producer will use `valueSer` for both keys and values.