### PR TITLE
The `KafkaFuture` implementation is, since Kafka v3.0.0, backed by a `CompletableFuture`

### DIFF
--- a/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -44,6 +44,7 @@ import zio.blocking.Blocking
 import zio.duration.Duration
 
 import java.util.Optional
+import java.util.concurrent.CompletionException
 import scala.jdk.CollectionConverters._
 
 trait AdminClient {
@@ -507,20 +508,35 @@ object AdminClient extends Accessible[AdminClient] {
       admin    <- make(settings)
     } yield admin).toLayer
 
-  def fromKafkaFuture[R, T](kfv: RIO[R, KafkaFuture[T]]): RIO[R, T] =
-    kfv.flatMap { f =>
-      Task.effectAsyncInterrupt[T] { cb =>
-        f.whenComplete {
-          new KafkaFuture.BiConsumer[T, Throwable] {
-            def accept(t: T, e: Throwable): Unit =
-              if (f.isCancelled) cb(ZIO.fiberId.flatMap(id => Task.halt(Cause.interrupt(id))))
-              else if (e ne null) cb(Task.fail(e))
-              else cb(Task.succeed(t))
-          }
-        }
-        Left(ZIO.effectTotal(f.cancel(true)))
+  def fromKafkaFuture[R, T](kfv: RIO[R, KafkaFuture[T]]): RIO[R, T] = {
+
+    /*
+     * Inspired by the implementation of [[zio.interop.javaz.fromCompletionStage]].
+     *
+     * See:
+     *   - https://github.com/zio/zio/blob/v1.0.13/core/jvm/src/main/scala/zio/interop/javaz.scala#L47-L80
+     */
+    def unwrapCompletionException(isFatal: Throwable => Boolean)(t: Throwable): Task[Nothing] =
+      t match {
+        case e: CompletionException => Task.fail(e.getCause)
+        case e if !isFatal(e)       => Task.fail(e)
+        case e                      => Task.die(e)
       }
-    }
+
+    kfv.flatMap(f =>
+      Task.effectSuspendTotalWith { (p, _) =>
+        Task.effectAsyncInterrupt[T] { cb =>
+          f.toCompletionStage.whenComplete { (v: T, t: Throwable) =>
+            if (f.isCancelled) cb(ZIO.fiberId.flatMap(id => Task.halt(Cause.interrupt(id))))
+            else if (t ne null) cb(unwrapCompletionException(p.fatal)(t))
+            else cb(Task.succeed(v))
+          }
+
+          Left(ZIO.effectTotal(f.cancel(true)))
+        }
+      }
+    )
+  }
 
   def fromKafkaFutureVoid[R](kfv: RIO[R, KafkaFuture[Void]]): RIO[R, Unit] =
     fromKafkaFuture(kfv).unit


### PR DESCRIPTION
See:
  - https://issues.apache.org/jira/browse/KAFKA-6987
  - https://cwiki.apache.org/confluence/display/KAFKA/KIP-707%3A+The+future+of+KafkaFuture
  - https://github.com/apache/kafka/pull/9878
 
#### Why do we need to change this code?
In my project, we have tests testing that when a Topic doesn't exist but we are trying to do something with this topic, the code correctly fails.
In these tests, we are validating that the error we are getting back from the Kafka client is `org.apache.kafka.common.errors.UnknownTopicOrPartitionException`.

Since the update of the kafka-clients to v3+, our tests are now failing because we're not getting a `org.apache.kafka.common.errors.UnknownTopicOrPartitionException` error anymore but a `java.util.concurrent.CompletionException` error wrapping the `org.apache.kafka.common.errors.UnknownTopicOrPartitionException`:

```scala
[info]     - should fail if topic does not exist
[info]       java.util.concurrent.CompletionException: org.apache.kafka.common.errors.UnknownTopicOrPartitionException: <error message> did not satisfy isSubtype(UnknownTopicOrPartitionException)
```

This PR fixes this problem