### PR TITLE
Add fuctions to serialize and deserialize to option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,9 @@ libraryDependencies ++= Seq(
   "org.scala-lang.modules"  %% "scala-collection-compat" % "2.1.6",
   compilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full)
 ) ++ {
-  if (scalaBinaryVersion.value == "2.13") silencer else Seq.empty
+  if (scalaBinaryVersion.value == "2.13") silencer
+  else if (scalaBinaryVersion.value == "2.12") silencer
+  else Seq.empty
 }
 
 Compile / compile / scalacOptions ++= {

--- a/src/main/scala/zio/kafka/serde/Serde.scala
+++ b/src/main/scala/zio/kafka/serde/Serde.scala
@@ -25,6 +25,9 @@ trait Serde[-R, T] extends Deserializer[R, T] with Serializer[R, T] {
    */
   def inmapM[R1 <: R, U](f: T => RIO[R1, U])(g: U => RIO[R1, T]): Serde[R1, U] =
     Serde(mapM(f))(contramapM(g))
+
+  def asOption(implicit ev: T <:< AnyRef, ev2: Null <:< T): Serde[R, Option[T]] =
+    Serde(super[Deserializer].asOption)(super[Serializer].asOption)
 }
 
 object Serde extends Serdes {

--- a/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -24,6 +24,9 @@ trait Serializer[-R, -T] {
    */
   def contramapM[R1 <: R, U](f: U => RIO[R1, T]): Serializer[R1, U] =
     Serializer((topic, headers, u) => f(u).flatMap(serialize(topic, headers, _)))
+
+  def asOption[U <: T](implicit ev: Null <:< T): Serializer[R, Option[U]] =
+    contramap(_.orNull)
 }
 
 object Serializer extends Serdes {

--- a/src/test/scala/zio/kafka/serde/DeserializerSpec.scala
+++ b/src/test/scala/zio/kafka/serde/DeserializerSpec.scala
@@ -3,6 +3,7 @@ package zio.kafka.serde
 import org.apache.kafka.common.header.internals.RecordHeaders
 import zio._
 import zio.test.Assertion._
+import zio.test.TestAspect._
 import zio.test._
 
 object DeserializerSpec extends DefaultRunnableSpec {
@@ -22,7 +23,7 @@ object DeserializerSpec extends DefaultRunnableSpec {
           )
         }
       }
-    )
+    ) @@ sequential //For some reason the tests have to run in sequence else they would hang and timeout eventually
   )
 
   private lazy val stringDeserializer: Deserializer[Any, String] = Serde.string

--- a/src/test/scala/zio/kafka/serde/DeserializerSpec.scala
+++ b/src/test/scala/zio/kafka/serde/DeserializerSpec.scala
@@ -1,0 +1,29 @@
+package zio.kafka.serde
+
+import org.apache.kafka.common.header.internals.RecordHeaders
+import zio._
+import zio.test.Assertion._
+import zio.test._
+
+object DeserializerSpec extends DefaultRunnableSpec {
+  override def spec = suite("Deserializer")(
+    suite("asOption")(
+      testM("deserialize to None when value is null") {
+        assertM(stringDeserializer.asOption.deserialize("topic1", new RecordHeaders, null))(isNone)
+      },
+      testM("deserialize to None when value is null also when underlying deserializer fails on null values") {
+        val deserializer = Deserializer((_, _, _) => ZIO.fail(new RuntimeException("cannot handle null")))
+        assertM(deserializer.asOption.deserialize("topic1", new RecordHeaders, null))(isNone)
+      },
+      testM("deserialize to Some when value is not null") {
+        checkM(Gen.anyString) { string =>
+          assertM(stringDeserializer.asOption.deserialize("topic1", new RecordHeaders, string.getBytes))(
+            isSome(equalTo(string))
+          )
+        }
+      }
+    )
+  )
+
+  private lazy val stringDeserializer: Deserializer[Any, String] = Serde.string
+}

--- a/src/test/scala/zio/kafka/serde/SerdeSpec.scala
+++ b/src/test/scala/zio/kafka/serde/SerdeSpec.scala
@@ -1,0 +1,40 @@
+package zio.kafka.serde
+
+import org.apache.kafka.common.header.internals.RecordHeaders
+import zio.test.Assertion._
+import zio.test._
+
+import scala.reflect.ClassTag
+
+object SerdeSpec extends DefaultRunnableSpec {
+  override def spec = suite("Serde")(
+    testSerde(Serde.string, Gen.anyString),
+    testSerde(Serde.int, Gen.anyInt),
+    testSerde(Serde.short, Gen.anyShort),
+    testSerde(Serde.float, Gen.anyFloat),
+    testSerde(Serde.double, Gen.anyDouble),
+    testSerde(Serde.long, Gen.anyLong),
+    testSerde(Serde.uuid, Gen.anyUUID),
+    testSerde(Serde.byteArray, Gen.listOf(Gen.anyByte).map(_.toArray)),
+    suite("asOption")(
+      testM("serialize and deserialize None values to null and visa versa") {
+        val serde = Serde.string.asOption
+        for {
+          serialized   <- serde.serialize("topic1", new RecordHeaders, None)
+          deserialized <- serde.deserialize("topic1", new RecordHeaders, serialized)
+        } yield assert(serialized)(isNull) && assert(deserialized)(isNone)
+      }
+    )
+  )
+
+  private def testSerde[R, A](serde: Serde[Any, A], gen: Gen[R, A])(implicit clsTag: ClassTag[A]) =
+    testM(s"serialize and deserialize ${clsTag.runtimeClass.getSimpleName}") {
+      checkM(gen) { value =>
+        for {
+          serialized   <- serde.serialize("topic1", new RecordHeaders, value)
+          deserialized <- serde.deserialize("topic1", new RecordHeaders, serialized)
+        } yield assert(deserialized)(equalTo(deserialized))
+      }
+    }
+
+}

--- a/src/test/scala/zio/kafka/serde/SerializerSpec.scala
+++ b/src/test/scala/zio/kafka/serde/SerializerSpec.scala
@@ -1,0 +1,23 @@
+package zio.kafka.serde
+
+import org.apache.kafka.common.header.internals.RecordHeaders
+import zio.test.Assertion._
+import zio.test._
+
+object SerializerSpec extends DefaultRunnableSpec {
+  override def spec = suite("Serializer")(
+    suite("asOption")(
+      testM("serialize None values to null") {
+        assertM(stringSerializer.asOption.serialize("topic1", new RecordHeaders, None))(isNull)
+      },
+      testM("serialize Some values") {
+        checkM(Gen.anyString) { string =>
+          assertM(stringSerializer.asOption.serialize("topic1", new RecordHeaders, Some(string)))(
+            equalTo(string.getBytes)
+          )
+        }
+      }
+    )
+  )
+  private lazy val stringSerializer: Serializer[Any, String] = Serde.string
+}


### PR DESCRIPTION
In Kafka topics, records can have null values. Records with null values have a special meaning namely a 'delete' of the record. For log compacted topics, records that have null value will be marked for deletion and will be deleted (eventually).