### PR TITLE
stop thinking controller node are always present

### DIFF
--- a/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -103,7 +103,7 @@ trait AdminClient {
   /**
    * Get the cluster controller.
    */
-  def describeClusterController(options: Option[DescribeClusterOptions] = None): Task[Node]
+  def describeClusterController(options: Option[DescribeClusterOptions] = None): Task[Option[Node]]
 
   /**
    * Get the cluster id.
@@ -316,13 +316,10 @@ object AdminClient {
     /**
      * Get the cluster controller.
      */
-    override def describeClusterController(options: Option[DescribeClusterOptions] = None): Task[Node] =
+    override def describeClusterController(options: Option[DescribeClusterOptions] = None): Task[Option[Node]] =
       fromKafkaFuture(
         describeCluster(options).map(_.controller())
-      ).flatMap { jNode =>
-        ZIO
-          .getOrFailWith(new RuntimeException("Empty/NoNode not expected when listing cluster nodes"))(Node(jNode))
-      }
+      ).map(Node(_))
 
     /**
      * Get the cluster id.

--- a/src/test/scala/zio/kafka/AdminSpec.scala
+++ b/src/test/scala/zio/kafka/AdminSpec.scala
@@ -113,7 +113,7 @@ object AdminSpec extends DefaultRunnableSpec {
         KafkaTestUtils.withAdmin { client =>
           for {
             controller <- client.describeClusterController()
-          } yield assert(controller.id)(equalTo(0))
+          } yield assert(controller.map(_.id))(isSome(equalTo(0)))
         }
       },
       testM("get cluster id") {


### PR DESCRIPTION
Sorry I missed that one my last PR, inside org.apache.kafka.clients.admin.DescribeClusterResult:
```
    /**
     * Returns a future which yields the current controller id.
     * Note that this may yield null, if the controller ID is not yet known.
     */
    public KafkaFuture<Node> controller() {
        return controller;
    }
```