### PR TITLE
Change produce to produceAsync, add version awaiting ack

### DIFF
--- a/src/test/scala/Benchmarks.scala
+++ b/src/test/scala/Benchmarks.scala
@@ -22,7 +22,7 @@ object PopulateTopic extends App {
     dataStream(872000).map {
       case (k, v) => new ProducerRecord("inputs-topic", null, null, k, v)
     }.chunks
-      .mapM(Producer.produceChunk[Any, String, String])
+      .mapM(Producer.produceChunkAsync[Any, String, String])
       .mapMPar(5)(_.flatMap(chunk => console.putStrLn(s"Wrote chunk of ${chunk.size}")))
       .runDrain
       .provideCustomLayer(

--- a/src/test/scala/KafkaTestUtils.scala
+++ b/src/test/scala/KafkaTestUtils.scala
@@ -31,7 +31,7 @@ object KafkaTestUtils {
     key: String,
     message: String
   ): ZIO[Blocking with StringProducer, Throwable, RecordMetadata] =
-    Producer.produce[Any, String, String](new ProducerRecord(topic, key, message)).flatten
+    Producer.produce[Any, String, String](new ProducerRecord(topic, key, message))
 
   def produceMany(
     topic: String,
@@ -42,7 +42,6 @@ object KafkaTestUtils {
       .produceChunk[Any, String, String](Chunk.fromIterable(kvs.map {
         case (k, v) => new ProducerRecord(topic, partition, null, k, v)
       }))
-      .flatten
 
   def produceMany(
     topic: String,
@@ -52,7 +51,6 @@ object KafkaTestUtils {
       .produceChunk[Any, String, String](Chunk.fromIterable(kvs.map {
         case (k, v) => new ProducerRecord(topic, k, v)
       }))
-      .flatten
 
   def consumerSettings(groupId: String, clientId: String, offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto()) =
     ZIO.access[Kafka] { kafka: Kafka =>

--- a/src/test/scala/ProducerSpec.scala
+++ b/src/test/scala/ProducerSpec.scala
@@ -34,7 +34,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           }
 
         for {
-          outcome  <- Producer.produceChunk[Any, String, String](chunks).flatten
+          outcome  <- Producer.produceChunk[Any, String, String](chunks)
           settings <- consumerSettings("testGroup", "testClient")
           record1 <- withConsumer(Topics(Set(topic1)), settings).use { consumer =>
                       for {
@@ -59,7 +59,7 @@ object ProducerSpec extends DefaultRunnableSpec {
       testM("an empty chunk of records") {
         val chunks = Chunk.fromIterable(List.empty)
         for {
-          outcome <- Producer.produceChunk[Any, String, String](chunks).flatten
+          outcome <- Producer.produceChunk[Any, String, String](chunks)
         } yield assert(outcome.length)(equalTo(0))
       }
     ).provideSomeLayerShared[TestEnvironment](


### PR DESCRIPTION
This targets #164 .
It adds renames two stage functions `produce` to `produceAsync` and `produceChunk` to `produceChunkAsync` and introduces one stage `produce` and `produceChunk`