### PR TITLE
Remove listener for pausing partitions on rebalance revoke

### DIFF
--- a/src/main/scala/zio/kafka/consumer/internal/RebalanceListener.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/RebalanceListener.scala
@@ -15,7 +15,7 @@ private[consumer] final case class RebalanceListener(
   /**
    * Combine with another [[RebalanceListener]] and execute their actions sequentially
    */
-  def ++(that: RebalanceListener) =
+  def ++(that: RebalanceListener): RebalanceListener =
     RebalanceListener(
       assigned => onAssigned(assigned) *> that.onAssigned(assigned),
       revoked => onRevoked(revoked) *> that.onRevoked(revoked)
@@ -34,9 +34,4 @@ private[consumer] final case class RebalanceListener(
       }
     }
 
-}
-
-object RebalanceListener {
-  def onRevoked(action: Set[TopicPartition] => Task[Unit]): RebalanceListener =
-    RebalanceListener(_ => Task.unit, action)
 }


### PR DESCRIPTION
As discussed in Discord channel, seems that revoke callback implies that assigned partitions are no longer available so pausing them may be redundant.

I really don't know the implications of this change, so expert advice is welcomed 😅 