### PR TITLE
Aesthetic idiomatic changes

### DIFF
--- a/src/main/scala/zio/kafka/consumer/Offset.scala
+++ b/src/main/scala/zio/kafka/consumer/Offset.scala
@@ -2,7 +2,7 @@ package zio.kafka.consumer
 
 import org.apache.kafka.clients.consumer.RetriableCommitFailedException
 import org.apache.kafka.common.TopicPartition
-import zio.{ Schedule, Task, ZIO }
+import zio.{ RIO, Schedule, Task }
 import zio.clock.Clock
 
 sealed trait Offset {
@@ -15,7 +15,7 @@ sealed trait Offset {
    * Attempts to commit and retries according to the given policy when the commit fails
    * with a RetriableCommitFailedException
    */
-  def commitOrRetry[R](policy: Schedule[R, Throwable, Any]): ZIO[R with Clock, Throwable, Unit] =
+  def commitOrRetry[R](policy: Schedule[R, Throwable, Any]): RIO[R with Clock, Unit] =
     Offset.commitOrRetry(commit, policy)
 }
 
@@ -23,7 +23,7 @@ object Offset {
   private[consumer] def commitOrRetry[R, B](
     commit: Task[Unit],
     policy: Schedule[R, Throwable, B]
-  ): ZIO[R with Clock, Throwable, Unit] =
+  ): RIO[R with Clock, Unit] =
     commit.retry(
       Schedule.recurWhile[Throwable] {
         case _: RetriableCommitFailedException => true

--- a/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
+++ b/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
@@ -1,7 +1,7 @@
 package zio.kafka.consumer
 
 import org.apache.kafka.common.TopicPartition
-import zio.{ Schedule, Task, ZIO }
+import zio.{ RIO, Schedule, Task }
 import zio.clock.Clock
 
 sealed trait OffsetBatch {
@@ -14,7 +14,7 @@ sealed trait OffsetBatch {
    * Attempts to commit and retries according to the given policy when the commit fails
    * with a RetriableCommitFailedException
    */
-  def commitOrRetry[R](policy: Schedule[R, Throwable, Any]): ZIO[R with Clock, Throwable, Unit] =
+  def commitOrRetry[R](policy: Schedule[R, Throwable, Any]): RIO[R with Clock, Unit] =
     Offset.commitOrRetry(commit, policy)
 }
 
@@ -30,13 +30,13 @@ private final case class OffsetBatchImpl(
 ) extends OffsetBatch {
   def commit: Task[Unit] = commitHandle(offsets)
 
-  def merge(offset: Offset) =
+  def merge(offset: Offset): OffsetBatch =
     copy(
       offsets = offsets + (offset.topicPartition -> (offsets
         .getOrElse(offset.topicPartition, -1L) max offset.offset))
     )
 
-  def merge(otherOffsets: OffsetBatch) = {
+  def merge(otherOffsets: OffsetBatch): OffsetBatch = {
     val newOffsets = Map.newBuilder[TopicPartition, Long]
     newOffsets ++= offsets
     otherOffsets.offsets.foreach {
@@ -52,7 +52,7 @@ private final case class OffsetBatchImpl(
 
 case object EmptyOffsetBatch extends OffsetBatch {
   val offsets: Map[TopicPartition, Long]       = Map()
-  val commit                                   = Task.unit
+  val commit: Task[Unit]                       = Task.unit
   def merge(offset: Offset): OffsetBatch       = offset.batch
   def merge(offsets: OffsetBatch): OffsetBatch = offsets
 }

--- a/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -40,14 +40,12 @@ private[consumer] object ConsumerAccess {
     for {
       access   <- Semaphore.make(1).toManaged_
       blocking <- ZManaged.service[Blocking.Service]
-      consumer <- blocking.blocking {
-                   ZIO {
-                     new KafkaConsumer[Array[Byte], Array[Byte]](
-                       settings.driverSettings.asJava,
-                       new ByteArrayDeserializer(),
-                       new ByteArrayDeserializer()
-                     )
-                   }
+      consumer <- blocking.effectBlocking {
+                   new KafkaConsumer[Array[Byte], Array[Byte]](
+                     settings.driverSettings.asJava,
+                     new ByteArrayDeserializer(),
+                     new ByteArrayDeserializer()
+                   )
                  }.toManaged(c => blocking.blocking(access.withPermit(UIO(c.close(settings.closeTimeout)))))
     } yield new ConsumerAccess(consumer, access, blocking)
 }

--- a/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -18,12 +18,12 @@ private[consumer] class ConsumerAccess(
   def withConsumer[A](f: ByteArrayKafkaConsumer => A): Task[A] =
     withConsumerM[Any, A](c => ZIO(f(c)))
 
-  def withConsumerM[R, A](f: ByteArrayKafkaConsumer => ZIO[R, Throwable, A]): ZIO[R, Throwable, A] =
+  def withConsumerM[R, A](f: ByteArrayKafkaConsumer => RIO[R, A]): RIO[R, A] =
     access.withPermit(withConsumerNoPermit(f))
 
   private[consumer] def withConsumerNoPermit[R, A](
-    f: ByteArrayKafkaConsumer => ZIO[R, Throwable, A]
-  ): ZIO[R, Throwable, A] =
+    f: ByteArrayKafkaConsumer => RIO[R, A]
+  ): RIO[R, A] =
     blocking
       .blocking(ZIO.effectSuspend(f(consumer)))
       .catchSome {
@@ -36,7 +36,7 @@ private[consumer] class ConsumerAccess(
 private[consumer] object ConsumerAccess {
   type ByteArrayKafkaConsumer = KafkaConsumer[Array[Byte], Array[Byte]]
 
-  def make(settings: ConsumerSettings) =
+  def make(settings: ConsumerSettings): RManaged[Blocking, ConsumerAccess] =
     for {
       access   <- Semaphore.make(1).toManaged_
       blocking <- ZManaged.service[Blocking.Service]

--- a/src/main/scala/zio/kafka/consumer/internal/RequestBuffer.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/RequestBuffer.scala
@@ -1,7 +1,7 @@
 package zio.kafka.consumer.internal
 
 import zio._
-import zio.stream.ZStream
+import zio.stream.{ UStream, ZStream }
 
 /**
  * A queue-like construct for buffering requests. Allows to take all of the
@@ -32,7 +32,7 @@ private[internal] class RequestBuffer(ref: Ref[RequestBuffer.State]) {
       }
       .flatten
 
-  def stream: ZStream[Any, Nothing, List[Runloop.Request]] =
+  def stream: UStream[List[Runloop.Request]] =
     ZStream.repeatEffectOption {
       takeAll.catchAllCause(cause => if (cause.interrupted) ZIO.fail(None) else ZIO.halt(cause))
     }

--- a/src/main/scala/zio/kafka/consumer/internal/RequestBuffer.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/RequestBuffer.scala
@@ -16,11 +16,11 @@ private[internal] class RequestBuffer(ref: Ref[RequestBuffer.State]) {
   def offer(request: Runloop.Request): UIO[Any] =
     ref.modify {
       case Shutdown      => ZIO.interrupt      -> Shutdown
-      case Empty(notify) => notify.succeed(()) -> Filled(List(request))
-      case Filled(items) => UIO.unit           -> Filled(request :: items)
+      case Empty(notify) => notify.succeed(()) -> Filled(Chunk(request))
+      case Filled(items) => UIO.unit           -> Filled(request +: items)
     }.flatten
 
-  def takeAll: UIO[List[Runloop.Request]] =
+  def takeAll: UIO[Chunk[Runloop.Request]] =
     Promise
       .make[Nothing, Unit]
       .flatMap { p =>
@@ -32,7 +32,7 @@ private[internal] class RequestBuffer(ref: Ref[RequestBuffer.State]) {
       }
       .flatten
 
-  def stream: UStream[List[Runloop.Request]] =
+  def stream: UStream[Chunk[Runloop.Request]] =
     ZStream.repeatEffectOption {
       takeAll.catchAllCause(cause => if (cause.interrupted) ZIO.fail(None) else ZIO.halt(cause))
     }
@@ -46,7 +46,7 @@ private[internal] object RequestBuffer {
   object State {
     case object Shutdown                                 extends State
     case class Empty(notifyFill: Promise[Nothing, Unit]) extends State
-    case class Filled(items: List[Runloop.Request])      extends State
+    case class Filled(items: Chunk[Runloop.Request])     extends State
   }
 
   def make: UIO[RequestBuffer] =

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -148,10 +148,10 @@ private[consumer] final class Runloop(
       if (revoked(req.tp)) {
         revokeAction = revokeAction *> req.cont.fail(None)
         buf -= req.tp
-      } else acc +:= req
+      } else acc :+= req
     }
 
-    revokeAction.as((acc.reverse, buf.toMap))
+    revokeAction.as((acc, buf.toMap))
   }
 
   /**

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -277,7 +277,7 @@ private[consumer] final class Runloop(
                        // Check shutdown again after polling (which takes up to the poll timeout)
                        isShutdown.flatMap { shutdown =>
                          if (shutdown) {
-                           pauseAllPartitions(c) *> ZIO.succeed(
+                           pauseAllPartitions(c).as(
                              (Set(), (state.pendingRequests, Map[TopicPartition, Chunk[ByteArrayConsumerRecord]]()))
                            )
                          } else if (records eq null) {

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -126,8 +126,8 @@ private[consumer] final class Runloop(
 
   /**
    * Does all needed to end revoked partitions:
-   * 1. Fail the Requests's continuation promises
-   * 2. Remove from the list of pending requets
+   * 1. Fail the Requests' continuation promises
+   * 2. Remove from the list of pending requests
    * 3. Remove from buffered records
    * @return New pending requests and new buffered records
    */

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -221,7 +221,7 @@ private[consumer] final class Runloop(
     offsetRetrieval match {
       case OffsetRetrieval.Manual(getOffsets) =>
         getOffsets(tps)
-          .flatMap(offsets => ZIO.foreach_(offsets) { case (tp, offset) => ZIO(c.seek(tp, offset)) })
+          .tap(offsets => ZIO.foreach_(offsets) { case (tp, offset) => ZIO(c.seek(tp, offset)) })
           .when(tps.nonEmpty)
 
       case OffsetRetrieval.Auto(_) =>

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -258,8 +258,8 @@ private[consumer] final class Runloop(
     }
 
   private def pauseAllPartitions(c: ByteArrayKafkaConsumer) = ZIO.effectTotal {
-    val currentAssigned = c.assignment().asScala.toSet
-    c.pause(currentAssigned.asJava)
+    val currentAssigned = c.assignment()
+    c.pause(currentAssigned)
   }
 
   private def handlePoll(state: State): RIO[Blocking, State] =

--- a/src/main/scala/zio/kafka/producer/package.scala
+++ b/src/main/scala/zio/kafka/producer/package.scala
@@ -195,9 +195,9 @@ package object producer {
       private[producer] def close: UIO[Unit] = UIO(p.close(producerSettings.closeTimeout))
     }
 
-    def live[R: Tag, K: Tag, V: Tag]: ZLayer[Has[Serializer[R, K]] with Has[Serializer[R, V]] with Has[
+    def live[R: Tag, K: Tag, V: Tag]: RLayer[Has[Serializer[R, K]] with Has[Serializer[R, V]] with Has[
       ProducerSettings
-    ] with Blocking, Throwable, Producer[R, K, V]] =
+    ] with Blocking, Producer[R, K, V]] =
       (for {
         keySerializer   <- ZManaged.service[Serializer[R, K]]
         valueSerializer <- ZManaged.service[Serializer[R, V]]
@@ -209,7 +209,7 @@ package object producer {
       settings: ProducerSettings,
       keySerializer: Serializer[R, K],
       valueSerializer: Serializer[R, V]
-    ): ZManaged[Blocking, Throwable, Service[R, K, V]] =
+    ): RManaged[Blocking, Service[R, K, V]] =
       (for {
         props    <- ZIO.effect(settings.driverSettings)
         _        <- keySerializer.configure(props, isKey = true)
@@ -295,13 +295,13 @@ package object producer {
     /**
      * Accessor method for [[Service.flush]]
      */
-    def flush[R: Tag, K: Tag, V: Tag]: ZIO[R with Producer[R, K, V], Throwable, Unit] =
+    def flush[R: Tag, K: Tag, V: Tag]: RIO[R with Producer[R, K, V], Unit] =
       withProducerService(_.flush)
 
     /**
      * Accessor method for [[Service.metrics]]
      */
-    def metrics[R: Tag, K: Tag, V: Tag]: ZIO[R with Producer[R, K, V], Throwable, Map[MetricName, Metric]] =
+    def metrics[R: Tag, K: Tag, V: Tag]: RIO[R with Producer[R, K, V], Map[MetricName, Metric]] =
       withProducerService(_.metrics)
   }
 }


### PR DESCRIPTION
Merely aesthetic changes without modifying current logic: usage of `ifM` instead of plain `if/else`, internals of `List` removed in favor of `Chunk`, public return type and concrete ZIO aliases, and so.

When changing to use `Chunk` I decided to use it the same way as `List` was being used, like prepending elements to the colletion. But I don't know if it's worth to change the prepend strategy for append. I don't know which one is faster for `Chunk`, but looking at the code I believe either would work correctly.

For example, this code:

```scala
    while (reqsIt.hasNext) {
      val req = reqsIt.next
      if (revoked(req.tp)) {
        revokeAction = revokeAction *> req.cont.fail(None)
        buf -= req.tp
      } else acc :+= req
    }

    revokeAction.as((acc.reverse, buf.toMap))
```

can be simplified to:

```scala
    while (reqsIt.hasNext) {
      val req = reqsIt.next
      if (revoked(req.tp)) {
        revokeAction = revokeAction *> req.cont.fail(None)
        buf -= req.tp
      } else acc +:= req
    }

    revokeAction.as((acc, buf.toMap))
```

but only if append is better than prepend, thus we can save this `reverse` call.

Similarly, this:

```scala
def addCommit(c: Command.Commit)           = copy(pendingCommits = c +: pendingCommits)
def addRequest(c: Runloop.Request)         = copy(pendingRequests = c +: pendingRequests)
def addRequests(c: Chunk[Runloop.Request]) = copy(pendingRequests = c ++ pendingRequests)
```

stores elements in LIFO order, which I guess doesn't matter but can be changed to FIFO:

```scala
def addCommit(c: Command.Commit)           = copy(pendingCommits = pendingCommits :+ c)
def addRequest(c: Runloop.Request)         = copy(pendingRequests = pendingRequests :+ c)
def addRequests(c: Chunk[Runloop.Request]) = copy(pendingRequests = pendingRequests ++ c)
```

if more performant.

Another topic that I want to discuss is the removal of `List` from public API (`Consumer`, `AdminClient` and `Producer`). I haven't changed anything in this respect, to be backwards compatible, but I don't know if you want to refactor that too.

Finally, I have another branch for removing the internal `RequestBuffer` with a plain `Queue` that maps `Chunks`, but I don't want to create a PR until this is merged, because all `Chunk` references are here.