### PR TITLE
Avoid calling resume/pause if topic collection is empty

### DIFF
--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -239,8 +239,8 @@ private[consumer] final class Runloop(
     val toResume = assignment intersect requestedPartitions
     val toPause  = assignment -- requestedPartitions
 
-    c.resume(toResume.asJava)
-    c.pause(toPause.asJava)
+    if (toResume.nonEmpty) c.resume(toResume.asJava)
+    if (toPause.nonEmpty) c.pause(toPause.asJava)
   }
 
   private def doPoll(c: ByteArrayKafkaConsumer, requestedPartitions: Set[TopicPartition]) =


### PR DESCRIPTION
While doing some performance tests/investigation at driver level, I've noticed that logs are polluted in `DEBUG` mode with lots of:

```
[09:59:00.307]-[zio-default-blocking-1] DEBUG o.a.k.c.c.KafkaConsumer - [Consumer clientId=solver-service-0Ke8-consumer, groupId=solver-local-aartigao-2101121448] Resuming partitions []
[09:59:00.308]-[zio-default-blocking-1] DEBUG o.a.k.c.c.KafkaConsumer - [Consumer clientId=solver-service-0Ke8-consumer, groupId=solver-local-aartigao-2101121448] Pausing partitions []
[09:59:00.532]-[zio-default-blocking-1] DEBUG o.a.k.c.c.KafkaConsumer - [Consumer clientId=solver-service-0Ke8-consumer, groupId=solver-local-aartigao-2101121448] Resuming partitions []
[09:59:00.532]-[zio-default-blocking-1] DEBUG o.a.k.c.c.KafkaConsumer - [Consumer clientId=solver-service-0Ke8-consumer, groupId=solver-local-aartigao-2101121448] Pausing partitions []
[09:59:00.677]-[zio-default-blocking-1] DEBUG o.a.k.c.c.KafkaConsumer - [Consumer clientId=solver-service-0Ke8-consumer, groupId=solver-local-aartigao-2101121448] Resuming partitions []
[09:59:00.677]-[zio-default-blocking-1] DEBUG o.a.k.c.c.KafkaConsumer - [Consumer clientId=solver-service-0Ke8-consumer, groupId=solver-local-aartigao-2101121448] Pausing partitions []
```

This PR simply avoids calling the underlying KafkaConsumer unless there's actually something to resume/pause.