### PR TITLE
Expose outputBuffer in plainStream

### DIFF
--- a/src/main/scala/zio/kafka/consumer/SubscribedConsumer.scala
+++ b/src/main/scala/zio/kafka/consumer/SubscribedConsumer.scala
@@ -20,9 +20,12 @@ class SubscribedConsumer(
 
   def plainStream[R, K, V](
     keyDeserializer: Deserializer[R, K],
-    valueDeserializer: Deserializer[R, V]
+    valueDeserializer: Deserializer[R, V],
+    outputBuffer: Int = 4
   ): ZStream[R with Clock with Blocking, Throwable, CommittableRecord[K, V]] =
-    partitionedStream(keyDeserializer, valueDeserializer).flatMapPar(n = Int.MaxValue)(_._2)
+    partitionedStream(keyDeserializer, valueDeserializer).flatMapPar(n = Int.MaxValue, outputBuffer = outputBuffer)(
+      _._2
+    )
 }
 
 class SubscribedConsumerFromEnvironment(
@@ -38,7 +41,10 @@ class SubscribedConsumerFromEnvironment(
 
   def plainStream[R, K, V](
     keyDeserializer: Deserializer[R, K],
-    valueDeserializer: Deserializer[R, V]
+    valueDeserializer: Deserializer[R, V],
+    outputBuffer: Int = 4
   ): ZStream[R with Clock with Blocking with Consumer, Throwable, CommittableRecord[K, V]] =
-    partitionedStream(keyDeserializer, valueDeserializer).flatMapPar(n = Int.MaxValue)(_._2)
+    partitionedStream(keyDeserializer, valueDeserializer).flatMapPar(n = Int.MaxValue, outputBuffer = outputBuffer)(
+      _._2
+    )
 }

--- a/src/main/scala/zio/kafka/consumer/package.scala
+++ b/src/main/scala/zio/kafka/consumer/package.scala
@@ -72,7 +72,7 @@ package object consumer {
        * The stream will emit messages from all topic-partitions interleaved. Per-partition
        * record order is guaranteed, but the topic-partition interleaving is non-deterministic.
        *
-       * Up to `outputBuffer` chunks for each topic-partition may be buffered in memory by this operator.
+       * Up to `outputBuffer` chunks may be buffered in memory by this operator.
        *
        * The stream can be completed by calling [[stopConsumption]].
        */


### PR DESCRIPTION
Expose how many chunks are buffered for each topic-partition in `plainStream`. Also use 4 as a default instead of 16 which is pretty high since we're dealing with chunks (I can revert back to 16 if we want to keep the behavior unchanged).