### PR TITLE
Handle `Command.Poll` while subscribed only

### DIFF
--- a/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -309,10 +309,10 @@ object Consumer {
                 }
           }
         }
-      }
+      } *> runloop.markSubscribed
 
     override def unsubscribe: Task[Unit] =
-      consumer.withConsumer(_.unsubscribe())
+      runloop.markUnsubscribed *> consumer.withConsumer(_.unsubscribe())
 
     override def metrics: Task[Map[MetricName, Metric]] =
       consumer.withConsumer(_.metrics().asScala.toMap)

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -30,7 +30,8 @@ private[consumer] final class Runloop(
   diagnostics: Diagnostics,
   shutdownRef: Ref[Boolean],
   offsetRetrieval: OffsetRetrieval,
-  userRebalanceListener: RebalanceListener
+  userRebalanceListener: RebalanceListener,
+  subscribedRef: Ref[Boolean]
 ) {
   private val isRebalancing = rebalancingRef.get
   private val isShutdown    = shutdownRef.get
@@ -69,6 +70,10 @@ private[consumer] final class Runloop(
 
     trackRebalancing ++ emitDiagnostics ++ userRebalanceListener
   }
+
+  def markSubscribed: UIO[Unit] = subscribedRef.set(true)
+
+  def markUnsubscribed: UIO[Unit] = subscribedRef.set(false)
 
   private def commit(offsets: Map[TopicPartition, Long]): Task[Unit] =
     for {
@@ -239,21 +244,15 @@ private[consumer] final class Runloop(
     if (toPause.nonEmpty) c.pause(toPause.asJava)
   }
 
-  private def doPoll(c: ByteArrayKafkaConsumer, requestedPartitions: Set[TopicPartition]) =
-    try {
-      val pollTimeout =
-        if (requestedPartitions.nonEmpty) this.pollTimeout.asJava
-        else 0.millis.asJava
+  private def doPoll(c: ByteArrayKafkaConsumer, requestedPartitions: Set[TopicPartition]) = {
+    val pollTimeout =
+      if (requestedPartitions.nonEmpty) this.pollTimeout.asJava
+      else 0.millis.asJava
 
-      val records = c.poll(pollTimeout)
+    val records = c.poll(pollTimeout)
 
-      if (records eq null) ConsumerRecords.empty[Array[Byte], Array[Byte]]() else records
-    } catch {
-      // The consumer will throw an IllegalStateException if no call to subscribe
-      // has been made yet, so we just ignore that. We have to poll even if c.subscription()
-      // is empty because pattern subscriptions start out as empty.
-      case _: IllegalStateException if c.subscription.isEmpty => ConsumerRecords.empty[Array[Byte], Array[Byte]]()
-    }
+    if (records eq null) ConsumerRecords.empty[Array[Byte], Array[Byte]]() else records
+  }
 
   private def pauseAllPartitions(c: ByteArrayKafkaConsumer) = ZIO.effectTotal {
     val currentAssigned = c.assignment()
@@ -387,7 +386,7 @@ private[consumer] final class Runloop(
   private def handleOperational(state: State, cmd: Command): RIO[Blocking, State] =
     cmd match {
       case Command.Poll() =>
-        handlePoll(state)
+        ZIO.ifM(subscribedRef.get)(handlePoll(state), UIO(state))
       case Command.Requests(reqs) =>
         handleRequests(state, reqs).flatMap { state =>
           // Optimization: eagerly poll if we have pending requests instead of waiting
@@ -470,7 +469,8 @@ private[consumer] object Runloop {
                           )
                       }
                       .toManaged(_.shutdown)
-      shutdownRef <- Ref.make(false).toManaged_
+      shutdownRef   <- Ref.make(false).toManaged_
+      subscribedRef <- Ref.make(false).toManaged_
       runloop = new Runloop(
                   consumer,
                   pollFrequency,
@@ -482,7 +482,8 @@ private[consumer] object Runloop {
                   diagnostics,
                   shutdownRef,
                   offsetRetrieval,
-                  userRebalanceListener
+                  userRebalanceListener,
+                  subscribedRef
                 )
       _ <- runloop.run
     } yield runloop

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -386,6 +386,7 @@ private[consumer] final class Runloop(
   private def handleOperational(state: State, cmd: Command): RIO[Blocking, State] =
     cmd match {
       case Command.Poll() =>
+        // The consumer will throw an IllegalStateException if no call to subscribe
         ZIO.ifM(subscribedRef.get)(handlePoll(state), UIO(state))
       case Command.Requests(reqs) =>
         handleRequests(state, reqs).flatMap { state =>

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -252,7 +252,7 @@ private[consumer] final class Runloop(
       // The consumer will throw an IllegalStateException if no call to subscribe
       // has been made yet, so we just ignore that. We have to poll even if c.subscription()
       // is empty because pattern subscriptions start out as empty.
-      case _: IllegalStateException => ConsumerRecords.empty[Array[Byte], Array[Byte]]()
+      case _: IllegalStateException if c.subscription.isEmpty => ConsumerRecords.empty[Array[Byte], Array[Byte]]()
     }
 
   private def pauseAllPartitions(c: ByteArrayKafkaConsumer) = ZIO.effectTotal {


### PR DESCRIPTION
In our systems, once in a blue moon, one of our ZIO instances has network issues between Kafka Client and Kafka Broker Coordinator, leaving processing of messages stuck. We use different technologies for different services so we have some systems using Akka Kafka and others ZIO Kafka. Both of them use the same Kafka Clients (3.0.0) and interact with the same Kafka Cluster (0.10.2.0). We only see this pattern on the ZIO instances.

Recently the issue happened again and we were able to profile the system with Async Profiler:

![image](https://user-images.githubusercontent.com/6449814/149914352-ad7b7214-9494-4bd3-bd07-599c58e3c9df.png)

We found out that `KafkaConsumer.poll` throws `IllegalStateException` for multiple reasons, but ZIO Kafka is treating all of them as if they were only when no call to `subscribe` has been made yet. This PR fixes this by adding a guard to ensure we're on the mentioned scenario (and let it crash otherwise).

We're not completely sure that this issue will be resolved with this fix, but we believe it's a good idea to not shadow all the `IllegalStateException`s under the umbrella of not being subscribed. In this same scenario, Alpakka Kafka closes the related Actor, returning the control to user which can decide what to do to handle the fatal situation.