### PR TITLE
Expose metrics for producer/consumer

### DIFF
--- a/src/test/scala/zio/kafka/ConsumerSpec.scala
+++ b/src/test/scala/zio/kafka/ConsumerSpec.scala
@@ -22,6 +22,12 @@ import zio.Chunk
 object ConsumerSpec extends DefaultRunnableSpec {
   override def spec: ZSpec[TestEnvironment, Throwable] =
     suite("Consumer Streaming")(
+      testM("export metrics") {
+        for {
+          metrics <- Consumer.metrics
+                      .provideSomeLayer[Kafka with Blocking with Clock](consumer("group1289", "client150"))
+        } yield assert(metrics)(isNonEmpty)
+      },
       testM("plainStream emits messages for a topic subscription") {
         val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
         for {

--- a/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -60,6 +60,11 @@ object ProducerSpec extends DefaultRunnableSpec {
         for {
           outcome <- Producer.produceChunk[Any, String, String](chunks)
         } yield assert(outcome.length)(equalTo(0))
+      },
+      testM("export metrics") {
+        for {
+          metrics <- Producer.metrics[Any, String, String]
+        } yield assert(metrics)(isNonEmpty)
       }
     ).provideSomeLayerShared[TestEnvironment](
       ((Kafka.embedded >>> stringProducer) ++ Kafka.embedded).mapError(TestFailure.fail) ++ Clock.live


### PR DESCRIPTION
Expose metrics for producer/consumer like [alpakka-kafka](https://doc.akka.io/docs/alpakka-kafka/current/producer.html#accessing-kafkaproducer-metrics) and [fs2-kafka](https://github.com/fd4s/fs2-kafka/blob/aaa82e23025df7f1ac03666f5bf05da1133f2c43/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala#L325) do.