### PR TITLE
Stop forking tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ inThisBuild(
     scalaVersion             := mainScala,
     crossScalaVersions       := allScala,
     Test / parallelExecution := false,
-    Test / fork              := true,
     run / fork               := true,
     pgpPublicRing            := file("/tmp/public.asc"),
     pgpSecretRing            := file("/tmp/secret.asc"),


### PR DESCRIPTION
I haven't been able to dig up much detail about this setting and everything it impacts, but I discussed with Adam and he thought it was worth proposing here.

When the tests are forked, we don't get the summary at the end, and the developer needs to scroll up through the (potentially huge) output in order to find it-

<img width="587" alt="Screen Shot 2022-06-28 at 9 08 27 PM" src="https://user-images.githubusercontent.com/2054940/176343833-0dbcc626-09c7-4ba9-9ea6-679e5ffa35c6.png">

When they aren't forked, we get the summary as expected.

<img width="788" alt="Screen Shot 2022-06-28 at 9 09 37 PM" src="https://user-images.githubusercontent.com/2054940/176343888-2a0b0e4b-afec-4ad0-aff9-4d0ddf64aa32.png">

I would love to hear feedback about why this setting was originally enabled, as it might give some clues about how to handle this situation in ZIO itself.

Ideally, we will get ZIO to support this setting, but I do not know how difficult/long that will be. So turning it off in this project would be a quick band-aid, as long as it doesn't cause other issues.