### PR TITLE
Add describeCluster* methods to AdminClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,5 +109,6 @@ project/plugins/project/
 ### Metals / Bloop ###
 .bloop/
 .metals/
+.bsp/
 
 # End of https://www.gitignore.io/api/sbt,scala,intellij+all

--- a/src/test/scala/zio/kafka/AdminSpec.scala
+++ b/src/test/scala/zio/kafka/AdminSpec.scala
@@ -94,6 +94,20 @@ object AdminSpec extends DefaultRunnableSpec {
               assert(list3.size)(equalTo(0))
         }
       },
+      testM("list cluster nodes") {
+        KafkaTestUtils.withAdmin { client =>
+          for {
+            nodes <- client.listClusterNodes()
+          } yield assert(nodes.size)(equalTo(1))
+        }
+      },
+      testM("get cluster controller") {
+        KafkaTestUtils.withAdmin { client =>
+          for {
+            controller <- client.getClusterController()
+          } yield assert(controller.id())(equalTo(0))
+        }
+      },
       testM("describe broker config") {
         KafkaTestUtils.withAdmin { client =>
           for {

--- a/src/test/scala/zio/kafka/AdminSpec.scala
+++ b/src/test/scala/zio/kafka/AdminSpec.scala
@@ -1,6 +1,7 @@
 package zio.kafka.admin
 
 import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.acl.AclOperation
 import org.apache.kafka.common.config.ConfigResource
 import zio.Chunk
 import zio.blocking.Blocking
@@ -97,15 +98,29 @@ object AdminSpec extends DefaultRunnableSpec {
       testM("list cluster nodes") {
         KafkaTestUtils.withAdmin { client =>
           for {
-            nodes <- client.listClusterNodes()
+            nodes <- client.describeClusterNodes()
           } yield assert(nodes.size)(equalTo(1))
         }
       },
       testM("get cluster controller") {
         KafkaTestUtils.withAdmin { client =>
           for {
-            controller <- client.getClusterController()
+            controller <- client.describeClusterController()
           } yield assert(controller.id())(equalTo(0))
+        }
+      },
+      testM("get cluster id") {
+        KafkaTestUtils.withAdmin { client =>
+          for {
+            controllerId <- client.describeClusterId()
+          } yield assert(controllerId.nonEmpty)(isTrue)
+        }
+      },
+      testM("get cluster authorized operations") {
+        KafkaTestUtils.withAdmin { client =>
+          for {
+            operations <- client.describeClusterAuthorizedOperations()
+          } yield assert(operations)(equalTo(Set.empty[AclOperation]))
         }
       },
       testM("describe broker config") {


### PR DESCRIPTION
Small addition for `AdminClient` of listing the cluster nodes and getting the cluster controller.
Edit: `clusterId` and `authorizedOperations` were added as well.