### PR TITLE
Add mention to include `jackson-databind` libraryDependency in README.md until new version has been released.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ libraryDependencies ++= Seq(
 )
 ```
 
+On some JVMs it is necessary to add this dependency as well:	
+```	
+libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.2" // or higher version	
+```
+
 Somewhere in your application, configure the `zio.kafka.ConsumerSettings` 
 data type:
 ```scala


### PR DESCRIPTION
Can be removed after new version has been released, since https://github.com/zio/zio-kafka/commit/86f7c017b4f5add36d183c80ec0b9a1100697d4c already fixed it.