### PR TITLE
Fix NullPointerException in 'partitionsFor' when Topic is not created

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbt.Keys.{ fork, parallelExecution }
+
 lazy val scala211  = "2.11.12"
 lazy val scala212  = "2.12.11"
 lazy val scala213  = "2.13.3"
@@ -26,9 +28,9 @@ inThisBuild(
     useCoursier := false,
     scalaVersion := mainScala,
     crossScalaVersions := allScala,
-    parallelExecution in Test := false,
-    fork in Test := true,
-    fork in run := true,
+    Test / parallelExecution := false,
+    Test / fork := true,
+    run / fork := true,
     pgpPublicRing := file("/tmp/public.asc"),
     pgpSecretRing := file("/tmp/secret.asc"),
     pgpPassphrase := sys.env.get("PGP_PASSWORD").map(_.toArray),

--- a/src/main/scala/zio/kafka/consumer/package.scala
+++ b/src/main/scala/zio/kafka/consumer/package.scala
@@ -217,7 +217,10 @@ package object consumer {
         topic: String,
         timeout: Duration = Duration.Infinity
       ): RIO[Blocking, List[PartitionInfo]] =
-        consumer.withConsumer(_.partitionsFor(topic, timeout.asJava).asScala.toList)
+        consumer.withConsumer { c =>
+          val partitions = c.partitionsFor(topic, timeout.asJava)
+          if (partitions eq null) List.empty else partitions.asScala.toList
+        }
 
       override def position(partition: TopicPartition, timeout: Duration = Duration.Infinity): RIO[Blocking, Long] =
         consumer.withConsumer(_.position(partition, timeout.asJava))

--- a/src/test/scala/zio/kafka/ConsumerSpec.scala
+++ b/src/test/scala/zio/kafka/ConsumerSpec.scala
@@ -468,6 +468,18 @@ object ConsumerSpec extends DefaultRunnableSpec {
                          .provideSomeLayer[Kafka with Blocking with Clock](consumer("group3", "client3"))
           consumedMessages <- messagesReceived.get
         } yield assert(consumedMessages)(contains(newMessage).negate)
+      },
+      testM("partitions for topic doesn't fail if doesn't exist") {
+        for {
+          topic  <- randomTopic
+          group  <- randomGroup
+          client <- randomThing("client")
+          partitions <- Consumer
+                         .partitionsFor(topic)
+                         .provideSomeLayer[Kafka with Blocking with Clock](
+                           consumer(group, client, allowAutoCreateTopics = false)
+                         )
+        } yield assert(partitions)(isEmpty)
       }
     ).provideSomeLayerShared[TestEnvironment](
       ((Kafka.embedded >>> stringProducer) ++ Kafka.embedded).mapError(TestFailure.fail) ++ Clock.live


### PR DESCRIPTION
Today we've found that `NullPointerException` is raised when trying to resolve partitions for a particular topic.

Turns out if `allow.auto.create.topics` is set and topic is not created yet, it creates one with default values, but in our organization this flag is disabled.

This PR fixes that by checking nullability and also fixes some SBT warnings about slash syntax.