### PR TITLE
Removes Blocking environment requirement on most service methods

### DIFF
--- a/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.common.{
   TopicPartitionInfo => JTopicPartitionInfo
 }
 import zio._
-import zio.blocking.{ blocking, Blocking }
+import zio.blocking.Blocking
 import zio.duration.Duration
 
 import scala.collection.compat._

--- a/src/main/scala/zio/kafka/consumer/SubscribedConsumer.scala
+++ b/src/main/scala/zio/kafka/consumer/SubscribedConsumer.scala
@@ -2,7 +2,6 @@ package zio.kafka.consumer
 
 import org.apache.kafka.common.TopicPartition
 import zio.{ RIO, Task }
-import zio.clock.Clock
 import zio.stream.{ Stream, ZStream }
 import zio.kafka.serde.Deserializer
 

--- a/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -10,19 +10,27 @@ import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
 
 import scala.jdk.CollectionConverters._
 
-private[consumer] class ConsumerAccess(private[consumer] val consumer: ByteArrayKafkaConsumer, access: Semaphore) {
-  def withConsumer[A](f: ByteArrayKafkaConsumer => A): RIO[Blocking, A] =
+private[consumer] class ConsumerAccess(
+  private[consumer] val consumer: ByteArrayKafkaConsumer,
+  access: Semaphore,
+  blocking: Blocking.Service
+) {
+  def withConsumer[A](f: ByteArrayKafkaConsumer => A): Task[A] =
     withConsumerM[Any, A](c => ZIO(f(c)))
 
-  def withConsumerM[R, A](f: ByteArrayKafkaConsumer => ZIO[R, Throwable, A]): ZIO[R with Blocking, Throwable, A] =
+  def withConsumerM[R, A](f: ByteArrayKafkaConsumer => ZIO[R, Throwable, A]): ZIO[R, Throwable, A] =
     access.withPermit(withConsumerNoPermit(f))
 
   private[consumer] def withConsumerNoPermit[R, A](
     f: ByteArrayKafkaConsumer => ZIO[R, Throwable, A]
-  ): ZIO[R with Blocking, Throwable, A] =
-    blocking(ZIO.effectSuspend(f(consumer))).catchSome {
-      case _: WakeupException => ZIO.interrupt
-    }.fork.flatMap(fib => fib.join.onInterrupt(ZIO.effectTotal(consumer.wakeup()) *> fib.interrupt))
+  ): ZIO[R, Throwable, A] =
+    blocking
+      .blocking(ZIO.effectSuspend(f(consumer)))
+      .catchSome {
+        case _: WakeupException => ZIO.interrupt
+      }
+      .fork
+      .flatMap(fib => fib.join.onInterrupt(ZIO.effectTotal(consumer.wakeup()) *> fib.interrupt))
 }
 
 private[consumer] object ConsumerAccess {
@@ -30,8 +38,9 @@ private[consumer] object ConsumerAccess {
 
   def make(settings: ConsumerSettings) =
     for {
-      access <- Semaphore.make(1).toManaged_
-      consumer <- blocking {
+      access   <- Semaphore.make(1).toManaged_
+      blocking <- ZManaged.service[Blocking.Service]
+      consumer <- blocking.blocking {
                    ZIO {
                      new KafkaConsumer[Array[Byte], Array[Byte]](
                        settings.driverSettings.asJava,
@@ -39,6 +48,6 @@ private[consumer] object ConsumerAccess {
                        new ByteArrayDeserializer()
                      )
                    }
-                 }.toManaged(c => blocking(access.withPermit(UIO(c.close(settings.closeTimeout)))))
-    } yield new ConsumerAccess(consumer, access)
+                 }.toManaged(c => blocking.blocking(access.withPermit(UIO(c.close(settings.closeTimeout)))))
+    } yield new ConsumerAccess(consumer, access, blocking)
 }

--- a/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -4,7 +4,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.errors.WakeupException
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import zio._
-import zio.blocking.{ blocking, Blocking }
+import zio.blocking.Blocking
 import zio.kafka.consumer.ConsumerSettings
 import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
 

--- a/src/main/scala/zio/kafka/consumer/package.scala
+++ b/src/main/scala/zio/kafka/consumer/package.scala
@@ -320,9 +320,9 @@ package object consumer {
                   )
       } yield Live(wrapper, settings, runloop)
 
-    def withConsumerService[R, A](
-      r: Service => RIO[R, A]
-    ): RIO[R with Consumer, A] =
+    def withConsumerService[A](
+      r: Service => Task[A]
+    ): RIO[Consumer, A] =
       ZIO.accessM(env => r(env.get[Service]))
 
     /**

--- a/src/main/scala/zio/kafka/consumer/package.scala
+++ b/src/main/scala/zio/kafka/consumer/package.scala
@@ -25,12 +25,12 @@ package object consumer {
        *
        * This is subject to consumer rebalancing, unless using a manual subscription.
        */
-      def assignment: RIO[Blocking, Set[TopicPartition]]
+      def assignment: Task[Set[TopicPartition]]
 
       def beginningOffsets(
         partitions: Set[TopicPartition],
         timeout: Duration = Duration.Infinity
-      ): RIO[Blocking, Map[TopicPartition, Long]]
+      ): Task[Map[TopicPartition, Long]]
 
       /**
        * Retrieve the last committed offset for the given topic-partitions
@@ -38,14 +38,14 @@ package object consumer {
       def committed(
         partitions: Set[TopicPartition],
         timeout: Duration = Duration.Infinity
-      ): RIO[Blocking, Map[TopicPartition, Option[OffsetAndMetadata]]]
+      ): Task[Map[TopicPartition, Option[OffsetAndMetadata]]]
 
       def endOffsets(
         partitions: Set[TopicPartition],
         timeout: Duration = Duration.Infinity
-      ): RIO[Blocking, Map[TopicPartition, Long]]
+      ): Task[Map[TopicPartition, Long]]
 
-      def listTopics(timeout: Duration = Duration.Infinity): RIO[Blocking, Map[String, List[PartitionInfo]]]
+      def listTopics(timeout: Duration = Duration.Infinity): Task[Map[String, List[PartitionInfo]]]
 
       /**
        * Create a stream with messages on the subscribed topic-partitions by topic-partition
@@ -61,7 +61,7 @@ package object consumer {
         keyDeserializer: Deserializer[R, K],
         valueDeserializer: Deserializer[R, V]
       ): ZStream[
-        Clock with Blocking,
+        Clock,
         Throwable,
         (TopicPartition, ZStream[R, Throwable, CommittableRecord[K, V]])
       ]
@@ -80,7 +80,7 @@ package object consumer {
         keyDeserializer: Deserializer[R, K],
         valueDeserializer: Deserializer[R, V],
         outputBuffer: Int = 4
-      ): ZStream[R with Clock with Blocking, Throwable, CommittableRecord[K, V]]
+      ): ZStream[R with Clock, Throwable, CommittableRecord[K, V]]
 
       /**
        * Stops consumption of data, drains buffered records, and ends the attached
@@ -98,11 +98,11 @@ package object consumer {
         commitRetryPolicy: Schedule[Clock, Any, Any] = Schedule.exponential(1.second) && Schedule.recurs(3)
       )(
         f: (K, V) => URIO[RC, Unit]
-      ): ZIO[R with RC with Blocking with Clock, Throwable, Unit]
+      ): ZIO[R with RC with Clock, Throwable, Unit]
 
-      def subscribe(subscription: Subscription): RIO[Blocking, Unit]
+      def subscribe(subscription: Subscription): Task[Unit]
 
-      def unsubscribe: RIO[Blocking, Unit]
+      def unsubscribe: Task[Unit]
 
       /**
        * Look up the offsets for the given partitions by timestamp. The returned offset for each partition is the
@@ -114,20 +114,20 @@ package object consumer {
       def offsetsForTimes(
         timestamps: Map[TopicPartition, Long],
         timeout: Duration = Duration.Infinity
-      ): RIO[Blocking, Map[TopicPartition, OffsetAndTimestamp]]
+      ): Task[Map[TopicPartition, OffsetAndTimestamp]]
 
-      def partitionsFor(topic: String, timeout: Duration = Duration.Infinity): RIO[Blocking, List[PartitionInfo]]
+      def partitionsFor(topic: String, timeout: Duration = Duration.Infinity): Task[List[PartitionInfo]]
 
-      def position(partition: TopicPartition, timeout: Duration = Duration.Infinity): RIO[Blocking, Long]
+      def position(partition: TopicPartition, timeout: Duration = Duration.Infinity): Task[Long]
 
       def subscribeAnd(subscription: Subscription): SubscribedConsumer
 
-      def subscription: RIO[Blocking, Set[String]]
+      def subscription: Task[Set[String]]
 
       /**
        * Expose internal consumer metrics
        */
-      def metrics: RIO[Blocking, Map[MetricName, Metric]]
+      def metrics: Task[Map[MetricName, Metric]]
     }
 
     final case class Live(
@@ -136,13 +136,13 @@ package object consumer {
       private val runloop: Runloop
     ) extends Service {
 
-      override def assignment: RIO[Blocking, Set[TopicPartition]] =
+      override def assignment: Task[Set[TopicPartition]] =
         consumer.withConsumer(_.assignment().asScala.toSet)
 
       override def beginningOffsets(
         partitions: Set[TopicPartition],
         timeout: Duration = Duration.Infinity
-      ): RIO[Blocking, Map[TopicPartition, Long]] =
+      ): Task[Map[TopicPartition, Long]] =
         consumer.withConsumer(
           _.beginningOffsets(partitions.asJava, timeout.asJava).asScala.view.mapValues(_.longValue()).toMap
         )
@@ -150,7 +150,7 @@ package object consumer {
       override def committed(
         partitions: Set[TopicPartition],
         timeout: Duration = Duration.Infinity
-      ): RIO[Blocking, Map[TopicPartition, Option[OffsetAndMetadata]]] =
+      ): Task[Map[TopicPartition, Option[OffsetAndMetadata]]] =
         consumer.withConsumer(
           _.committed(partitions.asJava, timeout.asJava).asScala.toMap.view.mapValues(Option.apply).toMap
         )
@@ -158,7 +158,7 @@ package object consumer {
       override def endOffsets(
         partitions: Set[TopicPartition],
         timeout: Duration = Duration.Infinity
-      ): RIO[Blocking, Map[TopicPartition, Long]] =
+      ): Task[Map[TopicPartition, Long]] =
         consumer.withConsumer { eo =>
           val offs = eo.endOffsets(partitions.asJava, timeout.asJava)
           offs.asScala.view.mapValues(_.longValue()).toMap
@@ -171,13 +171,13 @@ package object consumer {
       override def stopConsumption: UIO[Unit] =
         runloop.gracefulShutdown
 
-      override def listTopics(timeout: Duration = Duration.Infinity): RIO[Blocking, Map[String, List[PartitionInfo]]] =
+      override def listTopics(timeout: Duration = Duration.Infinity): Task[Map[String, List[PartitionInfo]]] =
         consumer.withConsumer(_.listTopics(timeout.asJava).asScala.view.mapValues(_.asScala.toList).toMap)
 
       override def offsetsForTimes(
         timestamps: Map[TopicPartition, Long],
         timeout: Duration = Duration.Infinity
-      ): RIO[Blocking, Map[TopicPartition, OffsetAndTimestamp]] =
+      ): Task[Map[TopicPartition, OffsetAndTimestamp]] =
         consumer.withConsumer(
           _.offsetsForTimes(timestamps.view.mapValues(Long.box).toMap.asJava, timeout.asJava).asScala.toMap
           // If a partition doesn't exist yet, the map will have 'null' as entry.
@@ -189,7 +189,7 @@ package object consumer {
         keyDeserializer: Deserializer[R, K],
         valueDeserializer: Deserializer[R, V]
       ): ZStream[
-        Clock with Blocking,
+        Clock,
         Throwable,
         (TopicPartition, ZStream[R, Throwable, CommittableRecord[K, V]])
       ] = {
@@ -216,20 +216,20 @@ package object consumer {
       override def partitionsFor(
         topic: String,
         timeout: Duration = Duration.Infinity
-      ): RIO[Blocking, List[PartitionInfo]] =
+      ): Task[List[PartitionInfo]] =
         consumer.withConsumer { c =>
           val partitions = c.partitionsFor(topic, timeout.asJava)
           if (partitions eq null) List.empty else partitions.asScala.toList
         }
 
-      override def position(partition: TopicPartition, timeout: Duration = Duration.Infinity): RIO[Blocking, Long] =
+      override def position(partition: TopicPartition, timeout: Duration = Duration.Infinity): Task[Long] =
         consumer.withConsumer(_.position(partition, timeout.asJava))
 
       override def plainStream[R, K, V](
         keyDeserializer: Deserializer[R, K],
         valueDeserializer: Deserializer[R, V],
         outputBuffer: Int
-      ): ZStream[R with Clock with Blocking, Throwable, CommittableRecord[K, V]] =
+      ): ZStream[R with Clock, Throwable, CommittableRecord[K, V]] =
         partitionedStream(keyDeserializer, valueDeserializer).flatMapPar(n = Int.MaxValue, outputBuffer = outputBuffer)(
           _._2
         )
@@ -237,7 +237,7 @@ package object consumer {
       override def subscribeAnd(subscription: Subscription): SubscribedConsumer =
         new SubscribedConsumer(subscribe(subscription).as(this))
 
-      override def subscription: RIO[Blocking, Set[String]] =
+      override def subscription: Task[Set[String]] =
         consumer.withConsumer(_.subscription().asScala.toSet)
 
       override def consumeWith[R, RC, K, V](
@@ -247,7 +247,7 @@ package object consumer {
         commitRetryPolicy: Schedule[Clock, Any, Any] = Schedule.exponential(1.second) && Schedule.recurs(3)
       )(
         f: (K, V) => URIO[RC, Unit]
-      ): ZIO[R with RC with Blocking with Clock, Throwable, Unit] =
+      ): ZIO[R with RC with Clock, Throwable, Unit] =
         ZStream
           .fromEffect(subscribe(subscription))
           .flatMap { _ =>
@@ -264,7 +264,7 @@ package object consumer {
           .mapM(_.commitOrRetry(commitRetryPolicy))
           .runDrain
 
-      override def subscribe(subscription: Subscription): RIO[Blocking, Unit] =
+      override def subscribe(subscription: Subscription): Task[Unit] =
         ZIO.runtime[Any].flatMap { runtime =>
           consumer.withConsumerM { c =>
             subscription match {
@@ -289,10 +289,10 @@ package object consumer {
           }
         }
 
-      override def unsubscribe: RIO[Blocking, Unit] =
+      override def unsubscribe: Task[Unit] =
         consumer.withConsumer(_.unsubscribe())
 
-      override def metrics: RIO[Blocking, Map[MetricName, Metric]] =
+      override def metrics: Task[Map[MetricName, Metric]] =
         consumer.withConsumer(_.metrics().asScala.toMap)
     }
 
@@ -320,14 +320,14 @@ package object consumer {
       } yield Live(wrapper, settings, runloop)
 
     def withConsumerService[R, A](
-      r: Service => RIO[R with Blocking, A]
-    ): RIO[R with Blocking with Consumer, A] =
+      r: Service => RIO[R, A]
+    ): RIO[R with Consumer, A] =
       ZIO.accessM(env => r(env.get[Service]))
 
     /**
      * Accessor method for [[Service.assignment]]
      */
-    def assignment: RIO[Blocking with Consumer, Set[TopicPartition]] =
+    def assignment: RIO[Consumer, Set[TopicPartition]] =
       withConsumerService(_.assignment)
 
     /**
@@ -336,7 +336,7 @@ package object consumer {
     def beginningOffsets(
       partitions: Set[TopicPartition],
       timeout: Duration = Duration.Infinity
-    ): RIO[Blocking with Consumer, Map[TopicPartition, Long]] =
+    ): RIO[Consumer, Map[TopicPartition, Long]] =
       withConsumerService(_.beginningOffsets(partitions, timeout))
 
     /**
@@ -452,13 +452,13 @@ package object consumer {
     /**
      * Accessor method for [[Service.subscribe]]
      */
-    def subscribe(subscription: Subscription): RIO[Blocking with Consumer, Unit] =
+    def subscribe(subscription: Subscription): RIO[Consumer, Unit] =
       withConsumerService(_.subscribe(subscription))
 
     /**
      * Accessor method for [[Service.unsubscribe]]
      */
-    def unsubscribe: RIO[Blocking with Consumer, Unit] =
+    def unsubscribe: RIO[Consumer, Unit] =
       withConsumerService(_.unsubscribe)
 
     /**
@@ -467,7 +467,7 @@ package object consumer {
     def offsetsForTimes(
       timestamps: Map[TopicPartition, Long],
       timeout: Duration = Duration.Infinity
-    ): RIO[Blocking with Consumer, Map[TopicPartition, OffsetAndTimestamp]] =
+    ): RIO[Consumer, Map[TopicPartition, OffsetAndTimestamp]] =
       withConsumerService(_.offsetsForTimes(timestamps, timeout))
 
     /**
@@ -476,7 +476,7 @@ package object consumer {
     def partitionsFor(
       topic: String,
       timeout: Duration = Duration.Infinity
-    ): RIO[Blocking with Consumer, List[PartitionInfo]] =
+    ): RIO[Consumer, List[PartitionInfo]] =
       withConsumerService(_.partitionsFor(topic, timeout))
 
     /**
@@ -485,7 +485,7 @@ package object consumer {
     def position(
       partition: TopicPartition,
       timeout: Duration = Duration.Infinity
-    ): RIO[Blocking with Consumer, Long] =
+    ): RIO[Consumer, Long] =
       withConsumerService(_.position(partition, timeout))
 
     /**
@@ -504,13 +504,13 @@ package object consumer {
     /**
      * Accessor method for [[Service.subscription]]
      */
-    def subscription: RIO[Blocking with Consumer, Set[String]] =
+    def subscription: RIO[Consumer, Set[String]] =
       withConsumerService(_.subscription)
 
     /**
      * Accessor method for [[Service.metrics]]
      */
-    def metrics: RIO[Blocking with Consumer, Map[MetricName, Metric]] =
+    def metrics: RIO[Consumer, Map[MetricName, Metric]] =
       withConsumerService(_.metrics)
 
     sealed trait OffsetRetrieval

--- a/src/main/scala/zio/kafka/consumer/package.scala
+++ b/src/main/scala/zio/kafka/consumer/package.scala
@@ -60,8 +60,7 @@ package object consumer {
       def partitionedStream[R, K, V](
         keyDeserializer: Deserializer[R, K],
         valueDeserializer: Deserializer[R, V]
-      ): ZStream[
-        Clock,
+      ): Stream[
         Throwable,
         (TopicPartition, ZStream[R, Throwable, CommittableRecord[K, V]])
       ]
@@ -80,7 +79,7 @@ package object consumer {
         keyDeserializer: Deserializer[R, K],
         valueDeserializer: Deserializer[R, V],
         outputBuffer: Int = 4
-      ): ZStream[R with Clock, Throwable, CommittableRecord[K, V]]
+      ): ZStream[R, Throwable, CommittableRecord[K, V]]
 
       /**
        * Stops consumption of data, drains buffered records, and ends the attached
@@ -189,7 +188,7 @@ package object consumer {
         keyDeserializer: Deserializer[R, K],
         valueDeserializer: Deserializer[R, V]
       ): ZStream[
-        Clock,
+        Any,
         Throwable,
         (TopicPartition, ZStream[R, Throwable, CommittableRecord[K, V]])
       ] = {
@@ -229,7 +228,7 @@ package object consumer {
         keyDeserializer: Deserializer[R, K],
         valueDeserializer: Deserializer[R, V],
         outputBuffer: Int
-      ): ZStream[R with Clock, Throwable, CommittableRecord[K, V]] =
+      ): ZStream[R, Throwable, CommittableRecord[K, V]] =
         partitionedStream(keyDeserializer, valueDeserializer).flatMapPar(n = Int.MaxValue, outputBuffer = outputBuffer)(
           _._2
         )
@@ -347,7 +346,7 @@ package object consumer {
     def committed(
       partitions: Set[TopicPartition],
       timeout: Duration = Duration.Infinity
-    ): RIO[Blocking with Consumer, Map[TopicPartition, Option[OffsetAndMetadata]]] =
+    ): RIO[Consumer, Map[TopicPartition, Option[OffsetAndMetadata]]] =
       withConsumerService(_.committed(partitions, timeout))
 
     /**
@@ -356,7 +355,7 @@ package object consumer {
     def endOffsets(
       partitions: Set[TopicPartition],
       timeout: Duration = Duration.Infinity
-    ): RIO[Blocking with Consumer, Map[TopicPartition, Long]] =
+    ): RIO[Consumer, Map[TopicPartition, Long]] =
       withConsumerService(_.endOffsets(partitions, timeout))
 
     /**
@@ -364,7 +363,7 @@ package object consumer {
      */
     def listTopics(
       timeout: Duration = Duration.Infinity
-    ): RIO[Blocking with Consumer, Map[String, List[PartitionInfo]]] =
+    ): RIO[Consumer, Map[String, List[PartitionInfo]]] =
       withConsumerService(_.listTopics(timeout))
 
     /**
@@ -374,7 +373,7 @@ package object consumer {
       keyDeserializer: Deserializer[R, K],
       valueDeserializer: Deserializer[R, V]
     ): ZStream[
-      Consumer with Clock with Blocking,
+      Consumer,
       Throwable,
       (TopicPartition, ZStream[R, Throwable, CommittableRecord[K, V]])
     ] =
@@ -387,7 +386,7 @@ package object consumer {
       keyDeserializer: Deserializer[R, K],
       valueDeserializer: Deserializer[R, V],
       outputBuffer: Int = 4
-    ): ZStream[R with Consumer with Clock with Blocking, Throwable, CommittableRecord[K, V]] =
+    ): ZStream[R with Consumer, Throwable, CommittableRecord[K, V]] =
       ZStream.accessStream(_.get[Service].plainStream(keyDeserializer, valueDeserializer, outputBuffer))
 
     /**

--- a/src/test/scala/zio/kafka/ConsumerSpec.scala
+++ b/src/test/scala/zio/kafka/ConsumerSpec.scala
@@ -2,7 +2,7 @@ package zio.kafka.consumer
 
 import net.manub.embeddedkafka.EmbeddedKafka
 import org.apache.kafka.common.TopicPartition
-import zio.{ Promise, Ref, Task, ZIO }
+import zio.{ Chunk, Promise, Ref, Task, ZIO, ZLayer }
 import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.duration._
@@ -17,7 +17,6 @@ import zio.test.TestAspect._
 import zio.test.environment._
 import zio.test.{ DefaultRunnableSpec, _ }
 import zio.stream.ZTransducer
-import zio.Chunk
 
 object ConsumerSpec extends DefaultRunnableSpec {
   override def spec: ZSpec[TestEnvironment, Throwable] =
@@ -482,6 +481,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
         } yield assert(partitions)(isEmpty)
       }
     ).provideSomeLayerShared[TestEnvironment](
-      ((Kafka.embedded >>> stringProducer) ++ Kafka.embedded).mapError(TestFailure.fail) ++ Clock.live
+      ((Kafka.embedded ++ ZLayer.identity[Blocking] >>> stringProducer) ++ Kafka.embedded)
+        .mapError(TestFailure.fail) ++ Clock.live
     ) @@ timeout(180.seconds)
 }

--- a/src/test/scala/zio/kafka/KafkaTestUtils.scala
+++ b/src/test/scala/zio/kafka/KafkaTestUtils.scala
@@ -22,8 +22,9 @@ object KafkaTestUtils {
   val producerSettings: ZIO[Kafka, Nothing, ProducerSettings] =
     ZIO.access[Kafka](_.get[Kafka.Service].bootstrapServers).map(ProducerSettings(_))
 
-  val stringProducer: ZLayer[Kafka, Throwable, StringProducer] =
-    (ZLayer.fromEffect(producerSettings) ++ ZLayer.succeed(Serde.string: Serializer[Any, String])) >>>
+  val stringProducer: ZLayer[Kafka with Blocking, Throwable, StringProducer] =
+    (ZLayer.fromEffect(producerSettings) ++ ZLayer.succeed(Serde.string: Serializer[Any, String])) ++ ZLayer
+      .identity[Blocking] >>>
       Producer.live[Any, String, String]
 
   def produceOne(

--- a/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -2,6 +2,7 @@ package zio.kafka.producer
 
 import org.apache.kafka.clients.producer.ProducerRecord
 import zio._
+import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.kafka.KafkaTestUtils._
 import zio.kafka.consumer.{ Consumer, ConsumerSettings, Subscription }
@@ -67,6 +68,7 @@ object ProducerSpec extends DefaultRunnableSpec {
         } yield assert(metrics)(isNonEmpty)
       }
     ).provideSomeLayerShared[TestEnvironment](
-      ((Kafka.embedded >>> stringProducer) ++ Kafka.embedded).mapError(TestFailure.fail) ++ Clock.live
+      ((Kafka.embedded ++ ZLayer.identity[Blocking] >>> stringProducer) ++ Kafka.embedded)
+        .mapError(TestFailure.fail) ++ Clock.live
     )
 }


### PR DESCRIPTION
Since the use of `Blocking` is related to the underlying implementation, I've removed it from the environment on most methods and added it to the `ZLayer` and `ZManaged` definitions.

There were also a few cases where there was a `Clock` requirement that wasn't necessary (probably refactoring leftovers), I removed those as well.