### PR TITLE
GH-365 Allow manual subscription to consume a topic

### DIFF
--- a/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
+++ b/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
@@ -39,7 +39,7 @@ object CommittableRecord {
   def apply[K, V](
     record: ConsumerRecord[K, V],
     commitHandle: Map[TopicPartition, Long] => Task[Unit],
-    consumerGroupMetadata: ConsumerGroupMetadata
+    consumerGroupMetadata: Option[ConsumerGroupMetadata]
   ): CommittableRecord[K, V] =
     CommittableRecord(
       record,

--- a/src/main/scala/zio/kafka/consumer/Offset.scala
+++ b/src/main/scala/zio/kafka/consumer/Offset.scala
@@ -10,7 +10,7 @@ sealed trait Offset {
   def offset: Long
   def commit: Task[Unit]
   def batch: OffsetBatch
-  def consumerGroupMetadata: ConsumerGroupMetadata
+  def consumerGroupMetadata: Option[ConsumerGroupMetadata]
 
   /**
    * Attempts to commit and retries according to the given policy when the commit fails with a
@@ -37,7 +37,7 @@ private final case class OffsetImpl(
   topicPartition: TopicPartition,
   offset: Long,
   commitHandle: Map[TopicPartition, Long] => Task[Unit],
-  consumerGroupMetadata: ConsumerGroupMetadata
+  consumerGroupMetadata: Option[ConsumerGroupMetadata]
 ) extends Offset {
   def commit: Task[Unit] = commitHandle(Map(topicPartition -> offset))
   def batch: OffsetBatch = OffsetBatchImpl(Map(topicPartition -> offset), commitHandle, consumerGroupMetadata)

--- a/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
+++ b/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
@@ -10,7 +10,7 @@ sealed trait OffsetBatch {
   def commit: Task[Unit]
   def merge(offset: Offset): OffsetBatch
   def merge(offsets: OffsetBatch): OffsetBatch
-  def consumerGroupMetadata: ConsumerGroupMetadata
+  def consumerGroupMetadata: Option[ConsumerGroupMetadata]
 
   /**
    * Attempts to commit and retries according to the given policy when the commit fails with a
@@ -29,7 +29,7 @@ object OffsetBatch {
 private final case class OffsetBatchImpl(
   offsets: Map[TopicPartition, Long],
   commitHandle: Map[TopicPartition, Long] => Task[Unit],
-  consumerGroupMetadata: ConsumerGroupMetadata
+  consumerGroupMetadata: Option[ConsumerGroupMetadata]
 ) extends OffsetBatch {
   def commit: Task[Unit] = commitHandle(offsets)
 
@@ -53,9 +53,9 @@ private final case class OffsetBatchImpl(
 }
 
 case object EmptyOffsetBatch extends OffsetBatch {
-  val offsets: Map[TopicPartition, Long]           = Map()
-  val commit: Task[Unit]                           = Task.unit
-  def merge(offset: Offset): OffsetBatch           = offset.batch
-  def merge(offsets: OffsetBatch): OffsetBatch     = offsets
-  def consumerGroupMetadata: ConsumerGroupMetadata = new ConsumerGroupMetadata("")
+  val offsets: Map[TopicPartition, Long]                   = Map()
+  val commit: Task[Unit]                                   = Task.unit
+  def merge(offset: Offset): OffsetBatch                   = offset.batch
+  def merge(offsets: OffsetBatch): OffsetBatch             = offsets
+  def consumerGroupMetadata: Option[ConsumerGroupMetadata] = None
 }

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -16,6 +16,7 @@ import zio.stream._
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 private[consumer] final class Runloop(
   consumer: ConsumerAccess,
@@ -182,7 +183,7 @@ private[consumer] final class Runloop(
           )
 
         fulfillAction = fulfillAction *> req.cont.succeed(
-          concatenatedChunk.map(CommittableRecord(_, commit(_), consumer.consumer.groupMetadata()))
+          concatenatedChunk.map(CommittableRecord(_, commit(_), Try(consumer.consumer.groupMetadata()).toOption))
         )
         buf -= req.tp
       }

--- a/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -2,6 +2,7 @@ package zio.kafka.producer
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.common.errors.InvalidGroupIdException
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import zio.Cause.Fail
 import zio.blocking.Blocking
@@ -32,6 +33,11 @@ object TransactionalProducer {
               topicPartition -> new OffsetAndMetadata(offset + 1)
             }.asJava,
             offsetBatch.consumerGroupMetadata
+              .getOrElse(
+                throw new InvalidGroupIdException(
+                  "To use the group management or offset commit APIs, you must provide a valid group.id in the consumer configuration."
+                )
+              )
           )
         )
         .unless(offsetBatch.offsets.isEmpty) *>

--- a/src/test/scala/zio/kafka/AdminSpec.scala
+++ b/src/test/scala/zio/kafka/AdminSpec.scala
@@ -179,7 +179,7 @@ object AdminSpec extends DefaultRunnableSpec {
                 offsetBatch.commit.as(records)
               }
               .runCollect
-              .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(consumerGroupID, "topic9"))
+              .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("topic9", Some(consumerGroupID)))
 
           def toMap(records: Chunk[ConsumerRecord[String, String]]): Map[Int, List[(Long, String, String)]] =
             records.toList
@@ -216,7 +216,7 @@ object AdminSpec extends DefaultRunnableSpec {
             .plainStream[Has[Kafka] with Blocking with Clock, String, String](Serde.string, Serde.string)
             .take(count)
             .foreach(_.offset.commit)
-            .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(groupId, topic))
+            .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(topic, Some(groupId)))
 
         KafkaTestUtils.withAdmin { client =>
           for {
@@ -294,7 +294,7 @@ object AdminSpec extends DefaultRunnableSpec {
     .subscribeAnd(Subscription.topics(topicName))
     .plainStream(Serde.string, Serde.string)
     .foreach(_.offset.commit)
-    .provideSomeLayer(consumer(groupId, clientId, groupInstanceId))
+    .provideSomeLayer(consumer(clientId, Some(groupId), groupInstanceId))
 
   private def getStableConsumerGroupDescription(
     groupId: String

--- a/src/test/scala/zio/kafka/ConsumerSpec.scala
+++ b/src/test/scala/zio/kafka/ConsumerSpec.scala
@@ -23,7 +23,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
       testM("export metrics") {
         for {
           metrics <- Consumer.metrics
-                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("group1289", "client150"))
+                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client150", Some("group1289")))
         } yield assert(metrics)(isNonEmpty)
       },
       testM("plainStream emits messages for a topic subscription") {
@@ -36,7 +36,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                        .plainStream(Serde.string, Serde.string)
                        .take(5)
                        .runCollect
-                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("group150", "client150"))
+                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client150", Some("group150")))
           kvOut = records.map(r => (r.record.key, r.record.value)).toList
         } yield assert(kvOut)(equalTo(kvs))
       },
@@ -51,7 +51,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                      .take(100)
                      .mapChunks(c => Chunk(c.size))
                      .runCollect
-                     .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("group1289", "client150"))
+                     .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client150", Some("group1289")))
         } yield assert(sizes)(forall(isGreaterThan(1)))
       },
       testM("Consumer.subscribeAnd works properly") {
@@ -64,7 +64,22 @@ object ConsumerSpec extends DefaultRunnableSpec {
                        .plainStream(Serde.string, Serde.string)
                        .take(5)
                        .runCollect
-                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("group160", "client160"))
+                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client160", Some("group160")))
+          kvOut = records.map(r => (r.record.key, r.record.value)).toList
+        } yield assert(kvOut)(equalTo(kvs))
+      },
+      testM("Consumer.subscribeAnd manual subscription without groupId works properly") {
+        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          _ <- produceMany("topic160", kvs)
+
+          records <-
+            Consumer
+              .subscribeAnd(Subscription.Manual(Set(new org.apache.kafka.common.TopicPartition("topic160", 0))))
+              .plainStream(Serde.string, Serde.string)
+              .take(5)
+              .runCollect
+              .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(clientId = "client160"))
           kvOut = records.map(r => (r.record.key, r.record.value)).toList
         } yield assert(kvOut)(equalTo(kvs))
       },
@@ -78,7 +93,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                        .plainStream(Serde.string, Serde.string)
                        .take(100)
                        .runCollect
-                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("group170", "client170"))
+                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client170", Some("group170")))
           kvOut = records.map(r => (r.record.key, r.record.value)).toList
         } yield assert(kvOut)(equalTo(kvs))
       },
@@ -91,7 +106,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                        .plainStream(Serde.string, Serde.string)
                        .take(5)
                        .runCollect
-                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("group150", "client150"))
+                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client150", Some("group150")))
           kvOut = records.map(r => (r.record.key, r.record.value)).toList
         } yield assert(kvOut)(equalTo(kvs))
       },
@@ -109,7 +124,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                       .plainStream(Serde.string, Serde.string)
                       .take(1)
                       .runHead
-                      .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("group150", "client150"))
+                      .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client150", Some("group150")))
           kvOut = record.map(r => (r.record.key, r.record.value))
         } yield assert(kvOut)(isSome(equalTo("key2" -> "msg2")))
       },
@@ -131,7 +146,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                       .take(1)
                       .runHead
                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](
-                        consumer("group150", "client150", offsetRetrieval = offsetRetrieval)
+                        consumer("client150", Some("group150"), offsetRetrieval = offsetRetrieval)
                       )
           kvOut = record.map(r => (r.record.key, r.record.value))
         } yield assert(kvOut)(isSome(equalTo("key2-3" -> "msg2-3")))
@@ -157,7 +172,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                                          }
                                          .runCollect
                                          .provideSomeLayer[Has[Kafka] with Blocking with Clock](
-                                           consumer("group1", "first")
+                                           consumer("first", Some("group1"))
                                          )
                           } yield results
           secondResults <- for {
@@ -176,7 +191,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                                           }
                                           .runCollect
                                           .provideSomeLayer[Has[Kafka] with Blocking with Clock](
-                                            consumer("group1", "second")
+                                            consumer("second", Some("group1"))
                                           )
                            } yield results
         } yield assert((firstResults ++ secondResults).map(rec => rec.key() -> rec.value()).toList)(equalTo(data))
@@ -206,7 +221,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                    }
                    .take(nrMessages.toLong)
                    .runDrain
-                   .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(group, "client3"))
+                   .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client3", Some(group)))
                    .fork
           _                    <- fib.join
           messagesPerPartition <- ZIO.foreach(messagesReceived.values)(_.get)
@@ -221,7 +236,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
 
         for {
           _ <- produceMany(topic, messages)
-          consumeResult <- consumeWithStrings("group3", "client3", subscription) { case (_, _) =>
+          consumeResult <- consumeWithStrings("client3", Some("group3"), subscription) { case (_, _) =>
                              ZIO.fail(new IllegalArgumentException("consumeWith failure")).orDie
                            }.run
         } yield consumeResult.fold(
@@ -241,7 +256,9 @@ object ConsumerSpec extends DefaultRunnableSpec {
                  .zipWithIndex
                  .tap { case (_, idx) => Consumer.stopConsumption.when(idx == 3) }
                  .runDrain
-                 .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(group, "client150")) *> keepProducing
+                 .provideSomeLayer[Has[Kafka] with Blocking with Clock](
+                   consumer("client150", Some(group))
+                 ) *> keepProducing
                  .set(false)
         } yield assertCompletes
       },
@@ -265,7 +282,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                       .mapM(_.commit)
                       .runDrain *>
                       Consumer.committed(Set(new TopicPartition(topic, 0))).map(_.values.head))
-                      .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(group, "client150"))
+                      .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client150", Some(group)))
         } yield assert(offset.map(_.offset))(isSome(isLessThanEqualTo(10L)))
       } @@ TestAspect.ignore, // Not sure how to test this currently
       testM("offset batching collects the latest offset for all partitions") {
@@ -294,7 +311,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                        .mapM(_.commit)
                        .runDrain *>
                        Consumer.committed((0 until nrPartitions).map(new TopicPartition(topic, _)).toSet))
-                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(group, "client3"))
+                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client3", Some(group)))
         } yield assert(offsets.values.map(_.map(_.offset)))(forall(isSome(equalTo(nrMessages.toLong / nrPartitions))))
       },
       testM("handle rebalancing by completing topic-partition streams") {
@@ -322,7 +339,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                          }
                          .take(nrPartitions.toLong / 2)
                          .runDrain
-                         .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(group, "client1"))
+                         .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client1", Some(group)))
                          .fork
           _ <- Live.live(ZIO.sleep(5.seconds))
           consumer2 <- Consumer
@@ -330,7 +347,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                          .partitionedStream(Serde.string, Serde.string)
                          .take(nrPartitions.toLong / 2)
                          .runDrain
-                         .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(group, "client2"))
+                         .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client2", Some(group)))
                          .fork
           _ <- consumer1.join
           _ <- consumer2.join
@@ -365,7 +382,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                              .take(nrPartitions.toLong / 2)
                              .runDrain
                              .provideSomeLayer[Has[Kafka] with Blocking with Clock](
-                               consumer(group, "client1", diagnostics = diagnostics)
+                               consumer("client1", Some(group), diagnostics = diagnostics)
                              )
                              .fork
               diagnosticStream <- ZStream
@@ -379,7 +396,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                              .partitionedStream(Serde.string, Serde.string)
                              .take(nrPartitions.toLong / 2)
                              .runDrain
-                             .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(group, "client2"))
+                             .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client2", Some(group)))
                              .fork
               _ <- consumer1.join
               _ <- consumer1.join
@@ -411,7 +428,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                    offsetBatch.commit.as(records)
                  }
                  .runCollect
-                 .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("group1", "client1"))
+                 .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client1", Some("group1")))
           // Start a new consumer with manual offset before the committed offset
           offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
           secondResults <- Consumer
@@ -421,7 +438,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                              .map(_.record)
                              .runCollect
                              .provideSomeLayer[Has[Kafka] with Blocking with Clock](
-                               consumer("group1", "client2", offsetRetrieval = offsetRetrieval)
+                               consumer("client2", Some("group1"), offsetRetrieval = offsetRetrieval)
                              )
           // Check that we only got the records starting from the manually seek'd offset
         } yield assert(secondResults.map(rec => rec.key() -> rec.value()).toList)(equalTo(data.drop(manualOffsetSeek)))
@@ -433,7 +450,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
         val messages     = (1 to nrMessages).toList.map(i => (s"key$i", s"msg$i"))
 
         def consumeIt(messagesReceived: Ref[List[(String, String)]], done: Promise[Nothing, Unit]) =
-          consumeWithStrings("group3", "client3", subscription)({ (key, value) =>
+          consumeWithStrings("client3", Some("group3"), subscription)({ (key, value) =>
             (for {
               messagesSoFar <- messagesReceived.updateAndGet(_ :+ (key -> value))
               _             <- Task.when(messagesSoFar.size == nrMessages)(done.succeed(()))
@@ -459,7 +476,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                           .run(ZSink.collectAll[(String, String)])
                           .map(_.head)
                           .orDie)
-                          .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("group3", "client3"))
+                          .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client3", Some("group3")))
           consumedMessages <- messagesReceived.get
         } yield assert(consumedMessages)(contains(newMessage).negate)
       },
@@ -471,7 +488,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
           partitions <- Consumer
                           .partitionsFor(topic)
                           .provideSomeLayer[Has[Kafka] with Blocking with Clock](
-                            consumer(group, client, allowAutoCreateTopics = false)
+                            consumer(client, Some(group), allowAutoCreateTopics = false)
                           )
         } yield assert(partitions)(isEmpty)
       },
@@ -534,8 +551,8 @@ object ConsumerSpec extends DefaultRunnableSpec {
           fiber0 <- run(0, topic, allAssignments)
                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](
                         consumer(
-                          group,
                           client1,
+                          Some(group),
                           offsetRetrieval = OffsetRetrieval.Auto(reset = AutoOffsetStrategy.Earliest)
                         )
                       )
@@ -544,8 +561,8 @@ object ConsumerSpec extends DefaultRunnableSpec {
           fiber1 <- run(1, topic, allAssignments)
                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](
                         consumer(
-                          group,
                           client2,
+                          Some(group),
                           offsetRetrieval = OffsetRetrieval.Auto(reset = AutoOffsetStrategy.Earliest)
                         )
                       )
@@ -554,8 +571,8 @@ object ConsumerSpec extends DefaultRunnableSpec {
           fiber2 <- run(2, topic, allAssignments)
                       .provideSomeLayer[Has[Kafka] with Blocking with Clock](
                         consumer(
-                          group,
                           client3,
+                          Some(group),
                           offsetRetrieval = OffsetRetrieval.Auto(reset = AutoOffsetStrategy.Earliest)
                         )
                       )

--- a/src/test/scala/zio/kafka/ConsumerSpec.scala
+++ b/src/test/scala/zio/kafka/ConsumerSpec.scala
@@ -67,7 +67,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                        .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client160", Some("group160")))
           kvOut = records.map(r => (r.record.key, r.record.value)).toList
         } yield assert(kvOut)(equalTo(kvs))
-      },
+      } @@ TestAspect.flaky,
       testM("Consumer.subscribeAnd manual subscription without groupId works properly") {
         val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
         for {
@@ -82,7 +82,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
               .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(clientId = "client160"))
           kvOut = records.map(r => (r.record.key, r.record.value)).toList
         } yield assert(kvOut)(equalTo(kvs))
-      },
+      } @@ TestAspect.flaky,
       testM("Consuming+provideCustomLayer") {
         val kvs = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
         for {

--- a/src/test/scala/zio/kafka/ConsumerSpec.scala
+++ b/src/test/scala/zio/kafka/ConsumerSpec.scala
@@ -67,22 +67,22 @@ object ConsumerSpec extends DefaultRunnableSpec {
                        .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer("client160", Some("group160")))
           kvOut = records.map(r => (r.record.key, r.record.value)).toList
         } yield assert(kvOut)(equalTo(kvs))
-      } @@ TestAspect.flaky,
+      },
       testM("Consumer.subscribeAnd manual subscription without groupId works properly") {
         val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
         for {
-          _ <- produceMany("topic160", kvs)
+          _ <- produceMany("topic161", kvs)
 
           records <-
             Consumer
-              .subscribeAnd(Subscription.Manual(Set(new org.apache.kafka.common.TopicPartition("topic160", 0))))
+              .subscribeAnd(Subscription.Manual(Set(new org.apache.kafka.common.TopicPartition("topic161", 0))))
               .plainStream(Serde.string, Serde.string)
               .take(5)
               .runCollect
-              .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(clientId = "client160"))
+              .provideSomeLayer[Has[Kafka] with Blocking with Clock](consumer(clientId = "client161"))
           kvOut = records.map(r => (r.record.key, r.record.value)).toList
         } yield assert(kvOut)(equalTo(kvs))
-      } @@ TestAspect.flaky,
+      },
       testM("Consuming+provideCustomLayer") {
         val kvs = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
         for {

--- a/src/test/scala/zio/kafka/KafkaTestUtils.scala
+++ b/src/test/scala/zio/kafka/KafkaTestUtils.scala
@@ -93,7 +93,7 @@ object KafkaTestUtils {
         .withOffsetRetrieval(offsetRetrieval)
 
       val withClientInstanceId = clientInstanceId.fold(settings)(settings.withGroupInstanceId)
-      groupId.fold(withClientInstanceId)(settings.withGroupId)
+      groupId.fold(withClientInstanceId)(withClientInstanceId.withGroupId)
     }
 
   def transactionalConsumerSettings(

--- a/src/test/scala/zio/kafka/KafkaTestUtils.scala
+++ b/src/test/scala/zio/kafka/KafkaTestUtils.scala
@@ -71,15 +71,14 @@ object KafkaTestUtils {
       )
 
   def consumerSettings(
-    groupId: String,
     clientId: String,
+    groupId: Option[String] = None,
     clientInstanceId: Option[String] = None,
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto()
   ): URIO[Has[Kafka], ConsumerSettings] =
     ZIO.access[Has[Kafka]] { (kafka: Has[Kafka]) =>
       val settings = ConsumerSettings(kafka.get.bootstrapServers)
-        .withGroupId(groupId)
         .withClientId(clientId)
         .withCloseTimeout(5.seconds)
         .withProperties(
@@ -92,7 +91,9 @@ object KafkaTestUtils {
         )
         .withPerPartitionChunkPrefetch(16)
         .withOffsetRetrieval(offsetRetrieval)
-      clientInstanceId.fold(settings)(settings.withGroupInstanceId)
+
+      val withClientInstanceId = clientInstanceId.fold(settings)(settings.withGroupInstanceId)
+      groupId.fold(withClientInstanceId)(settings.withGroupId)
     }
 
   def transactionalConsumerSettings(
@@ -102,7 +103,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto()
   ): URIO[Has[Kafka], ConsumerSettings] =
-    consumerSettings(groupId, clientId, clientInstanceId, allowAutoCreateTopics, offsetRetrieval)
+    consumerSettings(clientId, Some(groupId), clientInstanceId, allowAutoCreateTopics, offsetRetrieval)
       .map(
         _.withProperties(
           ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed"
@@ -110,21 +111,21 @@ object KafkaTestUtils {
       )
 
   def consumer(
-    groupId: String,
     clientId: String,
+    groupId: Option[String] = None,
     clientInstanceId: Option[String] = None,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     allowAutoCreateTopics: Boolean = true,
     diagnostics: Diagnostics = Diagnostics.NoOp
   ): ZLayer[Has[Kafka] with Clock with Blocking, Throwable, Has[Consumer]] =
-    (consumerSettings(groupId, clientId, clientInstanceId, allowAutoCreateTopics, offsetRetrieval).toLayer ++
+    (consumerSettings(clientId, groupId, clientInstanceId, allowAutoCreateTopics, offsetRetrieval).toLayer ++
       ZLayer.requires[Clock with Blocking] ++
       ZLayer.succeed(diagnostics)) >>> Consumer.live
 
-  def consumeWithStrings[RC](groupId: String, clientId: String, subscription: Subscription)(
-    r: (String, String) => URIO[RC, Unit]
-  ): RIO[RC with Has[Kafka] with Blocking with Clock, Unit] =
-    consumerSettings(groupId, clientId, None).flatMap { settings =>
+  def consumeWithStrings[RC](clientId: String, groupId: Option[String] = None, subscription: Subscription)(
+    r: (String, String) => URIO[Any, Unit]
+  ): RIO[Any with Has[Kafka] with Blocking with Clock, Unit] =
+    consumerSettings(clientId, groupId, None).flatMap { settings =>
       Consumer.consumeWith(
         settings,
         subscription,

--- a/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -42,7 +42,7 @@ object ProducerSpec extends DefaultRunnableSpec {
 
         for {
           outcome  <- Producer.produceChunk(chunks, Serde.string, Serde.string)
-          settings <- consumerSettings("testGroup", "testClient")
+          settings <- consumerSettings("testClient", Some("testGroup"))
           record1 <- withConsumer(Topics(Set(topic1)), settings).use { consumer =>
                        for {
                          messages <- consumer.take.flatMap(_.done).mapError(_.getOrElse(new NoSuchElementException))
@@ -181,7 +181,7 @@ object ProducerSpec extends DefaultRunnableSpec {
                          for {
                            _        <- t.produce(aliceGives20, Serde.string, Serde.int, None)
                            _        <- Producer.produce(nonTransactional, Serde.string, Serde.int)
-                           settings <- consumerSettings("testGroup4", "testClient4")
+                           settings <- consumerSettings("testClient4", Some("testGroup4"))
                            recordChunk <- withConsumerInt(Topics(Set("accounts4")), settings).use { consumer =>
                                             for {
                                               messages <- consumer.take


### PR DESCRIPTION
Fixes https://github.com/zio/zio-kafka/issues/375

I required to make groupId optional and thus swap arguments for consumer construction.

The fix is not perfect as I found no solution to know if I can call `groupMetadata` without getting an exception ( see https://github.com/zio/zio-kafka/compare/master...mbaechler:allow-manual-consumer?expand=1#diff-4bb68de9081869e01fdb038a48581bb121471b3de1ddad2cf0e834e4e3e356fdR186 )

The same test is passing on 0.16.0.

I would appreciate a release 0.17.1 to fix this regression is possible.