### PR TITLE
Upgrade ZIO Version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ lazy val kafka =
         if (scalaBinaryVersion.value == "2.13") Seq("-Wconf:cat=unused-nowarn:s")
         else Seq()
       },
+      scalacOptions -= "-Xlint:infer-any",
       // workaround for bad constant pool issue
       (Compile / doc) := Def.taskDyn {
         val default = (Compile / doc).taskValue

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val scala3    = "3.1.1"
 lazy val mainScala = scala213
 lazy val allScala  = Seq(scala212, scala3, mainScala)
 
-lazy val zioVersion           = "2.0.0-RC2"
+lazy val zioVersion           = "2.0.0-RC3"
 lazy val kafkaVersion         = "3.1.0"
 lazy val embeddedKafkaVersion = "3.1.0" // Should be the same as kafkaVersion, except for the patch part
 

--- a/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -279,13 +279,13 @@ object Consumer {
 
           subscription match {
             case Subscription.Pattern(pattern) =>
-              ZIO(c.subscribe(pattern.pattern, runloop.rebalanceListener.toKafka(runtime, rc)))
+              ZIO.attempt(c.subscribe(pattern.pattern, runloop.rebalanceListener.toKafka(runtime, rc)))
             case Subscription.Topics(topics) =>
-              ZIO(c.subscribe(topics.asJava, runloop.rebalanceListener.toKafka(runtime, rc)))
+              ZIO.attempt(c.subscribe(topics.asJava, runloop.rebalanceListener.toKafka(runtime, rc)))
 
             // For manual subscriptions we have to do some manual work before starting the run loop
             case Subscription.Manual(topicPartitions) =>
-              ZIO(c.assign(topicPartitions.asJava)) *>
+              ZIO.attempt(c.assign(topicPartitions.asJava)) *>
                 ZIO.foreach(topicPartitions)(runloop.newPartitionStream).flatMap { partitionStreams =>
                   runloop.partitions.offer(
                     Take.chunk(
@@ -298,7 +298,7 @@ object Consumer {
                   settings.offsetRetrieval match {
                     case OffsetRetrieval.Manual(getOffsets) =>
                       getOffsets(topicPartitions).flatMap { offsets =>
-                        ZIO.foreachDiscard(offsets) { case (tp, offset) => ZIO(c.seek(tp, offset)) }
+                        ZIO.foreachDiscard(offsets) { case (tp, offset) => ZIO.attempt(c.seek(tp, offset)) }
                       }
                     case OffsetRetrieval.Auto(_) => ZIO.unit
                   }
@@ -318,16 +318,18 @@ object Consumer {
     ZSink.foldLeft[Offset, OffsetBatch](OffsetBatch.empty)(_ merge _)
 
   def live: RLayer[Clock with ConsumerSettings with Diagnostics, Consumer] =
-    (for {
-      settings    <- ZManaged.service[ConsumerSettings]
-      diagnostics <- ZManaged.service[Diagnostics]
-      consumer    <- make(settings, diagnostics)
-    } yield consumer).toLayer
+    ZLayer.scoped {
+      for {
+        settings    <- ZIO.service[ConsumerSettings]
+        diagnostics <- ZIO.service[Diagnostics]
+        consumer    <- make(settings, diagnostics)
+      } yield consumer
+    }
 
   def make(
     settings: ConsumerSettings,
     diagnostics: Diagnostics = Diagnostics.NoOp
-  ): RManaged[Clock, Consumer] =
+  ): ZIO[Clock with Scope, Throwable, Consumer] =
     for {
       wrapper <- ConsumerAccess.make(settings)
       runloop <- Runloop(
@@ -338,7 +340,7 @@ object Consumer {
                    settings.offsetRetrieval,
                    settings.rebalanceListener
                  )
-      clock <- ZManaged.service[Clock]
+      clock <- ZIO.service[Clock]
     } yield Live(wrapper, settings, runloop, clock)
 
   /**
@@ -471,9 +473,11 @@ object Consumer {
     valueDeserializer: Deserializer[R, V],
     commitRetryPolicy: Schedule[Clock, Any, Any] = Schedule.exponential(1.second) && Schedule.recurs(3)
   )(f: (K, V) => URIO[R1, Unit]): RIO[R with R1 with Clock, Unit] =
-    Consumer
-      .make(settings)
-      .use(_.consumeWith[R, R1, K, V](subscription, keyDeserializer, valueDeserializer, commitRetryPolicy)(f))
+    ZIO.scoped[R with R1 with Clock] {
+      Consumer
+        .make(settings)
+        .flatMap(_.consumeWith[R, R1, K, V](subscription, keyDeserializer, valueDeserializer, commitRetryPolicy)(f))
+    }
 
   /**
    * Accessor method for [[Consumer.subscribe]]

--- a/src/main/scala/zio/kafka/consumer/diagnostics/Diagnostics.scala
+++ b/src/main/scala/zio/kafka/consumer/diagnostics/Diagnostics.scala
@@ -1,6 +1,6 @@
 package zio.kafka.consumer.diagnostics
 
-import zio.{ Managed, Queue, UIO }
+import zio.{ Queue, Scope, UIO, ZIO }
 
 trait Diagnostics {
   val enabled: Boolean = true
@@ -21,7 +21,7 @@ object Diagnostics {
   }
 
   object SlidingQueue {
-    def make(queueSize: Int = 16): Managed[Nothing, SlidingQueue] =
-      Queue.sliding[DiagnosticEvent](queueSize).toManagedWith(_.shutdown).map(SlidingQueue(_))
+    def make(queueSize: Int = 16): ZIO[Scope, Nothing, SlidingQueue] =
+      ZIO.acquireRelease(Queue.sliding[DiagnosticEvent](queueSize))(_.shutdown).map(SlidingQueue(_))
   }
 }

--- a/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -14,7 +14,7 @@ private[consumer] class ConsumerAccess(
   access: Semaphore
 ) {
   def withConsumer[A](f: ByteArrayKafkaConsumer => A): Task[A] =
-    withConsumerM[Any, A](c => ZIO(f(c)))
+    withConsumerM[Any, A](c => ZIO.attempt(f(c)))
 
   def withConsumerM[R, A](f: ByteArrayKafkaConsumer => RIO[R, A]): RIO[R, A] =
     access.withPermit(withConsumerNoPermit(f))
@@ -34,15 +34,19 @@ private[consumer] class ConsumerAccess(
 private[consumer] object ConsumerAccess {
   type ByteArrayKafkaConsumer = KafkaConsumer[Array[Byte], Array[Byte]]
 
-  def make(settings: ConsumerSettings): TaskManaged[ConsumerAccess] =
+  def make(settings: ConsumerSettings): ZIO[Scope, Throwable, ConsumerAccess] =
     for {
-      access <- Semaphore.make(1).toManaged
-      consumer <- ZIO.attemptBlocking {
-                    new KafkaConsumer[Array[Byte], Array[Byte]](
-                      settings.driverSettings.asJava,
-                      new ByteArrayDeserializer(),
-                      new ByteArrayDeserializer()
-                    )
-                  }.toManagedWith(c => ZIO.blocking(access.withPermit(UIO(c.close(settings.closeTimeout)))))
+      access <- Semaphore.make(1)
+      consumer <- ZIO.acquireRelease {
+                    ZIO.attemptBlocking {
+                      new KafkaConsumer[Array[Byte], Array[Byte]](
+                        settings.driverSettings.asJava,
+                        new ByteArrayDeserializer(),
+                        new ByteArrayDeserializer()
+                      )
+                    }
+                  } { consumer =>
+                    ZIO.blocking(access.withPermit(UIO.succeed(consumer.close(settings.closeTimeout))))
+                  }
     } yield new ConsumerAccess(consumer, access)
 }

--- a/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -94,7 +94,7 @@ private[consumer] final class Runloop(
         consumer.withConsumerM { c =>
           // We don't wait for the completion of the commit here, because it
           // will only complete once we poll again.
-          ZIO(c.commitAsync(offsets.asJava, callback))
+          ZIO.attempt(c.commitAsync(offsets.asJava, callback))
         }
       }
       .catchAll(onFailure)
@@ -221,7 +221,7 @@ private[consumer] final class Runloop(
     offsetRetrieval match {
       case OffsetRetrieval.Manual(getOffsets) =>
         getOffsets(tps)
-          .tap(offsets => ZIO.foreachDiscard(offsets) { case (tp, offset) => ZIO(c.seek(tp, offset)) })
+          .tap(offsets => ZIO.foreachDiscard(offsets) { case (tp, offset) => ZIO.attempt(c.seek(tp, offset)) })
           .when(tps.nonEmpty)
           .unit
 
@@ -385,7 +385,7 @@ private[consumer] final class Runloop(
     cmd match {
       case Command.Poll() =>
         // The consumer will throw an IllegalStateException if no call to subscribe
-        ZIO.ifZIO(subscribedRef.get)(handlePoll(state), UIO(state))
+        ZIO.ifZIO(subscribedRef.get)(handlePoll(state), UIO.succeed(state))
       case Command.Requests(reqs) =>
         handleRequests(state, reqs).flatMap { state =>
           // Optimization: eagerly poll if we have pending requests instead of waiting
@@ -397,7 +397,7 @@ private[consumer] final class Runloop(
         handleCommit(state, cmd)
     }
 
-  def run: URManaged[Clock, Fiber.Runtime[Throwable, Unit]] =
+  def run: ZIO[Clock with Scope, Throwable, Fiber.Runtime[Throwable, Unit]] =
     ZStream
       .mergeAll(3, 1)(
         ZStream(Command.Poll()).repeat(Schedule.spaced(pollFrequency)),
@@ -409,8 +409,7 @@ private[consumer] final class Runloop(
       }
       .onError(cause => partitions.offer(Take.failCause(cause)))
       .unit
-      .toManaged
-      .fork
+      .forkScoped
 }
 
 private[consumer] object Runloop {
@@ -448,28 +447,31 @@ private[consumer] object Runloop {
     diagnostics: Diagnostics,
     offsetRetrieval: OffsetRetrieval,
     userRebalanceListener: RebalanceListener
-  ): RManaged[Clock, Runloop] =
+  ): ZIO[Clock with Scope, Throwable, Runloop] =
     for {
-      rebalancingRef <- Ref.make(false).toManaged
-      requestQueue   <- Queue.unbounded[Runloop.Request].toManagedWith(_.shutdown)
-      commitQueue    <- Queue.unbounded[Command.Commit].toManagedWith(_.shutdown)
-      partitions <- Queue
-                      .unbounded[
-                        Take[Throwable, (TopicPartition, Stream[Throwable, ByteArrayCommittableRecord])]
-                      ]
-                      .map { queue =>
-                        queue
-                          .mapZIO(
-                            _.fold(
-                              queue.shutdown.as(Take.end),
-                              cause => UIO.succeed(Take.failCause(cause)),
-                              chunk => UIO.succeed(Take.chunk(chunk))
+      rebalancingRef <- Ref.make(false)
+      requestQueue   <- ZIO.acquireRelease(Queue.unbounded[Runloop.Request])(_.shutdown)
+      commitQueue    <- ZIO.acquireRelease(Queue.unbounded[Command.Commit])(_.shutdown)
+      partitions <- ZIO.acquireRelease {
+                      Queue
+                        .unbounded[
+                          Take[Throwable, (TopicPartition, Stream[Throwable, ByteArrayCommittableRecord])]
+                        ]
+                        .map { queue =>
+                          queue
+                            .mapZIO(
+                              _.fold(
+                                queue.shutdown.as(Take.end),
+                                cause => UIO.succeed(Take.failCause(cause)),
+                                chunk => UIO.succeed(Take.chunk(chunk))
+                              )
                             )
-                          )
-                      }
-                      .toManagedWith(_.shutdown)
-      shutdownRef   <- Ref.make(false).toManaged
-      subscribedRef <- Ref.make(false).toManaged
+                        }
+                    } { queue =>
+                      queue.shutdown
+                    }
+      shutdownRef   <- Ref.make(false)
+      subscribedRef <- Ref.make(false)
       runloop = new Runloop(
                   consumer,
                   pollFrequency,

--- a/src/main/scala/zio/kafka/serde/Deserializer.scala
+++ b/src/main/scala/zio/kafka/serde/Deserializer.scala
@@ -78,11 +78,12 @@ object Deserializer extends Serdes {
     props: Map[String, AnyRef],
     isKey: Boolean
   ): Task[Deserializer[Any, T]] =
-    Task(deserializer.configure(props.asJava, isKey))
+    Task
+      .attempt(deserializer.configure(props.asJava, isKey))
       .as(
         new Deserializer[Any, T] {
           override def deserialize(topic: String, headers: Headers, data: Array[Byte]): Task[T] =
-            Task(deserializer.deserialize(topic, headers, data))
+            Task.attempt(deserializer.deserialize(topic, headers, data))
         }
       )
 }

--- a/src/main/scala/zio/kafka/serde/Serde.scala
+++ b/src/main/scala/zio/kafka/serde/Serde.scala
@@ -74,17 +74,18 @@ object Serde extends Serdes {
    * Create a Serde from a Kafka Serde
    */
   def fromKafkaSerde[T](serde: KafkaSerde[T], props: Map[String, AnyRef], isKey: Boolean) =
-    Task(serde.configure(props.asJava, isKey))
+    Task
+      .attempt(serde.configure(props.asJava, isKey))
       .as(
         new Serde[Any, T] {
           val serializer   = serde.serializer()
           val deserializer = serde.deserializer()
 
           override def deserialize(topic: String, headers: Headers, data: Array[Byte]): Task[T] =
-            Task(deserializer.deserialize(topic, headers, data))
+            Task.attempt(deserializer.deserialize(topic, headers, data))
 
           override def serialize(topic: String, headers: Headers, value: T): Task[Array[Byte]] =
-            Task(serializer.serialize(topic, headers, value))
+            Task.attempt(serializer.serialize(topic, headers, value))
         }
       )
 

--- a/src/main/scala/zio/kafka/serde/Serdes.scala
+++ b/src/main/scala/zio/kafka/serde/Serdes.scala
@@ -24,9 +24,9 @@ private[zio] trait Serdes {
       val deserializer = serde.deserializer()
 
       override def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[Any, T] =
-        Task(deserializer.deserialize(topic, headers, data))
+        Task.attempt(deserializer.deserialize(topic, headers, data))
 
       override def serialize(topic: String, headers: Headers, value: T): RIO[Any, Array[Byte]] =
-        Task(serializer.serialize(topic, headers, value))
+        Task.attempt(serializer.serialize(topic, headers, value))
     }
 }

--- a/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -60,11 +60,12 @@ object Serializer extends Serdes {
     props: Map[String, AnyRef],
     isKey: Boolean
   ): Task[Serializer[Any, T]] =
-    Task(serializer.configure(props.asJava, isKey))
+    Task
+      .attempt(serializer.configure(props.asJava, isKey))
       .as(
         new Serializer[Any, T] {
           override def serialize(topic: String, headers: Headers, value: T): Task[Array[Byte]] =
-            Task(serializer.serialize(topic, headers, value))
+            Task.attempt(serializer.serialize(topic, headers, value))
         }
       )
 

--- a/src/test/scala/zio/kafka/Benchmarks.scala
+++ b/src/test/scala/zio/kafka/Benchmarks.scala
@@ -25,7 +25,7 @@ object PopulateTopic extends ZIOAppDefault {
       .mapZIOPar(5)(_.flatMap(chunk => Console.printLine(s"Wrote chunk of ${chunk.size}")))
       .runDrain
       .provideCustomLayer(
-        ZLayer.fromManaged(
+        ZLayer.scoped[Any](
           Producer.make(
             ProducerSettings(List("localhost:9092"))
               .withProperty(ProducerConfig.ACKS_CONFIG, "1")
@@ -109,7 +109,7 @@ object ZIOKafka extends ZIOAppDefault {
               )
             }
         })
-      .provideCustomLayer(ZLayer.fromManaged(Consumer.make(settings)))
+      .provideCustomLayer(ZLayer.scoped(Consumer.make(settings)))
       .exitCode
 
   }

--- a/src/test/scala/zio/kafka/ConsumerSpec.scala
+++ b/src/test/scala/zio/kafka/ConsumerSpec.scala
@@ -135,7 +135,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
           _ <- ZIO.foreach(1 to nrPartitions) { i =>
                  produceMany(topic, partition = i % nrPartitions, kvs = (0 to 9).map(j => s"key$i-$j" -> s"msg$i-$j"))
                }
-          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
+          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO.attempt(tps.map(_ -> manualOffsetSeek.toLong).toMap))
           record <- Consumer
                       .subscribeAnd(Subscription.manual(topic, partition = 2))
                       .plainStream(Serde.string, Serde.string)
@@ -200,7 +200,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
           // Produce messages on several partitions
           topic <- randomTopic
           group <- randomGroup
-          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+          _     <- Task.attempt(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
           _ <- ZIO.foreach(1 to nrMessages) { i =>
                  produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
                }
@@ -289,7 +289,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
           // Produce messages on several partitions
           topic <- randomTopic
           group <- randomGroup
-          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+          _     <- Task.attempt(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
           _ <- ZIO.foreach(1 to nrMessages) { i =>
                  produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
                }
@@ -318,7 +318,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
           // Produce messages on several partitions
           topic <- randomTopic
           group <- randomGroup
-          _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+          _     <- Task.attempt(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
           _ <- ZIO.foreach(1 to nrMessages) { i =>
                  produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
                }
@@ -353,53 +353,54 @@ object ConsumerSpec extends DefaultRunnableSpec {
         val nrMessages   = 50
         val nrPartitions = 6
 
-        Diagnostics.SlidingQueue
-          .make()
-          .use { diagnostics =>
-            for {
-              // Produce messages on several partitions
-              topic <- randomTopic
-              group <- randomGroup
-              _     <- Task(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
-              _ <- ZIO.foreach(1 to nrMessages) { i =>
-                     produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
-                   }
+        ZIO.scoped {
+          Diagnostics.SlidingQueue
+            .make()
+            .flatMap { diagnostics =>
+              for {
+                // Produce messages on several partitions
+                topic <- randomTopic
+                group <- randomGroup
+                _     <- Task.attempt(EmbeddedKafka.createCustomTopic(topic, partitions = nrPartitions))
+                _ <- ZIO.foreach(1 to nrMessages) { i =>
+                       produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
+                     }
 
-              // Consume messages
-              subscription = Subscription.topics(topic)
-              consumer1 <- Consumer
-                             .subscribeAnd(subscription)
-                             .partitionedStream(Serde.string, Serde.string)
-                             .flatMapPar(nrPartitions) { case (tp, partition) =>
-                               ZStream
-                                 .fromZIO(partition.runDrain)
-                                 .as(tp)
-                             }
-                             .take(nrPartitions.toLong / 2)
-                             .runDrain
-                             .provideSomeLayer[Kafka with Clock](
-                               consumer("client1", Some(group), diagnostics = diagnostics)
-                             )
-                             .fork
-              diagnosticStream <- ZStream
-                                    .fromQueue(diagnostics.queue)
-                                    .collect { case rebalance: DiagnosticEvent.Rebalance => rebalance }
-                                    .runCollect
-                                    .fork
-              _ <- ZIO.sleep(5.seconds)
-              consumer2 <- Consumer
-                             .subscribeAnd(subscription)
-                             .partitionedStream(Serde.string, Serde.string)
-                             .take(nrPartitions.toLong / 2)
-                             .runDrain
-                             .provideSomeLayer[Kafka with Clock](consumer("client2", Some(group)))
-                             .fork
-              _ <- consumer1.join
-              _ <- consumer1.join
-              _ <- consumer2.join
-            } yield diagnosticStream.join
-          }
-          .flatten
+                // Consume messages
+                subscription = Subscription.topics(topic)
+                consumer1 <- Consumer
+                               .subscribeAnd(subscription)
+                               .partitionedStream(Serde.string, Serde.string)
+                               .flatMapPar(nrPartitions) { case (tp, partition) =>
+                                 ZStream
+                                   .fromZIO(partition.runDrain)
+                                   .as(tp)
+                               }
+                               .take(nrPartitions.toLong / 2)
+                               .runDrain
+                               .provideSomeLayer[Kafka with Clock](
+                                 consumer("client1", Some(group), diagnostics = diagnostics)
+                               )
+                               .fork
+                diagnosticStream <- ZStream
+                                      .fromQueue(diagnostics.queue)
+                                      .collect { case rebalance: DiagnosticEvent.Rebalance => rebalance }
+                                      .runCollect
+                                      .fork
+                _ <- ZIO.sleep(5.seconds)
+                consumer2 <- Consumer
+                               .subscribeAnd(subscription)
+                               .partitionedStream(Serde.string, Serde.string)
+                               .take(nrPartitions.toLong / 2)
+                               .runDrain
+                               .provideSomeLayer[Kafka with Clock](consumer("client2", Some(group)))
+                               .fork
+                _ <- consumer1.join
+                _ <- consumer1.join
+                _ <- consumer2.join
+              } yield diagnosticStream.join
+            }
+        }.flatten
           .map(diagnosticEvents => assert(diagnosticEvents.size)(isGreaterThanEqualTo(2)))
       },
       test("support manual seeking") {
@@ -426,7 +427,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
                  .runCollect
                  .provideSomeLayer[Kafka with Clock](consumer("client1", Some("group1")))
           // Start a new consumer with manual offset before the committed offset
-          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO(tps.map(_ -> manualOffsetSeek.toLong).toMap))
+          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO.attempt(tps.map(_ -> manualOffsetSeek.toLong).toMap))
           secondResults <- Consumer
                              .subscribeAnd(Subscription.topics(topic))
                              .plainStream(Serde.string, Serde.string)
@@ -450,7 +451,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
             (for {
               messagesSoFar <- messagesReceived.updateAndGet(_ :+ (key -> value))
               _             <- Task.when(messagesSoFar.size == nrMessages)(done.succeed(()))
-            } yield ()).orDie
+            } yield ())
           }).fork
 
         for {

--- a/src/test/scala/zio/kafka/KafkaFutureSpec.scala
+++ b/src/test/scala/zio/kafka/KafkaFutureSpec.scala
@@ -11,53 +11,63 @@ object KafkaFutureSpec extends DefaultRunnableSpec {
   override def spec =
     suite("kafka future conversion")(
       test("completes successfully") {
-        withKafkaFuture.use { f =>
-          for {
-            fiber  <- AdminClient.fromKafkaFuture(ZIO.succeed(f)).fork
-            _      <- ZIO.succeed(f.complete(true))
-            result <- fiber.await
-          } yield assert(result)(equalTo(Exit.succeed(true))) &&
-            assert(f.isDone)(equalTo(true) ?? "Kafka future is done")
+        ZIO.scoped[Any] {
+          withKafkaFuture.flatMap { f =>
+            for {
+              fiber  <- AdminClient.fromKafkaFuture(ZIO.succeed(f)).fork
+              _      <- ZIO.succeed(f.complete(true))
+              result <- fiber.await
+            } yield assert(result)(equalTo(Exit.succeed(true))) &&
+              assert(f.isDone)(equalTo(true) ?? "Kafka future is done")
+          }
         }
       },
       test("completes with failure") {
-        withKafkaFuture.use { f =>
-          val t = new RuntimeException("failure")
-          for {
-            fiber  <- AdminClient.fromKafkaFuture(ZIO.succeed(f)).fork
-            _      <- ZIO.succeed(f.completeExceptionally(t))
-            result <- fiber.await
-          } yield assert(result)(equalTo(Exit.fail(t))) &&
-            assert(f.isDone)(equalTo(true) ?? "Kafka future is done")
+        ZIO.scoped[Any] {
+          withKafkaFuture.flatMap { f =>
+            val t = new RuntimeException("failure")
+            for {
+              fiber  <- AdminClient.fromKafkaFuture(ZIO.succeed(f)).fork
+              _      <- ZIO.succeed(f.completeExceptionally(t))
+              result <- fiber.await
+            } yield assert(result)(equalTo(Exit.fail(t))) &&
+              assert(f.isDone)(equalTo(true) ?? "Kafka future is done")
+          }
         }
       },
       test("future is cancelled") {
-        withKafkaFuture.use { f =>
-          for {
-            fiber  <- AdminClient.fromKafkaFuture(ZIO.succeed(f)).fork
-            _      <- ZIO.succeed(f.cancel(true))
-            result <- fiber.await
-          } yield assert(result.isInterrupted)(equalTo(true) ?? "fiber was interrupted") &&
-            assert(f.isCancelled)(equalTo(true) ?? "Kafka future was cancelled") &&
-            assert(f.isDone)(equalTo(true) ?? "Kafka future is done")
+        ZIO.scoped[Any] {
+          withKafkaFuture.flatMap { f =>
+            for {
+              fiber  <- AdminClient.fromKafkaFuture(ZIO.succeed(f)).fork
+              _      <- ZIO.succeed(f.cancel(true))
+              result <- fiber.await
+            } yield assert(result.isInterrupted)(equalTo(true) ?? "fiber was interrupted") &&
+              assert(f.isCancelled)(equalTo(true) ?? "Kafka future was cancelled") &&
+              assert(f.isDone)(equalTo(true) ?? "Kafka future is done")
+          }
         }
       },
       test("interrupted") {
-        withKafkaFuture.use { f =>
-          for {
-            latch  <- Promise.make[Nothing, Unit]
-            fiber  <- AdminClient.fromKafkaFuture(latch.succeed(()) *> ZIO.succeed(f)).fork
-            _      <- latch.await
-            result <- fiber.interrupt
-          } yield assert(result.isInterrupted)(equalTo(true) ?? "fiber was interrupted") &&
-            assert(f.isCancelled)(equalTo(true) ?? "Kafka future was cancelled") &&
-            assert(f.isDone)(equalTo(true) ?? "Kafka future is done")
+        ZIO.scoped[Any] {
+          withKafkaFuture.flatMap { f =>
+            for {
+              latch  <- Promise.make[Nothing, Unit]
+              fiber  <- AdminClient.fromKafkaFuture(latch.succeed(()) *> ZIO.succeed(f)).fork
+              _      <- latch.await
+              result <- fiber.interrupt
+            } yield assert(result.isInterrupted)(equalTo(true) ?? "fiber was interrupted") &&
+              assert(f.isCancelled)(equalTo(true) ?? "Kafka future was cancelled") &&
+              assert(f.isDone)(equalTo(true) ?? "Kafka future is done")
+          }
         }
       } @@ flaky
     )
 
   def withKafkaFuture =
-    ZIO.succeed(new KafkaFutureImpl[Boolean]).toManagedWith { f =>
+    ZIO.acquireRelease {
+      ZIO.succeed(new KafkaFutureImpl[Boolean])
+    } { f =>
       ZIO.succeed {
         f.completeExceptionally(new RuntimeException("Kafka future was not completed"))
       }

--- a/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -15,7 +15,7 @@ import zio.test._
 object ProducerSpec extends DefaultRunnableSpec {
   def withConsumerInt(subscription: Subscription, settings: ConsumerSettings) =
     Consumer.make(settings).flatMap { c =>
-      c.subscribe(subscription).toManaged *> c.plainStream(Serde.string, Serde.int).toQueue()
+      c.subscribe(subscription) *> c.plainStream(Serde.string, Serde.int).toQueue()
     }
 
   override def spec =
@@ -35,25 +35,29 @@ object ProducerSpec extends DefaultRunnableSpec {
         )
         def withConsumer(subscription: Subscription, settings: ConsumerSettings) =
           Consumer.make(settings).flatMap { c =>
-            (c.subscribe(subscription).toManaged *> c.plainStream(Serde.string, Serde.string).toQueue())
+            (c.subscribe(subscription) *> c.plainStream(Serde.string, Serde.string).toQueue())
           }
 
         for {
           outcome  <- Producer.produceChunk(chunks, Serde.string, Serde.string)
           settings <- consumerSettings("testClient", Some("testGroup"))
-          record1 <- withConsumer(Topics(Set(topic1)), settings).use { consumer =>
-                       for {
-                         messages <- consumer.take.flatMap(_.done).mapError(_.getOrElse(new NoSuchElementException))
-                         record = messages
-                                    .filter(rec => rec.record.key == key1 && rec.record.value == value1)
-                                    .toSeq
-                       } yield record
+          record1 <- ZIO.scoped {
+                       withConsumer(Topics(Set(topic1)), settings).flatMap { consumer =>
+                         for {
+                           messages <- consumer.take.flatMap(_.done).mapError(_.getOrElse(new NoSuchElementException))
+                           record = messages
+                                      .filter(rec => rec.record.key == key1 && rec.record.value == value1)
+                                      .toSeq
+                         } yield record
+                       }
                      }
-          record2 <- withConsumer(Topics(Set(topic2)), settings).use { consumer =>
-                       for {
-                         messages <- consumer.take.flatMap(_.done).mapError(_.getOrElse(new NoSuchElementException))
-                         record = messages.filter(rec => rec.record.key == key2 && rec.record.value == value2)
-                       } yield record
+          record2 <- ZIO.scoped {
+                       withConsumer(Topics(Set(topic2)), settings).flatMap { consumer =>
+                         for {
+                           messages <- consumer.take.flatMap(_.done).mapError(_.getOrElse(new NoSuchElementException))
+                           record = messages.filter(rec => rec.record.key == key2 && rec.record.value == value2)
+                         } yield record
+                       }
                      }
         } yield assertTrue(outcome.length == 2) &&
           assertTrue(record1.nonEmpty) &&
@@ -77,18 +81,22 @@ object ProducerSpec extends DefaultRunnableSpec {
         val initialBobAccount   = new ProducerRecord("accounts0", "bob", 0)
 
         for {
-          _ <- TransactionalProducer.createTransaction.use { t =>
-                 t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
-                   t.produce(initialAliceAccount, Serde.string, Serde.int, None)
+          _ <- ZIO.scoped {
+                 TransactionalProducer.createTransaction.flatMap { t =>
+                   t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
+                     t.produce(initialAliceAccount, Serde.string, Serde.int, None)
+                 }
                }
           settings <- transactionalConsumerSettings("testGroup0", "testClient0")
-          recordChunk <- withConsumerInt(Topics(Set("accounts0")), settings).use { consumer =>
-                           for {
-                             messages <- consumer.take
-                                           .flatMap(_.done)
-                                           .mapError(_.getOrElse(new NoSuchElementException))
-                             record = messages.filter(rec => rec.record.key == "bob")
-                           } yield record
+          recordChunk <- ZIO.scoped {
+                           withConsumerInt(Topics(Set("accounts0")), settings).flatMap { consumer =>
+                             for {
+                               messages <- consumer.take
+                                             .flatMap(_.done)
+                                             .mapError(_.getOrElse(new NoSuchElementException))
+                               record = messages.filter(rec => rec.record.key == "bob")
+                             } yield record
+                           }
                          }
         } yield assertTrue(recordChunk.map(_.value).last == 0)
       },
@@ -101,25 +109,31 @@ object ProducerSpec extends DefaultRunnableSpec {
         val bobReceives20       = new ProducerRecord("accounts1", "bob", 20)
 
         for {
-          _ <- TransactionalProducer.createTransaction.use { t =>
-                 t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
-                   t.produce(initialAliceAccount, Serde.string, Serde.int, None)
+          _ <- ZIO.scoped {
+                 TransactionalProducer.createTransaction.flatMap { t =>
+                   t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
+                     t.produce(initialAliceAccount, Serde.string, Serde.int, None)
+                 }
                }
-          _ <- TransactionalProducer.createTransaction.use { t =>
-                 t.produce(aliceGives20, Serde.string, Serde.int, None) *>
-                   t.produce(bobReceives20, Serde.string, Serde.int, None) *>
-                   t.abort
+          _ <- ZIO.scoped {
+                 TransactionalProducer.createTransaction.flatMap { t =>
+                   t.produce(aliceGives20, Serde.string, Serde.int, None) *>
+                     t.produce(bobReceives20, Serde.string, Serde.int, None) *>
+                     t.abort
+                 }
                }.catchSome { case UserInitiatedAbort =>
                  ZIO.unit // silences the abort
                }
           settings <- transactionalConsumerSettings("testGroup1", "testClient1")
-          recordChunk <- withConsumerInt(Topics(Set("accounts1")), settings).use { consumer =>
-                           for {
-                             messages <- consumer.take
-                                           .flatMap(_.done)
-                                           .mapError(_.getOrElse(new NoSuchElementException))
-                             record = messages.filter(rec => rec.record.key == "bob")
-                           } yield record
+          recordChunk <- ZIO.scoped {
+                           withConsumerInt(Topics(Set("accounts1")), settings).flatMap { consumer =>
+                             for {
+                               messages <- consumer.take
+                                             .flatMap(_.done)
+                                             .mapError(_.getOrElse(new NoSuchElementException))
+                               record = messages.filter(rec => rec.record.key == "bob")
+                             } yield record
+                           }
                          }
         } yield assertTrue(recordChunk.map(_.value).last == 0)
       },
@@ -129,35 +143,43 @@ object ProducerSpec extends DefaultRunnableSpec {
         val initialAliceAccount = new ProducerRecord("accounts2", "alice", 20)
         val initialBobAccount   = new ProducerRecord("accounts2", "bob", 0)
 
-        val transaction1 = TransactionalProducer.createTransaction.use { t =>
-          t.produce(initialAliceAccount, Serde.string, Serde.int, None)
+        val transaction1 = ZIO.scoped {
+          TransactionalProducer.createTransaction.flatMap { t =>
+            t.produce(initialAliceAccount, Serde.string, Serde.int, None)
+          }
         }
-        val transaction2 = TransactionalProducer.createTransaction.use { t =>
-          t.produce(initialBobAccount, Serde.string, Serde.int, None)
+        val transaction2 = ZIO.scoped {
+          TransactionalProducer.createTransaction.flatMap { t =>
+            t.produce(initialBobAccount, Serde.string, Serde.int, None)
+          }
         }
 
         for {
           _        <- transaction1 <&> transaction2
           settings <- transactionalConsumerSettings("testGroup2", "testClient2")
-          recordChunk <- withConsumerInt(Topics(Set("accounts2")), settings).use { consumer =>
-                           for {
-                             messages <- consumer.take
-                                           .flatMap(_.done)
-                                           .mapError(_.getOrElse(new NoSuchElementException))
-                           } yield messages
+          recordChunk <- ZIO.scoped {
+                           withConsumerInt(Topics(Set("accounts2")), settings).flatMap { consumer =>
+                             for {
+                               messages <- consumer.take
+                                             .flatMap(_.done)
+                                             .mapError(_.getOrElse(new NoSuchElementException))
+                             } yield messages
+                           }
                          }
         } yield assert(recordChunk.map(_.value))(contains(0) && contains(20))
       },
       test("exception management") {
         val initialBobAccount = new ProducerRecord("accounts3", "bob", 0)
 
-        val failingTransaction1 = TransactionalProducer.createTransaction.use { t =>
-          t.produce(
-            initialBobAccount,
-            Serde.string,
-            Serde.int.contramap((_: Int) => throw new RuntimeException("test")),
-            None
-          )
+        val failingTransaction1 = ZIO.scoped {
+          TransactionalProducer.createTransaction.flatMap { t =>
+            t.produce(
+              initialBobAccount,
+              Serde.string,
+              Serde.int.contramap((_: Int) => throw new RuntimeException("test")),
+              None
+            )
+          }
         }
 
         assertM(failingTransaction1.unit.exit)(dies(hasMessage(equalTo("test"))))
@@ -171,24 +193,31 @@ object ProducerSpec extends DefaultRunnableSpec {
         val aliceGives20        = new ProducerRecord("accounts4", "alice", 0)
 
         for {
-          _ <- TransactionalProducer.createTransaction.use { t =>
-                 t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
-                   t.produce(initialAliceAccount, Serde.string, Serde.int, None)
+          _ <- ZIO.scoped {
+                 TransactionalProducer.createTransaction.flatMap { t =>
+                   t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
+                     t.produce(initialAliceAccount, Serde.string, Serde.int, None)
+                 }
                }
-          assertion <- TransactionalProducer.createTransaction.use { t =>
-                         for {
-                           _        <- t.produce(aliceGives20, Serde.string, Serde.int, None)
-                           _        <- Producer.produce(nonTransactional, Serde.string, Serde.int)
-                           settings <- consumerSettings("testClient4", Some("testGroup4"))
-                           recordChunk <- withConsumerInt(Topics(Set("accounts4")), settings).use { consumer =>
-                                            for {
-                                              messages <- consumer.take
-                                                            .flatMap(_.done)
-                                                            .mapError(_.getOrElse(new NoSuchElementException))
-                                              record = messages.filter(rec => rec.record.key == "no one")
-                                            } yield record
-                                          }
-                         } yield assertTrue(recordChunk.nonEmpty)
+          assertion <- ZIO.scoped {
+                         TransactionalProducer.createTransaction.flatMap { t =>
+                           for {
+                             _        <- t.produce(aliceGives20, Serde.string, Serde.int, None)
+                             _        <- Producer.produce(nonTransactional, Serde.string, Serde.int)
+                             settings <- consumerSettings("testClient4", Some("testGroup4"))
+                             recordChunk <- ZIO.scoped {
+                                              withConsumerInt(Topics(Set("accounts4")), settings).flatMap { consumer =>
+                                                for {
+                                                  messages <- consumer.take
+                                                                .flatMap(_.done)
+                                                                .mapError(_.getOrElse(new NoSuchElementException))
+                                                  record = messages.filter(rec => rec.record.key == "no one")
+                                                } yield record
+
+                                              }
+                                            }
+                           } yield assertTrue(recordChunk.nonEmpty)
+                         }
                        }
         } yield assertion
       },
@@ -201,24 +230,30 @@ object ProducerSpec extends DefaultRunnableSpec {
         val aliceGives20        = new ProducerRecord("accounts5", "alice", 0)
 
         for {
-          _ <- TransactionalProducer.createTransaction.use { t =>
-                 t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
-                   t.produce(initialAliceAccount, Serde.string, Serde.int, None)
+          _ <- ZIO.scoped {
+                 TransactionalProducer.createTransaction.flatMap { t =>
+                   t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
+                     t.produce(initialAliceAccount, Serde.string, Serde.int, None)
+                 }
                }
-          assertion <- TransactionalProducer.createTransaction.use { t =>
-                         for {
-                           _        <- t.produce(aliceGives20, Serde.string, Serde.int, None)
-                           _        <- Producer.produce(nonTransactional, Serde.string, Serde.int)
-                           settings <- transactionalConsumerSettings("testGroup5", "testClient5")
-                           recordChunk <- withConsumerInt(Topics(Set("accounts5")), settings).use { consumer =>
-                                            for {
-                                              messages <- consumer.take
-                                                            .flatMap(_.done)
-                                                            .mapError(_.getOrElse(new NoSuchElementException))
-                                              record = messages.filter(rec => rec.record.key == "no one")
-                                            } yield record
-                                          }
-                         } yield assertTrue(recordChunk.isEmpty)
+          assertion <- ZIO.scoped {
+                         TransactionalProducer.createTransaction.flatMap { t =>
+                           for {
+                             _        <- t.produce(aliceGives20, Serde.string, Serde.int, None)
+                             _        <- Producer.produce(nonTransactional, Serde.string, Serde.int)
+                             settings <- transactionalConsumerSettings("testGroup5", "testClient5")
+                             recordChunk <- ZIO.scoped {
+                                              withConsumerInt(Topics(Set("accounts5")), settings).flatMap { consumer =>
+                                                for {
+                                                  messages <- consumer.take
+                                                                .flatMap(_.done)
+                                                                .mapError(_.getOrElse(new NoSuchElementException))
+                                                  record = messages.filter(rec => rec.record.key == "no one")
+                                                } yield record
+                                              }
+                                            }
+                           } yield assertTrue(recordChunk.isEmpty)
+                         }
                        }
         } yield assertion
       },
@@ -232,26 +267,32 @@ object ProducerSpec extends DefaultRunnableSpec {
         val bobReceives20       = new ProducerRecord("accounts6", "bob", 20)
 
         for {
-          _ <- TransactionalProducer.createTransaction.use { t =>
-                 t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
-                   t.produce(initialAliceAccount, Serde.string, Serde.int, None)
+          _ <- ZIO.scoped {
+                 TransactionalProducer.createTransaction.flatMap { t =>
+                   t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
+                     t.produce(initialAliceAccount, Serde.string, Serde.int, None)
+                 }
                }
-          _ <- TransactionalProducer.createTransaction.use { t =>
-                 t.produce(aliceGives20, Serde.string, Serde.int, None) *>
-                   Producer.produce(nonTransactional, Serde.string, Serde.int) *>
-                   t.produce(bobReceives20, Serde.string, Serde.int, None) *>
-                   t.abort
+          _ <- ZIO.scoped {
+                 TransactionalProducer.createTransaction.flatMap { t =>
+                   t.produce(aliceGives20, Serde.string, Serde.int, None) *>
+                     Producer.produce(nonTransactional, Serde.string, Serde.int) *>
+                     t.produce(bobReceives20, Serde.string, Serde.int, None) *>
+                     t.abort
+                 }
                }.catchSome { case UserInitiatedAbort =>
                  ZIO.unit // silences the abort
                }
           settings <- transactionalConsumerSettings("testGroup6", "testClient6")
-          recordChunk <- withConsumerInt(Topics(Set("accounts6")), settings).use { consumer =>
-                           for {
-                             messages <- consumer.take
-                                           .flatMap(_.done)
-                                           .mapError(_.getOrElse(new NoSuchElementException))
-                             record = messages.filter(rec => rec.record.key == "no one")
-                           } yield record
+          recordChunk <- ZIO.scoped {
+                           withConsumerInt(Topics(Set("accounts6")), settings).flatMap { consumer =>
+                             for {
+                               messages <- consumer.take
+                                             .flatMap(_.done)
+                                             .mapError(_.getOrElse(new NoSuchElementException))
+                               record = messages.filter(rec => rec.record.key == "no one")
+                             } yield record
+                           }
                          }
         } yield assertTrue(recordChunk.nonEmpty)
       },
@@ -265,30 +306,38 @@ object ProducerSpec extends DefaultRunnableSpec {
           _        <- Producer.produce(initialAliceAccount, Serde.string, Serde.int)
           settings <- transactionalConsumerSettings("testGroup7", "testClient7")
           committedOffset <-
-            Consumer.make(settings).use { c =>
-              c.subscribe(Topics(Set("accounts7"))) *> c
-                .plainStream(Serde.string, Serde.int)
-                .toQueue()
-                .use { q =>
-                  val readAliceAccount = for {
-                    messages <- q.take
-                                  .flatMap(_.done)
-                                  .mapError(_.getOrElse(new NoSuchElementException))
-                  } yield messages.head
-                  for {
-                    aliceHadMoneyCommittableMessage <- readAliceAccount
-                    _ <- TransactionalProducer.createTransaction.use { t =>
-                           t.produce(
-                             AliceAccountFeesPaid,
-                             Serde.string,
-                             Serde.int,
-                             Some(aliceHadMoneyCommittableMessage.offset)
-                           )
-                         }
-                    aliceTopicPartition = new TopicPartition("accounts7", aliceHadMoneyCommittableMessage.partition)
-                    committed <- c.committed(Set(aliceTopicPartition))
-                  } yield committed(aliceTopicPartition)
-                }
+            ZIO.scoped {
+              Consumer.make(settings).flatMap { c =>
+                c.subscribe(Topics(Set("accounts7"))) *>
+                  ZIO.scoped {
+                    c
+                      .plainStream(Serde.string, Serde.int)
+                      .toQueue()
+                      .flatMap { q =>
+                        val readAliceAccount = for {
+                          messages <- q.take
+                                        .flatMap(_.done)
+                                        .mapError(_.getOrElse(new NoSuchElementException))
+                        } yield messages.head
+                        for {
+                          aliceHadMoneyCommittableMessage <- readAliceAccount
+                          _ <- ZIO.scoped {
+                                 TransactionalProducer.createTransaction.flatMap { t =>
+                                   t.produce(
+                                     AliceAccountFeesPaid,
+                                     Serde.string,
+                                     Serde.int,
+                                     Some(aliceHadMoneyCommittableMessage.offset)
+                                   )
+                                 }
+                               }
+                          aliceTopicPartition =
+                            new TopicPartition("accounts7", aliceHadMoneyCommittableMessage.partition)
+                          committed <- c.committed(Set(aliceTopicPartition))
+                        } yield committed(aliceTopicPartition)
+                      }
+                  }
+              }
             }
 
         } yield assertTrue(committedOffset.get.offset() == 1L)
@@ -302,34 +351,38 @@ object ProducerSpec extends DefaultRunnableSpec {
         for {
           _        <- Producer.produce(initialAliceAccount, Serde.string, Serde.int)
           settings <- transactionalConsumerSettings("testGroup8", "testClient8")
-          committedOffset <- Consumer.make(settings).use { c =>
-                               c.subscribe(Topics(Set("accounts8"))) *> c
-                                 .plainStream(Serde.string, Serde.int)
-                                 .toQueue()
-                                 .use { q =>
-                                   val readAliceAccount = for {
-                                     messages <- q.take
-                                                   .flatMap(_.done)
-                                                   .mapError(_.getOrElse(new NoSuchElementException))
-                                   } yield messages.head
-                                   for {
-                                     aliceHadMoneyCommittableMessage <- readAliceAccount
-                                     _ <- TransactionalProducer.createTransaction.use { t =>
-                                            t.produce(
-                                              AliceAccountFeesPaid,
-                                              Serde.string,
-                                              Serde.int,
-                                              Some(aliceHadMoneyCommittableMessage.offset)
-                                            ) *>
-                                              t.abort
-                                          }.catchSome { case UserInitiatedAbort =>
-                                            ZIO.unit // silences the abort
-                                          }
-                                     aliceTopicPartition =
-                                       new TopicPartition("accounts8", aliceHadMoneyCommittableMessage.partition)
-                                     committed <- c.committed(Set(aliceTopicPartition))
-                                   } yield committed(aliceTopicPartition)
-                                 }
+          committedOffset <- ZIO.scoped {
+                               Consumer.make(settings).flatMap { c =>
+                                 c.subscribe(Topics(Set("accounts8"))) *> c
+                                   .plainStream(Serde.string, Serde.int)
+                                   .toQueue()
+                                   .flatMap { q =>
+                                     val readAliceAccount = for {
+                                       messages <- q.take
+                                                     .flatMap(_.done)
+                                                     .mapError(_.getOrElse(new NoSuchElementException))
+                                     } yield messages.head
+                                     for {
+                                       aliceHadMoneyCommittableMessage <- readAliceAccount
+                                       _ <- ZIO.scoped {
+                                              TransactionalProducer.createTransaction.flatMap { t =>
+                                                t.produce(
+                                                  AliceAccountFeesPaid,
+                                                  Serde.string,
+                                                  Serde.int,
+                                                  Some(aliceHadMoneyCommittableMessage.offset)
+                                                ) *>
+                                                  t.abort
+                                              }
+                                            }.catchSome { case UserInitiatedAbort =>
+                                              ZIO.unit // silences the abort
+                                            }
+                                       aliceTopicPartition =
+                                         new TopicPartition("accounts8", aliceHadMoneyCommittableMessage.partition)
+                                       committed <- c.committed(Set(aliceTopicPartition))
+                                     } yield committed(aliceTopicPartition)
+                                   }
+                               }
                              }
 
         } yield assert(committedOffset)(isNone)
@@ -337,8 +390,10 @@ object ProducerSpec extends DefaultRunnableSpec {
       test("fails if transaction leaks") {
         val test = for {
           transactionThief <- Ref.make(Option.empty[Transaction])
-          _ <- TransactionalProducer.createTransaction.use { t =>
-                 transactionThief.set(Some(t))
+          _ <- ZIO.scoped {
+                 TransactionalProducer.createTransaction.flatMap { t =>
+                   transactionThief.set(Some(t))
+                 }
                }
           t <- transactionThief.get
           _ <- t.get.produce("any-topic", 0, 0, Serde.int, Serde.int, None)
@@ -348,12 +403,16 @@ object ProducerSpec extends DefaultRunnableSpec {
       test("fails if transaction leaks in an open transaction") {
         val test = for {
           transactionThief <- Ref.make(Option.empty[Transaction])
-          _ <- TransactionalProducer.createTransaction.use { t =>
-                 transactionThief.set(Some(t))
+          _ <- ZIO.scoped {
+                 TransactionalProducer.createTransaction.flatMap { t =>
+                   transactionThief.set(Some(t))
+                 }
                }
           t <- transactionThief.get
-          _ <- TransactionalProducer.createTransaction.use { _ =>
-                 t.get.produce("any-topic", 0, 0, Serde.int, Serde.int, None)
+          _ <- ZIO.scoped {
+                 TransactionalProducer.createTransaction.flatMap { _ =>
+                   t.get.produce("any-topic", 0, 0, Serde.int, Serde.int, None)
+                 }
                }
         } yield ()
         assertM(test.exit)(failsCause(containsCause(Cause.fail(TransactionLeaked(OffsetBatch.empty)))))

--- a/src/test/scala/zio/kafka/embedded/Kafka.scala
+++ b/src/test/scala/zio/kafka/embedded/Kafka.scala
@@ -20,11 +20,11 @@ object Kafka {
     override def stop(): UIO[Unit]              = UIO.unit
   }
 
-  val embedded: ZLayer[Any, Throwable, Kafka] = ZLayer.fromManaged {
+  val embedded: ZLayer[Any, Throwable, Kafka] = ZLayer.scoped {
     implicit val embeddedKafkaConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
       customBrokerProperties = Map("group.min.session.timeout.ms" -> "500", "group.initial.rebalance.delay.ms" -> "0")
     )
-    ZManaged.acquireReleaseWith(ZIO.attempt(EmbeddedKafkaService(EmbeddedKafka.start())))(_.stop())
+    ZIO.acquireRelease(ZIO.attempt(EmbeddedKafkaService(EmbeddedKafka.start())))(_.stop())
   }
 
   val local: ZLayer[Any, Nothing, Kafka] = ZLayer.succeed(DefaultLocal)


### PR DESCRIPTION
A more incremental approach to #454. Only upgrades to `RC3` for now but all tests are passing and this gets over the hump of the `Scope` changes. Will try to upgrade to `RC4` and `RC5` next.