### PR TITLE
avoid throwing catching invalid group id exception

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -351,6 +351,7 @@ object Consumer {
     for {
       wrapper <- ConsumerAccess.make(settings)
       runloop <- Runloop(
+                   settings.hasGroupId,
                    wrapper,
                    settings.pollInterval,
                    settings.pollTimeout,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -39,6 +39,9 @@ case class ConsumerSettings(
   def withGroupId(groupId: String): ConsumerSettings =
     withProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
 
+  private[consumer] def hasGroupId: Boolean =
+    properties.contains(ConsumerConfig.GROUP_ID_CONFIG)
+
   def withGroupInstanceId(groupInstanceId: String): ConsumerSettings =
     withProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -5,16 +5,22 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.RebalanceInProgressException
 import zio._
 import zio.kafka.consumer.Consumer.OffsetRetrieval
-import zio.kafka.consumer.diagnostics.{DiagnosticEvent, Diagnostics}
+import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
 import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
-import zio.kafka.consumer.internal.Runloop.{BufferedRecords, ByteArrayCommittableRecord, ByteArrayConsumerRecord, Command}
-import zio.kafka.consumer.{CommittableRecord, RebalanceListener}
+import zio.kafka.consumer.internal.Runloop.{
+  BufferedRecords,
+  ByteArrayCommittableRecord,
+  ByteArrayConsumerRecord,
+  Command
+}
+import zio.kafka.consumer.{ CommittableRecord, RebalanceListener }
 import zio.stream._
 
 import java.util
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.util.Try
+import scala.util.control.NonFatal
 
 private[consumer] final class Runloop(
   hasGroupId: Boolean,
@@ -259,7 +265,7 @@ private[consumer] final class Runloop(
             consumerGroupMetadata =
               if (hasGroupId)
                 try Some(consumer.consumer.groupMetadata())
-                catch { case _: Throwable => None }
+                catch { case NonFatal(_) => None }
               else None
           )
         })


### PR DESCRIPTION
When starting a consumer without a group id, the code is going to throw and catch a lot of time the same exception. This is not really good for performance