### PR TITLE
Include jackson-databind as transitive dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,6 @@ libraryDependencies ++= Seq(
 )
 ```
 
-On some JVMs it is necessary to add this dependency as well:
-```
-libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.2" // or higher version
-```
-
 Somewhere in your application, configure the `zio.kafka.ConsumerSettings` 
 data type:
 ```scala

--- a/build.sbt
+++ b/build.sbt
@@ -59,12 +59,13 @@ buildInfoPackage := "zio.kafka"
 buildInfoObject := "BuildInfo"
 
 libraryDependencies ++= Seq(
-  "dev.zio"                %% "zio-streams"             % zioVersion,
-  "dev.zio"                %% "zio-test"                % zioVersion % "test",
-  "dev.zio"                %% "zio-test-sbt"            % zioVersion % "test",
-  "org.apache.kafka"       % "kafka-clients"            % kafkaVersion,
-  "ch.qos.logback"         % "logback-classic"          % "1.2.3" % "test",
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.2.0",
+  "dev.zio"                    %% "zio-streams"             % zioVersion,
+  "dev.zio"                    %% "zio-test"                % zioVersion % "test",
+  "dev.zio"                    %% "zio-test-sbt"            % zioVersion % "test",
+  "org.apache.kafka"           % "kafka-clients"            % kafkaVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind"         % "2.10.2",
+  "ch.qos.logback"             % "logback-classic"          % "1.2.3" % "test",
+  "org.scala-lang.modules"     %% "scala-collection-compat" % "2.2.0",
   compilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full)
 ) ++ {
   if (scalaBinaryVersion.value == "2.13") silencer


### PR DESCRIPTION
Recent kafka-clients have made the jackson-databind dependency `provided`, which leads to runtime errors for `zio-kafka` users.

We did not discover this during testing on CircleCI because we use embedded-kafka, which brings in the dependency.