### PR TITLE
Expose the internal Java `AdminClient`

### DIFF
--- a/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -186,7 +186,7 @@ object AdminClient {
    * @param adminClient
    */
   private final case class LiveAdminClient(
-    private[admin] val adminClient: JAdminClient,
+    adminClient: JAdminClient,
     private val blocking: Blocking.Service
   ) extends AdminClient {
 


### PR DESCRIPTION
So that this lib is easier to use when some of the Java `AdminClient` methods are not yet implemented in the zio-kafka lib