### PR TITLE
Transactional second draft

### DIFF
--- a/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
+++ b/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
@@ -1,8 +1,8 @@
 package zio.kafka.consumer
 
-import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, ConsumerRecord}
+import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, ConsumerRecord }
 import org.apache.kafka.common.TopicPartition
-import zio.{RIO, Task}
+import zio.{ RIO, Task }
 import zio.kafka.serde.Deserializer
 
 final case class CommittableRecord[K, V](record: ConsumerRecord[K, V], offset: Offset) {
@@ -43,6 +43,11 @@ object CommittableRecord {
   ): CommittableRecord[K, V] =
     CommittableRecord(
       record,
-      OffsetImpl(new TopicPartition(record.topic(), record.partition()), record.offset(), commitHandle, consumerGroupMetadata)
+      OffsetImpl(
+        new TopicPartition(record.topic(), record.partition()),
+        record.offset(),
+        commitHandle,
+        consumerGroupMetadata
+      )
     )
 }

--- a/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
+++ b/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
@@ -38,10 +38,11 @@ final case class CommittableRecord[K, V](record: ConsumerRecord[K, V], offset: O
 object CommittableRecord {
   def apply[K, V](
     record: ConsumerRecord[K, V],
-    commitHandle: Map[TopicPartition, Long] => Task[Unit]
+    commitHandle: Map[TopicPartition, Long] => Task[Unit],
+    consumerGroupId: String
   ): CommittableRecord[K, V] =
     CommittableRecord(
       record,
-      OffsetImpl(new TopicPartition(record.topic(), record.partition()), record.offset(), commitHandle)
+      OffsetImpl(new TopicPartition(record.topic(), record.partition()), record.offset(), commitHandle, consumerGroupId)
     )
 }

--- a/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
+++ b/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
@@ -1,8 +1,8 @@
 package zio.kafka.consumer
 
-import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, ConsumerRecord}
 import org.apache.kafka.common.TopicPartition
-import zio.{ RIO, Task }
+import zio.{RIO, Task}
 import zio.kafka.serde.Deserializer
 
 final case class CommittableRecord[K, V](record: ConsumerRecord[K, V], offset: Offset) {
@@ -39,10 +39,10 @@ object CommittableRecord {
   def apply[K, V](
     record: ConsumerRecord[K, V],
     commitHandle: Map[TopicPartition, Long] => Task[Unit],
-    consumerGroupId: String
+    consumerGroupMetadata: ConsumerGroupMetadata
   ): CommittableRecord[K, V] =
     CommittableRecord(
       record,
-      OffsetImpl(new TopicPartition(record.topic(), record.partition()), record.offset(), commitHandle, consumerGroupId)
+      OffsetImpl(new TopicPartition(record.topic(), record.partition()), record.offset(), commitHandle, consumerGroupMetadata)
     )
 }

--- a/src/main/scala/zio/kafka/consumer/Offset.scala
+++ b/src/main/scala/zio/kafka/consumer/Offset.scala
@@ -1,8 +1,8 @@
 package zio.kafka.consumer
 
-import org.apache.kafka.clients.consumer.RetriableCommitFailedException
+import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, RetriableCommitFailedException}
 import org.apache.kafka.common.TopicPartition
-import zio.{ RIO, Schedule, Task }
+import zio.{RIO, Schedule, Task}
 import zio.clock.Clock
 
 sealed trait Offset {
@@ -10,7 +10,7 @@ sealed trait Offset {
   def offset: Long
   def commit: Task[Unit]
   def batch: OffsetBatch
-  def consumerGroupId: String
+  def consumerGroupMetadata: ConsumerGroupMetadata
 
   /**
    * Attempts to commit and retries according to the given policy when the commit fails
@@ -37,8 +37,8 @@ private final case class OffsetImpl(
   topicPartition: TopicPartition,
   offset: Long,
   commitHandle: Map[TopicPartition, Long] => Task[Unit],
-  consumerGroupId: String
+  consumerGroupMetadata: ConsumerGroupMetadata
 ) extends Offset {
   def commit: Task[Unit] = commitHandle(Map(topicPartition -> offset))
-  def batch: OffsetBatch = OffsetBatchImpl(Map(topicPartition -> offset), commitHandle, consumerGroupId)
+  def batch: OffsetBatch = OffsetBatchImpl(Map(topicPartition -> offset), commitHandle, consumerGroupMetadata)
 }

--- a/src/main/scala/zio/kafka/consumer/Offset.scala
+++ b/src/main/scala/zio/kafka/consumer/Offset.scala
@@ -1,8 +1,8 @@
 package zio.kafka.consumer
 
-import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, RetriableCommitFailedException}
+import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, RetriableCommitFailedException }
 import org.apache.kafka.common.TopicPartition
-import zio.{RIO, Schedule, Task}
+import zio.{ RIO, Schedule, Task }
 import zio.clock.Clock
 
 sealed trait Offset {

--- a/src/main/scala/zio/kafka/consumer/Offset.scala
+++ b/src/main/scala/zio/kafka/consumer/Offset.scala
@@ -10,6 +10,7 @@ sealed trait Offset {
   def offset: Long
   def commit: Task[Unit]
   def batch: OffsetBatch
+  def consumerGroupId: String
 
   /**
    * Attempts to commit and retries according to the given policy when the commit fails
@@ -35,8 +36,9 @@ object Offset {
 private final case class OffsetImpl(
   topicPartition: TopicPartition,
   offset: Long,
-  commitHandle: Map[TopicPartition, Long] => Task[Unit]
+  commitHandle: Map[TopicPartition, Long] => Task[Unit],
+  consumerGroupId: String
 ) extends Offset {
   def commit: Task[Unit] = commitHandle(Map(topicPartition -> offset))
-  def batch: OffsetBatch = OffsetBatchImpl(Map(topicPartition -> offset), commitHandle)
+  def batch: OffsetBatch = OffsetBatchImpl(Map(topicPartition -> offset), commitHandle, consumerGroupId)
 }

--- a/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
+++ b/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
@@ -1,5 +1,6 @@
 package zio.kafka.consumer
 
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata
 import org.apache.kafka.common.TopicPartition
 import zio.{ RIO, Schedule, Task }
 import zio.clock.Clock
@@ -9,7 +10,7 @@ sealed trait OffsetBatch {
   def commit: Task[Unit]
   def merge(offset: Offset): OffsetBatch
   def merge(offsets: OffsetBatch): OffsetBatch
-  def consumerGroupId: String
+  def consumerGroupMetadata: ConsumerGroupMetadata
 
   /**
    * Attempts to commit and retries according to the given policy when the commit fails
@@ -28,7 +29,7 @@ object OffsetBatch {
 private final case class OffsetBatchImpl(
   offsets: Map[TopicPartition, Long],
   commitHandle: Map[TopicPartition, Long] => Task[Unit],
-  consumerGroupId: String
+  consumerGroupMetadata: ConsumerGroupMetadata
 ) extends OffsetBatch {
   def commit: Task[Unit] = commitHandle(offsets)
 
@@ -52,9 +53,9 @@ private final case class OffsetBatchImpl(
 }
 
 case object EmptyOffsetBatch extends OffsetBatch {
-  val offsets: Map[TopicPartition, Long]       = Map()
-  val commit: Task[Unit]                       = Task.unit
-  def merge(offset: Offset): OffsetBatch       = offset.batch
-  def merge(offsets: OffsetBatch): OffsetBatch = offsets
-  def consumerGroupId: String                  = ""
+  val offsets: Map[TopicPartition, Long]           = Map()
+  val commit: Task[Unit]                           = Task.unit
+  def merge(offset: Offset): OffsetBatch           = offset.batch
+  def merge(offsets: OffsetBatch): OffsetBatch     = offsets
+  def consumerGroupMetadata: ConsumerGroupMetadata = new ConsumerGroupMetadata("")
 }

--- a/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
+++ b/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
@@ -9,6 +9,7 @@ sealed trait OffsetBatch {
   def commit: Task[Unit]
   def merge(offset: Offset): OffsetBatch
   def merge(offsets: OffsetBatch): OffsetBatch
+  def consumerGroupId: String
 
   /**
    * Attempts to commit and retries according to the given policy when the commit fails
@@ -26,7 +27,8 @@ object OffsetBatch {
 
 private final case class OffsetBatchImpl(
   offsets: Map[TopicPartition, Long],
-  commitHandle: Map[TopicPartition, Long] => Task[Unit]
+  commitHandle: Map[TopicPartition, Long] => Task[Unit],
+  consumerGroupId: String
 ) extends OffsetBatch {
   def commit: Task[Unit] = commitHandle(offsets)
 
@@ -54,4 +56,5 @@ case object EmptyOffsetBatch extends OffsetBatch {
   val commit: Task[Unit]                       = Task.unit
   def merge(offset: Offset): OffsetBatch       = offset.batch
   def merge(offsets: OffsetBatch): OffsetBatch = offsets
+  def consumerGroupId: String                  = ""
 }

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -181,7 +181,7 @@ private[consumer] final class Runloop(
           )
 
         fulfillAction = fulfillAction *> req.cont.succeed(
-          concatenatedChunk.map(CommittableRecord(_, commit(_), consumer.consumer.groupMetadata().groupId()))
+          concatenatedChunk.map(CommittableRecord(_, commit(_), consumer.consumer.groupMetadata()))
         )
         buf -= req.tp
       }

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -181,7 +181,7 @@ private[consumer] final class Runloop(
           )
 
         fulfillAction = fulfillAction *> req.cont.succeed(
-          concatenatedChunk.map(CommittableRecord(_, commit(_)))
+          concatenatedChunk.map(CommittableRecord(_, commit(_), consumer.consumer.groupMetadata().groupId()))
         )
         buf -= req.tp
       }

--- a/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/src/main/scala/zio/kafka/producer/Producer.scala
@@ -130,7 +130,7 @@ trait Producer {
 
 object Producer {
 
-  private final case class Live(
+  private[producer] final case class Live(
     p: KafkaProducer[Array[Byte], Array[Byte]],
     producerSettings: ProducerSettings,
     blocking: Blocking.Service

--- a/src/main/scala/zio/kafka/producer/Transaction.scala
+++ b/src/main/scala/zio/kafka/producer/Transaction.scala
@@ -1,28 +1,42 @@
 package zio.kafka.producer
 
 import org.apache.kafka.clients.producer.{ ProducerRecord, RecordMetadata }
+import zio.kafka.consumer.{ Offset, OffsetBatch }
 import zio.kafka.producer.TransactionalProducer.UserInitiatedAbort
-import zio.{ Cause, IO, RIO, RefM, ZIO }
+import zio.{ Cause, Chunk, IO, RIO, Ref, ZIO }
 import zio.kafka.serde.Serializer
 
-final private[producer] class Transaction(
-  private val producer: Producer
+final class Transaction private[producer] (
+  private val producer: Producer,
+  private[producer] val offsetBatchRef: Ref[OffsetBatch]
 ) {
   def produce[R, K, V](
     topic: String,
     key: K,
     value: V,
     keySerializer: Serializer[R, K],
-    valueSerializer: Serializer[R, V]
+    valueSerializer: Serializer[R, V],
+    offset: Option[Offset]
   ): RIO[R, RecordMetadata] =
-    produce(new ProducerRecord[K, V](topic, key, value), keySerializer, valueSerializer)
+    produce(new ProducerRecord[K, V](topic, key, value), keySerializer, valueSerializer, offset)
 
   def produce[R, K, V](
     producerRecord: ProducerRecord[K, V],
     keySerializer: Serializer[R, K],
-    valueSerializer: Serializer[R, V]
+    valueSerializer: Serializer[R, V],
+    offset: Option[Offset]
   ): RIO[R, RecordMetadata] =
-    producer.produce[R, K, V](producerRecord, keySerializer, valueSerializer)
+    ZIO.whenCase(offset) { case Some(offset) => offsetBatchRef.update(_ merge offset) } *>
+      producer.produce[R, K, V](producerRecord, keySerializer, valueSerializer)
+
+  def produceChunk[R, K, V](
+    records: Chunk[ProducerRecord[K, V]],
+    keySerializer: Serializer[R, K],
+    valueSerializer: Serializer[R, V],
+    offset: Option[Offset]
+  ): RIO[R, Chunk[RecordMetadata]] =
+    ZIO.whenCase(offset) { case Some(offset) => offsetBatchRef.update(_ merge offset) } *>
+      producer.produceChunk[R, K, V](records, keySerializer, valueSerializer)
 
   def abort: IO[TransactionalProducer.UserInitiatedAbort.type, Nothing] =
     ZIO.haltWith(t => Cause.traced(Cause.fail(UserInitiatedAbort), t()))

--- a/src/main/scala/zio/kafka/producer/Transaction.scala
+++ b/src/main/scala/zio/kafka/producer/Transaction.scala
@@ -2,8 +2,8 @@ package zio.kafka.producer
 
 import org.apache.kafka.clients.producer.{ ProducerRecord, RecordMetadata }
 import zio.kafka.consumer.{ Offset, OffsetBatch }
-import zio.kafka.producer.TransactionalProducer.UserInitiatedAbort
-import zio.{ Cause, Chunk, IO, RIO, Ref, ZIO }
+import zio.kafka.producer.TransactionalProducer.{ TransactionLeaked, UserInitiatedAbort }
+import zio.{ Cause, Chunk, IO, RIO, Ref, UIO, ZIO }
 import zio.kafka.serde.Serializer
 
 trait Transaction {
@@ -35,7 +35,8 @@ trait Transaction {
 
 final private[producer] class TransactionImpl(
   private val producer: Producer,
-  private[producer] val offsetBatchRef: Ref[OffsetBatch]
+  private[producer] val offsetBatchRef: Ref[OffsetBatch],
+  private val closed: Ref[Boolean]
 ) extends Transaction {
   def produce[R, K, V](
     topic: String,
@@ -53,7 +54,8 @@ final private[producer] class TransactionImpl(
     valueSerializer: Serializer[R, V],
     offset: Option[Offset]
   ): RIO[R, RecordMetadata] =
-    ZIO.whenCase(offset) { case Some(offset) => offsetBatchRef.update(_ merge offset) } *>
+    haltIfClosed *>
+      ZIO.whenCase(offset) { case Some(offset) => offsetBatchRef.update(_ merge offset) } *>
       producer.produce[R, K, V](producerRecord, keySerializer, valueSerializer)
 
   def produceChunk[R, K, V](
@@ -62,9 +64,17 @@ final private[producer] class TransactionImpl(
     valueSerializer: Serializer[R, V],
     offset: Option[Offset]
   ): RIO[R, Chunk[RecordMetadata]] =
-    ZIO.whenCase(offset) { case Some(offset) => offsetBatchRef.update(_ merge offset) } *>
+    haltIfClosed *>
+      ZIO.whenCase(offset) { case Some(offset) => offsetBatchRef.update(_ merge offset) } *>
       producer.produceChunk[R, K, V](records, keySerializer, valueSerializer)
 
   def abort: IO[TransactionalProducer.UserInitiatedAbort.type, Nothing] =
-    ZIO.haltWith(t => Cause.traced(Cause.fail(UserInitiatedAbort), t()))
+    ZIO.fail(UserInitiatedAbort)
+
+  private[producer] def markAsClosed: UIO[Unit] = closed.set(true)
+
+  private def haltIfClosed: IO[TransactionLeaked, Unit] =
+    offsetBatchRef.get
+      .flatMap(offsetBatch => ZIO.fail(TransactionLeaked(offsetBatch)))
+      .whenM(closed.get)
 }

--- a/src/main/scala/zio/kafka/producer/Transaction.scala
+++ b/src/main/scala/zio/kafka/producer/Transaction.scala
@@ -3,8 +3,8 @@ package zio.kafka.producer
 import org.apache.kafka.clients.producer.{ ProducerRecord, RecordMetadata }
 import zio.kafka.consumer.{ Offset, OffsetBatch }
 import zio.kafka.producer.TransactionalProducer.{ TransactionLeaked, UserInitiatedAbort }
-import zio.{ Cause, Chunk, IO, RIO, Ref, UIO, ZIO }
 import zio.kafka.serde.Serializer
+import zio.{ Chunk, IO, RIO, Ref, UIO, ZIO }
 
 trait Transaction {
   def produce[R, K, V](

--- a/src/main/scala/zio/kafka/producer/Transaction.scala
+++ b/src/main/scala/zio/kafka/producer/Transaction.scala
@@ -1,0 +1,29 @@
+package zio.kafka.producer
+
+import org.apache.kafka.clients.producer.{ ProducerRecord, RecordMetadata }
+import zio.kafka.producer.TransactionalProducer.UserInitiatedAbort
+import zio.{ Cause, IO, RIO, RefM, ZIO }
+import zio.kafka.serde.Serializer
+
+final private[producer] class Transaction(
+  private val producer: Producer
+) {
+  def produce[R, K, V](
+    topic: String,
+    key: K,
+    value: V,
+    keySerializer: Serializer[R, K],
+    valueSerializer: Serializer[R, V]
+  ): RIO[R, RecordMetadata] =
+    produce(new ProducerRecord[K, V](topic, key, value), keySerializer, valueSerializer)
+
+  def produce[R, K, V](
+    producerRecord: ProducerRecord[K, V],
+    keySerializer: Serializer[R, K],
+    valueSerializer: Serializer[R, V]
+  ): RIO[R, RecordMetadata] =
+    producer.produce[R, K, V](producerRecord, keySerializer, valueSerializer)
+
+  def abort: IO[TransactionalProducer.UserInitiatedAbort.type, Nothing] =
+    ZIO.haltWith(t => Cause.traced(Cause.fail(UserInitiatedAbort), t()))
+}

--- a/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -6,7 +6,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer
 import zio.Cause.Fail
 import zio.blocking.Blocking
 import zio.kafka.consumer.OffsetBatch
-import zio.{Exit, Has, IO, RLayer, RManaged, Ref, Semaphore, Task, ZIO, ZManaged}
+import zio.{ Exit, Has, IO, RLayer, RManaged, Ref, Semaphore, Task, ZIO, ZManaged }
 
 import scala.jdk.CollectionConverters._
 

--- a/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -59,6 +59,6 @@ object TransactionalProducer {
                      )
       _           <- blocking.effectBlocking(rawProducer.initTransactions())
       semaphore   <- Semaphore.make(1)
-      live = Producer.Live(rawProducer, settings.producerSettings, blocking)
+      live         = Producer.Live(rawProducer, settings.producerSettings, blocking)
     } yield LiveTransactionalProducer(live, blocking, semaphore)).toManaged(_.live.close)
 }

--- a/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -1,0 +1,64 @@
+package zio.kafka.producer
+
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import zio.Cause.Fail
+import zio.blocking.{ effectBlocking, Blocking }
+import zio.{ Exit, Has, IO, RLayer, RManaged, RefM, Semaphore, Task, UIO, ZIO, ZManaged }
+
+import scala.jdk.CollectionConverters._
+
+trait TransactionalProducer {
+  def createTransaction: ZManaged[Any, Throwable, Transaction]
+}
+
+object TransactionalProducer {
+  case object UserInitiatedAbort
+
+  private case class LiveTransactionalProducer(
+    live: Producer.Live,
+    blocking: Blocking.Service,
+    semaphore: Semaphore
+  ) extends TransactionalProducer {
+    val abortTransaction: Task[Unit]  = blocking.effectBlocking(live.p.abortTransaction())
+    val commitTransaction: Task[Unit] = blocking.effectBlocking(live.p.commitTransaction())
+
+    def createTransaction: ZManaged[Any, Throwable, Transaction] =
+      semaphore.withPermitManaged *> {
+        ZManaged.makeExit {
+          for {
+            _ <- IO(live.p.beginTransaction())
+          } yield new Transaction(producer = live)
+        } {
+          case (_, Exit.Success(_))                        => commitTransaction.retryN(5).orDie
+          case (_, Exit.Failure(Fail(UserInitiatedAbort))) => abortTransaction.retryN(5).orDie
+          case (_, Exit.Failure(_))                        => abortTransaction.retryN(5).orDie
+        }
+      }
+  }
+
+  def createTransaction: RManaged[Has[TransactionalProducer], Transaction] =
+    ZManaged.service[TransactionalProducer].flatMap(_.createTransaction)
+
+  val live: RLayer[Has[TransactionalProducerSettings] with Blocking, Has[TransactionalProducer]] =
+    (for {
+      settings <- ZManaged.service[TransactionalProducerSettings]
+      producer <- make(settings)
+    } yield producer).toLayer
+
+  def make(settings: TransactionalProducerSettings): RManaged[Blocking, TransactionalProducer] =
+    (for {
+      props       <- ZIO.effect(settings.producerSettings.driverSettings)
+      blocking    <- ZIO.service[Blocking.Service]
+      rawProducer <- ZIO.effect(
+                       new KafkaProducer[Array[Byte], Array[Byte]](
+                         props.asJava,
+                         new ByteArraySerializer(),
+                         new ByteArraySerializer()
+                       )
+                     )
+      _           <- blocking.effectBlocking(rawProducer.initTransactions())
+      semaphore   <- Semaphore.make(1)
+      live = Producer.Live(rawProducer, settings.producerSettings, blocking)
+    } yield LiveTransactionalProducer(live, blocking, semaphore)).toManaged(_.live.close)
+}

--- a/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -4,9 +4,9 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import zio.Cause.Fail
-import zio.blocking.{ effectBlocking, Blocking }
+import zio.blocking.Blocking
 import zio.kafka.consumer.OffsetBatch
-import zio.{ Exit, Has, IO, RLayer, RManaged, Ref, RefM, Semaphore, Task, UIO, ZIO, ZManaged }
+import zio.{Exit, Has, IO, RLayer, RManaged, Ref, Semaphore, Task, ZIO, ZManaged}
 
 import scala.jdk.CollectionConverters._
 

--- a/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -6,7 +6,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer
 import zio.Cause.Fail
 import zio.blocking.Blocking
 import zio.kafka.consumer.OffsetBatch
-import zio.{ Exit, Has, IO, RLayer, RManaged, Ref, Semaphore, Task, UIO, URIO, ZIO, ZManaged }
+import zio.{ Exit, Has, RLayer, RManaged, Ref, Semaphore, Task, UIO, ZIO, ZManaged }
 
 import scala.jdk.CollectionConverters._
 

--- a/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -40,7 +40,7 @@ object TransactionalProducer {
           for {
             offsetBatchRef <- Ref.make(OffsetBatch.empty)
             _              <- IO(live.p.beginTransaction())
-          } yield new Transaction(producer = live, offsetBatchRef = offsetBatchRef)
+          } yield new TransactionImpl(producer = live, offsetBatchRef = offsetBatchRef)
         } {
           case (transaction: Transaction, Exit.Success(_)) =>
             transaction.offsetBatchRef.get.flatMap(offsetBatch =>

--- a/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -29,7 +29,7 @@ object TransactionalProducer {
           offsetBatch.offsets.map { case (topicPartition, offset) =>
             topicPartition -> new OffsetAndMetadata(offset + 1)
           }.asJava,
-          offsetBatch.consumerGroupId
+          offsetBatch.consumerGroupMetadata
         )
       ) *>
         blocking.effectBlocking(live.p.commitTransaction())

--- a/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
+++ b/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
@@ -13,7 +13,7 @@ object TransactionalProducerSettings {
       producerSettings.withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
     ) {}
 
-  def apply(bootstrapServers: List[String], transactionalId: String): TransactionalProducerSettings =
+  def apply(bootstrapServers: List[String], transactionalId: String): TransactionalProducerSettings     =
     new TransactionalProducerSettings(
       ProducerSettings(
         bootstrapServers,
@@ -27,7 +27,7 @@ object TransactionalProducerSettings {
     closeTimeout: Duration,
     properties: Map[String, AnyRef],
     transactionalId: String
-  ): TransactionalProducerSettings =
+  ): TransactionalProducerSettings                                                                      =
     new TransactionalProducerSettings(
       ProducerSettings(
         bootstrapServers,

--- a/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
+++ b/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
@@ -1,0 +1,33 @@
+package zio.kafka.producer
+
+import org.apache.kafka.clients.producer.ProducerConfig
+import zio.duration.{ durationInt, Duration }
+
+case class TransactionalProducerSettings private (
+  producerSettings: ProducerSettings
+)
+
+object TransactionalProducerSettings {
+  def apply(bootstrapServers: List[String], transactionalId: String): TransactionalProducerSettings =
+    new TransactionalProducerSettings(
+      ProducerSettings(
+        bootstrapServers,
+        30.seconds,
+        Map(ProducerConfig.TRANSACTIONAL_ID_CONFIG -> transactionalId)
+      )
+    )
+
+  def apply(
+    bootstrapServers: List[String],
+    closeTimeout: Duration,
+    properties: Map[String, AnyRef],
+    transactionalId: String
+  ): TransactionalProducerSettings =
+    new TransactionalProducerSettings(
+      ProducerSettings(
+        bootstrapServers,
+        closeTimeout,
+        properties.updated(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
+      )
+    )
+}

--- a/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
+++ b/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
@@ -8,6 +8,11 @@ case class TransactionalProducerSettings private (
 )
 
 object TransactionalProducerSettings {
+  def apply(producerSettings: ProducerSettings, transactionalId: String): TransactionalProducerSettings =
+    new TransactionalProducerSettings(
+      producerSettings.withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
+    )
+
   def apply(bootstrapServers: List[String], transactionalId: String): TransactionalProducerSettings =
     new TransactionalProducerSettings(
       ProducerSettings(

--- a/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
+++ b/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
@@ -3,7 +3,7 @@ package zio.kafka.producer
 import org.apache.kafka.clients.producer.ProducerConfig
 import zio.duration.{ durationInt, Duration }
 
-case class TransactionalProducerSettings private (
+sealed abstract case class TransactionalProducerSettings private (
   producerSettings: ProducerSettings
 )
 
@@ -11,7 +11,7 @@ object TransactionalProducerSettings {
   def apply(producerSettings: ProducerSettings, transactionalId: String): TransactionalProducerSettings =
     new TransactionalProducerSettings(
       producerSettings.withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
-    )
+    ) {}
 
   def apply(bootstrapServers: List[String], transactionalId: String): TransactionalProducerSettings =
     new TransactionalProducerSettings(
@@ -20,7 +20,7 @@ object TransactionalProducerSettings {
         30.seconds,
         Map(ProducerConfig.TRANSACTIONAL_ID_CONFIG -> transactionalId)
       )
-    )
+    ) {}
 
   def apply(
     bootstrapServers: List[String],
@@ -34,5 +34,5 @@ object TransactionalProducerSettings {
         closeTimeout,
         properties.updated(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
       )
-    )
+    ) {}
 }

--- a/src/test/scala/zio/kafka/KafkaTestUtils.scala
+++ b/src/test/scala/zio/kafka/KafkaTestUtils.scala
@@ -88,13 +88,26 @@ object KafkaTestUtils {
           ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG       -> "3000",
           ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG    -> "250",
           ConsumerConfig.MAX_POLL_RECORDS_CONFIG         -> "10",
-          ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG -> allowAutoCreateTopics.toString,
-          ConsumerConfig.ISOLATION_LEVEL_CONFIG          -> "read_committed" // TODO: create separate config for transaction testing? or maybe even a transactional consumer?
+          ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG -> allowAutoCreateTopics.toString
         )
         .withPerPartitionChunkPrefetch(16)
         .withOffsetRetrieval(offsetRetrieval)
       clientInstanceId.fold(settings)(settings.withGroupInstanceId)
     }
+
+  def transactionalConsumerSettings(
+    groupId: String,
+    clientId: String,
+    clientInstanceId: Option[String] = None,
+    allowAutoCreateTopics: Boolean = true,
+    offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto()
+  ): URIO[Has[Kafka], ConsumerSettings] =
+    consumerSettings(groupId, clientId, clientInstanceId, allowAutoCreateTopics, offsetRetrieval)
+      .map(
+        _.withProperties(
+          ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed"
+        )
+      )
 
   def consumer(
     groupId: String,

--- a/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -1,6 +1,7 @@
 package zio.kafka.producer
 
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.TopicPartition
 import zio._
 import zio.blocking.Blocking
 import zio.clock.Clock
@@ -79,8 +80,8 @@ object ProducerSpec extends DefaultRunnableSpec {
 
         for {
           _           <- TransactionalProducer.createTransaction.use { t =>
-                           t.produce(initialBobAccount, Serde.string, Serde.int) *>
-                             t.produce(initialAliceAccount, Serde.string, Serde.int)
+                           t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
+                             t.produce(initialAliceAccount, Serde.string, Serde.int, None)
                          }
           settings    <- transactionalConsumerSettings("testGroup0", "testClient0")
           recordChunk <- withConsumerInt(Topics(Set("accounts0")), settings).use { consumer =>
@@ -103,12 +104,12 @@ object ProducerSpec extends DefaultRunnableSpec {
 
         for {
           _           <- TransactionalProducer.createTransaction.use { t =>
-                           t.produce(initialBobAccount, Serde.string, Serde.int) *>
-                             t.produce(initialAliceAccount, Serde.string, Serde.int)
+                           t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
+                             t.produce(initialAliceAccount, Serde.string, Serde.int, None)
                          }
           _           <- TransactionalProducer.createTransaction.use { t =>
-                           t.produce(aliceGives20, Serde.string, Serde.int) *>
-                             t.produce(bobReceives20, Serde.string, Serde.int) *>
+                           t.produce(aliceGives20, Serde.string, Serde.int, None) *>
+                             t.produce(bobReceives20, Serde.string, Serde.int, None) *>
                              t.abort
                          }.catchSome { case UserInitiatedAbort =>
                            ZIO.unit // silences the abort
@@ -131,10 +132,10 @@ object ProducerSpec extends DefaultRunnableSpec {
         val initialBobAccount   = new ProducerRecord("accounts2", "bob", 0)
 
         val transaction1 = TransactionalProducer.createTransaction.use { t =>
-          t.produce(initialAliceAccount, Serde.string, Serde.int)
+          t.produce(initialAliceAccount, Serde.string, Serde.int, None)
         }
         val transaction2 = TransactionalProducer.createTransaction.use { t =>
-          t.produce(initialBobAccount, Serde.string, Serde.int)
+          t.produce(initialBobAccount, Serde.string, Serde.int, None)
         }
 
         for {
@@ -156,7 +157,8 @@ object ProducerSpec extends DefaultRunnableSpec {
           t.produce(
             initialBobAccount,
             Serde.string,
-            Serde.int.contramap((_: Int) => throw new RuntimeException("test"))
+            Serde.int.contramap((_: Int) => throw new RuntimeException("test")),
+            None
           )
         }
 
@@ -175,12 +177,12 @@ object ProducerSpec extends DefaultRunnableSpec {
 
         for {
           _         <- TransactionalProducer.createTransaction.use { t =>
-                         t.produce(initialBobAccount, Serde.string, Serde.int) *>
-                           t.produce(initialAliceAccount, Serde.string, Serde.int)
+                         t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
+                           t.produce(initialAliceAccount, Serde.string, Serde.int, None)
                        }
           assertion <- TransactionalProducer.createTransaction.use { t =>
                          for {
-                           _           <- t.produce(aliceGives20, Serde.string, Serde.int)
+                           _           <- t.produce(aliceGives20, Serde.string, Serde.int, None)
                            _           <- Producer.produce(nonTransactional, Serde.string, Serde.int)
                            settings    <- consumerSettings("testGroup4", "testClient4")
                            recordChunk <- withConsumerInt(Topics(Set("accounts4")), settings).use { consumer =>
@@ -205,12 +207,12 @@ object ProducerSpec extends DefaultRunnableSpec {
 
         for {
           _         <- TransactionalProducer.createTransaction.use { t =>
-                         t.produce(initialBobAccount, Serde.string, Serde.int) *>
-                           t.produce(initialAliceAccount, Serde.string, Serde.int)
+                         t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
+                           t.produce(initialAliceAccount, Serde.string, Serde.int, None)
                        }
           assertion <- TransactionalProducer.createTransaction.use { t =>
                          for {
-                           _           <- t.produce(aliceGives20, Serde.string, Serde.int)
+                           _           <- t.produce(aliceGives20, Serde.string, Serde.int, None)
                            _           <- Producer.produce(nonTransactional, Serde.string, Serde.int)
                            settings    <- transactionalConsumerSettings("testGroup5", "testClient5")
                            recordChunk <- withConsumerInt(Topics(Set("accounts5")), settings).use { consumer =>
@@ -236,13 +238,13 @@ object ProducerSpec extends DefaultRunnableSpec {
 
         for {
           _           <- TransactionalProducer.createTransaction.use { t =>
-                           t.produce(initialBobAccount, Serde.string, Serde.int) *>
-                             t.produce(initialAliceAccount, Serde.string, Serde.int)
+                           t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
+                             t.produce(initialAliceAccount, Serde.string, Serde.int, None)
                          }
           _           <- TransactionalProducer.createTransaction.use { t =>
-                           t.produce(aliceGives20, Serde.string, Serde.int) *>
+                           t.produce(aliceGives20, Serde.string, Serde.int, None) *>
                              Producer.produce(nonTransactional, Serde.string, Serde.int) *>
-                             t.produce(bobReceives20, Serde.string, Serde.int) *>
+                             t.produce(bobReceives20, Serde.string, Serde.int, None) *>
                              t.abort
                          }.catchSome { case UserInitiatedAbort =>
                            ZIO.unit // silences the abort
@@ -257,6 +259,85 @@ object ProducerSpec extends DefaultRunnableSpec {
                            } yield record
                          }
         } yield assert(recordChunk)(isNonEmpty)
+      },
+      testM("committing offsets after a successful transaction") {
+        import Subscription._
+
+        val initialAliceAccount  = new ProducerRecord("accounts7", "alice", 20)
+        val AliceAccountFeesPaid = new ProducerRecord("accounts7", "alice", 0)
+
+        for {
+          _               <- Producer.produce(initialAliceAccount, Serde.string, Serde.int)
+          settings        <- transactionalConsumerSettings("testGroup7", "testClient7")
+          committedOffset <-
+            Consumer.make(settings).use { c =>
+              c.subscribe(Topics(Set("accounts7"))) *> c
+                .plainStream(Serde.string, Serde.int)
+                .toQueue()
+                .use { q =>
+                  val readAliceAccount = for {
+                    messages <- q.take
+                                  .flatMap(_.done)
+                                  .mapError(_.getOrElse(new NoSuchElementException))
+                  } yield messages.head
+                  for {
+                    aliceHadMoneyCommittableMessage <- readAliceAccount
+                    _                               <- TransactionalProducer.createTransaction.use { t =>
+                                                         t.produce(
+                                                           AliceAccountFeesPaid,
+                                                           Serde.string,
+                                                           Serde.int,
+                                                           Some(aliceHadMoneyCommittableMessage.offset)
+                                                         )
+                                                       }
+                    aliceTopicPartition              = new TopicPartition("accounts7", aliceHadMoneyCommittableMessage.partition)
+                    committed                       <- c.committed(Set(aliceTopicPartition))
+                  } yield committed(aliceTopicPartition)
+                }
+            }
+
+        } yield assert(committedOffset.get.offset())(equalTo(1L))
+      },
+      testM("not committing offsets after a failed transaction") {
+        import Subscription._
+
+        val initialAliceAccount  = new ProducerRecord("accounts8", "alice", 20)
+        val AliceAccountFeesPaid = new ProducerRecord("accounts8", "alice", 0)
+
+        for {
+          _               <- Producer.produce(initialAliceAccount, Serde.string, Serde.int)
+          settings        <- transactionalConsumerSettings("testGroup8", "testClient8")
+          committedOffset <- Consumer.make(settings).use { c =>
+                               c.subscribe(Topics(Set("accounts8"))) *> c
+                                 .plainStream(Serde.string, Serde.int)
+                                 .toQueue()
+                                 .use { q =>
+                                   val readAliceAccount = for {
+                                     messages <- q.take
+                                                   .flatMap(_.done)
+                                                   .mapError(_.getOrElse(new NoSuchElementException))
+                                   } yield messages.head
+                                   for {
+                                     aliceHadMoneyCommittableMessage <- readAliceAccount
+                                     _                               <- TransactionalProducer.createTransaction.use { t =>
+                                                                          t.produce(
+                                                                            AliceAccountFeesPaid,
+                                                                            Serde.string,
+                                                                            Serde.int,
+                                                                            Some(aliceHadMoneyCommittableMessage.offset)
+                                                                          ) *>
+                                                                            t.abort
+                                                                        }.catchSome { case UserInitiatedAbort =>
+                                                                          ZIO.unit // silences the abort
+                                                                        }
+                                     aliceTopicPartition              =
+                                       new TopicPartition("accounts8", aliceHadMoneyCommittableMessage.partition)
+                                     committed                       <- c.committed(Set(aliceTopicPartition))
+                                   } yield committed(aliceTopicPartition)
+                                 }
+                             }
+
+        } yield assert(committedOffset)(isNone)
       }
     ).provideSomeLayerShared[TestEnvironment](
       ((Kafka.embedded ++ ZLayer.identity[Blocking] >>> producer) ++

--- a/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -340,10 +340,10 @@ object ProducerSpec extends DefaultRunnableSpec {
         val test = for {
           transactionThief <- Ref.make(Option.empty[Transaction])
           _                <- TransactionalProducer.createTransaction.use { t =>
-            transactionThief.set(Some(t))
-          }
+                                transactionThief.set(Some(t))
+                              }
           t                <- transactionThief.get
-          _ <- t.get.produce("any-topic", 0, 0, Serde.int, Serde.int, None)
+          _                <- t.get.produce("any-topic", 0, 0, Serde.int, Serde.int, None)
         } yield ()
         assertM(test.run)(failsCause(containsCause(Cause.fail(TransactionLeaked(OffsetBatch.empty)))))
       },
@@ -354,7 +354,7 @@ object ProducerSpec extends DefaultRunnableSpec {
                                 transactionThief.set(Some(t))
                               }
           t                <- transactionThief.get
-          _            <- TransactionalProducer.createTransaction.use { _ =>
+          _                <- TransactionalProducer.createTransaction.use { _ =>
                                 t.get.produce("any-topic", 0, 0, Serde.int, Serde.int, None)
                               }
         } yield ()

--- a/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -7,12 +7,18 @@ import zio.clock.Clock
 import zio.kafka.KafkaTestUtils._
 import zio.kafka.consumer.{ Consumer, ConsumerSettings, Subscription }
 import zio.kafka.embedded.Kafka
+import zio.kafka.producer.TransactionalProducer.UserInitiatedAbort
 import zio.kafka.serde.Serde
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestEnvironment
 
 object ProducerSpec extends DefaultRunnableSpec {
+  def withConsumerInt(subscription: Subscription, settings: ConsumerSettings) =
+    Consumer.make(settings).flatMap { c =>
+      c.subscribe(subscription).toManaged_ *> c.plainStream(Serde.string, Serde.int).toQueue()
+    }
+
   override def spec =
     suite("producer test suite")(
       testM("one record") {
@@ -64,9 +70,105 @@ object ProducerSpec extends DefaultRunnableSpec {
         for {
           metrics <- Producer.metrics
         } yield assert(metrics)(isNonEmpty)
+      },
+      testM("a simple transaction") {
+        import Subscription._
+
+        val initialAliceAccount = new ProducerRecord("accounts0", "alice", 20)
+        val initialBobAccount   = new ProducerRecord("accounts0", "bob", 0)
+
+        for {
+          _           <- TransactionalProducer.createTransaction.use { t =>
+                           t.produce(initialBobAccount, Serde.string, Serde.int) *>
+                             t.produce(initialAliceAccount, Serde.string, Serde.int)
+                         }
+          settings    <- consumerSettings("testGroup0", "testClient0")
+          recordChunk <- withConsumerInt(Topics(Set("accounts0")), settings).use { consumer =>
+                           for {
+                             messages <- consumer.take
+                                           .flatMap(_.done)
+                                           .mapError(_.getOrElse(new NoSuchElementException))
+                             record    = messages.filter(rec => rec.record.key == "bob")
+                           } yield record
+                         }
+        } yield assert(recordChunk.map(_.value).last)(equalTo(0))
+      },
+      testM("an aborted transaction should not be read") {
+        import Subscription._
+
+        val initialAliceAccount = new ProducerRecord("accounts1", "alice", 20)
+        val initialBobAccount   = new ProducerRecord("accounts1", "bob", 0)
+        val aliceGives20        = new ProducerRecord("accounts1", "alice", 0)
+        val bobReceives20       = new ProducerRecord("accounts1", "bob", 20)
+
+        for {
+          _           <- TransactionalProducer.createTransaction.use { t =>
+                           t.produce(initialBobAccount, Serde.string, Serde.int) *>
+                             t.produce(initialAliceAccount, Serde.string, Serde.int)
+                         }
+          _           <- TransactionalProducer.createTransaction.use { t =>
+                           t.produce(aliceGives20, Serde.string, Serde.int) *>
+                             t.produce(bobReceives20, Serde.string, Serde.int) *>
+                             t.abort
+                         }.catchSome { case UserInitiatedAbort =>
+                           ZIO.unit // silences the abort
+                         }
+          settings    <- consumerSettings("testGroup1", "testClient1")
+          recordChunk <- withConsumerInt(Topics(Set("accounts1")), settings).use { consumer =>
+                           for {
+                             messages <- consumer.take
+                                           .flatMap(_.done)
+                                           .mapError(_.getOrElse(new NoSuchElementException))
+                             record    = messages.filter(rec => rec.record.key == "bob")
+                           } yield record
+                         }
+        } yield assert(recordChunk.map(_.value).last)(equalTo(0))
+      },
+      testM("serialize concurrent transactions") {
+        import Subscription._
+
+        val initialAliceAccount = new ProducerRecord("accounts2", "alice", 20)
+        val initialBobAccount   = new ProducerRecord("accounts2", "bob", 0)
+
+        val transaction1 = TransactionalProducer.createTransaction.use { t =>
+          t.produce(initialAliceAccount, Serde.string, Serde.int)
+        }
+        val transaction2 = TransactionalProducer.createTransaction.use { t =>
+          t.produce(initialBobAccount, Serde.string, Serde.int)
+        }
+
+        for {
+          _           <- transaction1 <&> transaction2
+          settings    <- consumerSettings("testGroup2", "testClient2")
+          recordChunk <- withConsumerInt(Topics(Set("accounts2")), settings).use { consumer =>
+                           for {
+                             messages <- consumer.take
+                                           .flatMap(_.done)
+                                           .mapError(_.getOrElse(new NoSuchElementException))
+                           } yield messages
+                         }
+        } yield assert(recordChunk.map(_.value))(contains(0) && contains(20))
+      },
+      testM("exception management") {
+        val initialBobAccount = new ProducerRecord("accounts3", "bob", 0)
+
+        val failingTransaction1 = TransactionalProducer.createTransaction.use { t =>
+          t.produce(
+            initialBobAccount,
+            Serde.string,
+            Serde.int.contramap((_: Int) => throw new RuntimeException("test"))
+          )
+        }
+
+        val failingBob = for {
+          _ <- failingTransaction1
+        } yield ()
+        assertM(failingBob.run)(dies(hasMessage(equalTo("test"))))
       }
     ).provideSomeLayerShared[TestEnvironment](
-      ((Kafka.embedded ++ ZLayer.identity[Blocking] >>> producer) ++ Kafka.embedded)
+      ((Kafka.embedded ++ ZLayer.identity[Blocking] >>> producer) ++
+        (Kafka.embedded ++ ZLayer.identity[Blocking] >>> transactionalProducer) ++
+        Kafka.embedded)
         .mapError(TestFailure.fail) ++ Clock.live
     )
 }


### PR DESCRIPTION
This version of https://github.com/zio/zio-kafka/pull/351, while simplified, probably strikes a good balance.
The main difference is that the transactional producer has only the *transactional* modality. It is possible to interleave with non-transactional messages (as demonstrated in the integration tests) but it requires a second, non-transactional producer. This is because of the greatly limited kafka API.
It would be possible in the future to build a general purpose producer that internally contains both the producers and even queues concurrent transactions, but the current implementation probably covers >80% of use cases already.