### PR TITLE
Make `consumer` available to OffsetRetrieval.Manual's getOffsets.

### DIFF
--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -222,7 +222,7 @@ private[consumer] final class Runloop(
   private def doSeekForNewPartitions(c: ByteArrayKafkaConsumer, tps: Set[TopicPartition]): Task[Unit] =
     offsetRetrieval match {
       case OffsetRetrieval.Manual(getOffsets) =>
-        getOffsets(tps)
+        getOffsets(tps, consumer)
           .tap(offsets => ZIO.foreach_(offsets) { case (tp, offset) => ZIO(c.seek(tp, offset)) })
           .when(tps.nonEmpty)
 

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -8,7 +8,7 @@ import zio._
 import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.duration._
-import zio.kafka.consumer.Consumer.OffsetRetrieval
+import zio.kafka.consumer.Consumer.{ ConsumerForAdminAccess, OffsetRetrieval }
 import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
 import zio.kafka.consumer.CommittableRecord
 import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
@@ -222,7 +222,7 @@ private[consumer] final class Runloop(
   private def doSeekForNewPartitions(c: ByteArrayKafkaConsumer, tps: Set[TopicPartition]): Task[Unit] =
     offsetRetrieval match {
       case OffsetRetrieval.Manual(getOffsets) =>
-        getOffsets(tps, consumer)
+        getOffsets(tps, ConsumerForAdminAccess(consumer))
           .tap(offsets => ZIO.foreach_(offsets) { case (tp, offset) => ZIO(c.seek(tp, offset)) })
           .when(tps.nonEmpty)
 

--- a/src/test/scala/zio/kafka/ConsumerSpec.scala
+++ b/src/test/scala/zio/kafka/ConsumerSpec.scala
@@ -124,7 +124,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
           _              <- ZIO.foreach(1 to nrPartitions) { i =>
                               produceMany(topic, partition = i % nrPartitions, kvs = (0 to 9).map(j => s"key$i-$j" -> s"msg$i-$j"))
                             }
-          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
+          offsetRetrieval = OffsetRetrieval.Manual((tps, _) => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
           record         <- Consumer
                               .subscribeAnd(Subscription.manual(topic, partition = 2))
                               .plainStream(Serde.string, Serde.string)
@@ -413,7 +413,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                               .runCollect
                               .provideSomeLayer[Kafka with Blocking with Clock](consumer("group1", "client1"))
           // Start a new consumer with manual offset before the committed offset
-          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
+          offsetRetrieval = OffsetRetrieval.Manual((tps, _) => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
           secondResults  <- Consumer
                               .subscribeAnd(Subscription.topics(topic))
                               .plainStream(Serde.string, Serde.string)


### PR DESCRIPTION
Taking a crack at this.

@jypma @aartigao @svroonland, I added `ConsumerAccess` to the signature of `getOffsets` in `OffsetRetrieval.Manual`, as in:
`getOffsets: (Set[TopicPartition], ConsumerAccess) => Task[Map[TopicPartition, Long]]`

A couple of concerns:
1. I'm not sure if it's kosher to expose `consumer` to userland.
2. Users would probably have to duplicate the implementations such as `endOffsets` and `offsetsForTimes` of `Consumer.Live`. It's not hard but it's inconvenient.

Please have a look at this draft and let me know your thoughts.