### PR TITLE
Add describeConfigsAsync to AdminClient

### DIFF
--- a/src/test/scala/zio/kafka/AdminSpec.scala
+++ b/src/test/scala/zio/kafka/AdminSpec.scala
@@ -100,16 +100,21 @@ object AdminSpec extends ZIOSpecWithKafka {
             _ <- client.createTopics(
                    List(AdminClient.NewTopic("adminspec-topic6", 1, 1), AdminClient.NewTopic("adminspec-topic7", 4, 1))
                  )
-            configs <- client.describeConfigs(
-                         List(
-                           ConfigResource(ConfigResourceType.Topic, "adminspec-topic6"),
-                           ConfigResource(ConfigResourceType.Topic, "adminspec-topic7")
-                         )
-                       )
+            configResources = List(
+                                ConfigResource(ConfigResourceType.Topic, "adminspec-topic6"),
+                                ConfigResource(ConfigResourceType.Topic, "adminspec-topic7")
+                              )
+            configs <- client.describeConfigs(configResources) <&>
+                         client.describeConfigsAsync(configResources).flatMap { configs =>
+                           ZIO.foreachPar(configs) { case (resource, configTask) =>
+                             configTask.map(config => (resource, config))
+                           }
+                         }
             _     <- client.deleteTopics(List("adminspec-topic6", "adminspec-topic7"))
             list3 <- listTopicsFiltered(client)
           } yield assert(list1.size)(equalTo(0)) &&
-            assert(configs.size)(equalTo(2)) &&
+            assert(configs._1.size)(equalTo(2)) &&
+            assert(configs._2.size)(equalTo(2)) &&
             assert(list3.size)(equalTo(0))
         }
       },
@@ -150,6 +155,20 @@ object AdminSpec extends ZIOSpecWithKafka {
                          )
                        )
           } yield assert(configs.size)(equalTo(1))
+        }
+      },
+      test("describe broker config async") {
+        KafkaTestUtils.withAdmin { client =>
+          for {
+            configTasks <- client.describeConfigsAsync(
+                             List(
+                               ConfigResource(ConfigResourceType.Broker, "0")
+                             )
+                           )
+            configs <- ZIO.foreachPar(configTasks) { case (resource, configTask) =>
+                         configTask.map(config => (resource, config))
+                       }
+          } yield assertTrue(configs.size == 1)
         }
       },
       test("list offsets") {


### PR DESCRIPTION
This allows per resource error handling, ie the user can filter out resources that kafka-user doesn't have access to.