### PR TITLE
Fix Serializer#asOption

### DIFF
--- a/src/main/scala/zio/kafka/serde/Deserializer.scala
+++ b/src/main/scala/zio/kafka/serde/Deserializer.scala
@@ -55,7 +55,7 @@ trait Deserializer[-R, +T] {
   /**
    * Returns a new deserializer that deserializes values as Option values, mapping null data to None values.
    */
-  def asOption(implicit ev: T <:< AnyRef): Deserializer[R, Option[T]] =
+  def asOption: Deserializer[R, Option[T]] =
     Deserializer((topic, headers, data) => ZIO.foreach(Option(data))(deserialize(topic, headers, _)))
 }
 

--- a/src/main/scala/zio/kafka/serde/Deserializer.scala
+++ b/src/main/scala/zio/kafka/serde/Deserializer.scala
@@ -4,9 +4,8 @@ import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.{ Deserializer => KafkaDeserializer }
 import zio.{ RIO, Task, ZIO }
 
-import scala.annotation.nowarn
-import scala.util.{ Failure, Success, Try }
 import scala.jdk.CollectionConverters._
+import scala.util.{ Failure, Success, Try }
 
 /**
  * Deserializer from byte array to a value of some type T
@@ -56,7 +55,7 @@ trait Deserializer[-R, +T] {
   /**
    * Returns a new deserializer that deserializes values as Option values, mapping null data to None values.
    */
-  def asOption(implicit @nowarn ev: T <:< AnyRef): Deserializer[R, Option[T]] =
+  def asOption(implicit ev: T <:< AnyRef): Deserializer[R, Option[T]] =
     Deserializer((topic, headers, data) => ZIO.foreach(Option(data))(deserialize(topic, headers, _)))
 }
 

--- a/src/main/scala/zio/kafka/serde/Serde.scala
+++ b/src/main/scala/zio/kafka/serde/Serde.scala
@@ -20,7 +20,7 @@ trait Serde[-R, T] extends Deserializer[R, T] with Serializer[R, T] {
   /**
    * Creates a new Serde that uses optional values. Null data will be mapped to None values.
    */
-  def asOption(implicit ev: T <:< AnyRef, ev2: Null <:< T): Serde[R, Option[T]] =
+  override def asOption(implicit ev: T <:< AnyRef): Serde[R, Option[T]] =
     Serde(super[Deserializer].asOption)(super[Serializer].asOption)
 
   /**

--- a/src/main/scala/zio/kafka/serde/Serde.scala
+++ b/src/main/scala/zio/kafka/serde/Serde.scala
@@ -20,7 +20,7 @@ trait Serde[-R, T] extends Deserializer[R, T] with Serializer[R, T] {
   /**
    * Creates a new Serde that uses optional values. Null data will be mapped to None values.
    */
-  override def asOption(implicit ev: T <:< AnyRef): Serde[R, Option[T]] =
+  override def asOption: Serde[R, Option[T]] =
     Serde(super[Deserializer].asOption)(super[Serializer].asOption)
 
   /**

--- a/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -38,7 +38,12 @@ trait Serializer[-R, -T] {
    * Returns a new serializer that handles optional values and serializes them as nulls.
    */
   def asOption[U <: T](implicit ev: Null <:< T): Serializer[R, Option[U]] =
-    contramap(_.orNull)
+    Serializer { (topic, headers, valueOpt) =>
+      valueOpt match {
+        case None        => ZIO.succeed(null)
+        case Some(value) => serialize(topic, headers, value)
+      }
+    }
 }
 
 object Serializer extends Serdes {

--- a/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -1,8 +1,8 @@
 package zio.kafka.serde
 
-import zio.{ RIO, Task, ZIO }
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.{ Serializer => KafkaSerializer }
+import zio.{ RIO, Task, ZIO }
 
 import scala.jdk.CollectionConverters._
 
@@ -37,7 +37,7 @@ trait Serializer[-R, -T] {
   /**
    * Returns a new serializer that handles optional values and serializes them as nulls.
    */
-  def asOption[U <: T](implicit ev: Null <:< T): Serializer[R, Option[U]] =
+  def asOption[U <: T]: Serializer[R, Option[U]] =
     Serializer { (topic, headers, valueOpt) =>
       valueOpt match {
         case None        => ZIO.succeed(null)

--- a/src/test/scala/zio/kafka/serde/SerdeSpec.scala
+++ b/src/test/scala/zio/kafka/serde/SerdeSpec.scala
@@ -9,7 +9,7 @@ import scala.reflect.ClassTag
 object SerdeSpec extends ZIOSpecDefault {
   case class TestDataStructure(value: String)
 
-  val testDataStructureSerde = Serde.string.inmap[TestDataStructure](TestDataStructure)(_.value)
+  val testDataStructureSerde = Serde.string.inmap[TestDataStructure](TestDataStructure.apply)(_.value)
 
   override def spec = suite("Serde")(
     testSerde(Serde.string, Gen.string),

--- a/src/test/scala/zio/kafka/serde/SerdeSpec.scala
+++ b/src/test/scala/zio/kafka/serde/SerdeSpec.scala
@@ -7,6 +7,10 @@ import zio.test._
 import scala.reflect.ClassTag
 
 object SerdeSpec extends ZIOSpecDefault {
+  case class TestDataStructure(value: String)
+
+  val testDataStructureSerde = Serde.string.inmap[TestDataStructure](TestDataStructure)(_.value)
+
   override def spec = suite("Serde")(
     testSerde(Serde.string, Gen.string),
     testSerde(Serde.int, Gen.int),
@@ -18,7 +22,7 @@ object SerdeSpec extends ZIOSpecDefault {
     testSerde(Serde.byteArray, Gen.listOf(Gen.byte).map(_.toArray)),
     suite("asOption")(
       test("serialize and deserialize None values to null and visa versa") {
-        val serde = Serde.string.asOption
+        val serde = testDataStructureSerde.asOption
         for {
           serialized   <- serde.serialize("topic1", new RecordHeaders, None)
           deserialized <- serde.deserialize("topic1", new RecordHeaders, serialized)


### PR DESCRIPTION
It would pass null to the inner serializer, which would expect some non-primitive type T and might throw null pointer exceptions. 