### PR TITLE
Delete Spurious Uses Of ZIO#exitCode

### DIFF
--- a/src/test/scala/zio/kafka/Benchmarks.scala
+++ b/src/test/scala/zio/kafka/Benchmarks.scala
@@ -33,7 +33,6 @@ object PopulateTopic extends ZIOAppDefault {
           )
         )
       )
-      .exitCode
 }
 
 object Plain {
@@ -110,7 +109,6 @@ object ZIOKafka extends ZIOAppDefault {
             }
         })
       .provideLayer(ZLayer.scoped(Consumer.make(settings)))
-      .exitCode
 
   }
 }


### PR DESCRIPTION
`ZIOAppDefault` already converts the result of running the application to an `ExitCode` so there is no need to call `exitCode` directly.