### PR TITLE
Add ACL administration functionality to admin client

### DIFF
--- a/zio-kafka-test-utils/src/main/scala/zio/kafka/embedded/Kafka.scala
+++ b/zio-kafka-test-utils/src/main/scala/zio/kafka/embedded/Kafka.scala
@@ -22,7 +22,12 @@ object Kafka {
 
   val embedded: ZLayer[Any, Throwable, Kafka] = ZLayer.scoped {
     implicit val embeddedKafkaConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
-      customBrokerProperties = Map("group.min.session.timeout.ms" -> "500", "group.initial.rebalance.delay.ms" -> "0")
+      customBrokerProperties = Map(
+        "group.min.session.timeout.ms"     -> "500",
+        "group.initial.rebalance.delay.ms" -> "0",
+        "authorizer.class.name"            -> "kafka.security.authorizer.AclAuthorizer",
+        "allow.everyone.if.no.acl.found"   -> "true"
+      )
     )
     ZIO.acquireRelease(ZIO.attempt(EmbeddedKafkaService(EmbeddedKafka.start())))(_.stop())
   }

--- a/zio-kafka-test/src/test/scala/zio/kafka/AdminAclSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/AdminAclSpec.scala
@@ -1,0 +1,64 @@
+package zio.kafka.admin
+
+import zio.kafka.ZIOSpecWithKafka
+import zio.kafka.KafkaTestUtils
+import zio.test.Assertion._
+import zio.test._
+
+object AdminAclSpec extends ZIOSpecWithKafka {
+
+  override val kafkaPrefix: String = "adminaclspec"
+
+  private def aclFilter(topicPrefix: String) = AclBindingFilter(
+    ResourcePatternFilter(ResourceType.Topic, topicPrefix, PatternType.Prefixed),
+    AccessControlEntryFilter("User:ZIO", "*", AclOperation.Any, AclPermissionType.Allow)
+  )
+
+
+  override def spec =
+    suite("client admin acl test")(test("create, describe, delete single acl") {
+      KafkaTestUtils.withAdmin { client =>
+        for {
+          list1 <- client.describeAcls(aclFilter("adminspec-single-"))
+          _ <- client.createAcl(
+                 AclBinding(
+                   ResourcePattern(ResourceType.Topic, "adminspec-single-", PatternType.Prefixed),
+                   AccessControlEntry("User:ZIO", "*", AclOperation.Read, AclPermissionType.Allow)
+                 )
+               )
+          list2 <- client.describeAcls(aclFilter("adminspec-single-"))
+          _ <- client.deleteAcls(
+                 Seq(aclFilter("adminspec-single-"))
+               )          
+          list3 <-client.describeAcls(aclFilter("adminspec-single-"))
+        } yield assert(list1.size)(equalTo(0)) &&
+          assert(list2.size)(equalTo(1)) &&
+          assert(list3.size)(equalTo(0))
+      }
+    },
+    (test("create, describe, delete multiple acls") {
+      KafkaTestUtils.withAdmin { client =>
+        for {
+          list1 <- client.describeAcls(aclFilter("adminspec-multi-"))
+          _ <- client.createAcls(Seq(
+                 AclBinding(
+                   ResourcePattern(ResourceType.Topic, "adminspec-multi-", PatternType.Prefixed),
+                   AccessControlEntry("User:ZIO", "*", AclOperation.Read, AclPermissionType.Allow)
+                 ),
+
+                 AclBinding(
+                   ResourcePattern(ResourceType.Topic, "adminspec-multi-", PatternType.Prefixed),
+                   AccessControlEntry("User:ZIO", "*", AclOperation.Write, AclPermissionType.Allow)
+                 )
+               ))
+          list2 <- client.describeAcls(aclFilter("adminspec-multi-"))
+          _ <- client.deleteAcls(
+                 Seq(aclFilter("adminspec-multi-"))
+               )
+          list3 <- client.describeAcls(aclFilter("adminspec-multi-"))
+        } yield assert(list1.size)(equalTo(0)) &&
+          assert(list2.size)(equalTo(2)) &&
+          assert(list3.size)(equalTo(0))
+      }
+    }))
+  }

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AclBinding.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AclBinding.scala
@@ -1,0 +1,54 @@
+package zio.kafka.admin
+
+import org.apache.kafka.common.acl.{
+  AccessControlEntry => JAccessControlEntry,
+  AclBinding => JAclBinding,
+}
+import org.apache.kafka.common.resource.{
+  ResourcePattern => JResourcePattern
+}
+
+case class AclBinding(pattern: ResourcePattern, entry: AccessControlEntry) {
+  def asJava: JAclBinding = new JAclBinding(pattern.asJava, entry.asJava)
+}
+
+object AclBinding {
+  def apply(jAclBinding: JAclBinding): AclBinding =
+    AclBinding(ResourcePattern(jAclBinding.pattern()), AccessControlEntry(jAclBinding.entry()))
+}
+
+case class ResourcePattern(
+  resourceType: ResourceType,
+  name: String,
+  patternType: PatternType
+) {
+  def asJava: JResourcePattern = new JResourcePattern(resourceType.asJava, name, patternType.asJava)
+}
+
+object ResourcePattern {
+  def apply(jResourcePattern: JResourcePattern): ResourcePattern =
+    ResourcePattern(
+      ResourceType(jResourcePattern.resourceType()),
+      jResourcePattern.name(),
+      PatternType(jResourcePattern.patternType())
+    )
+}
+
+case class AccessControlEntry(
+  principal: String,
+  host: String,
+  operation: AclOperation,
+  permissionType: AclPermissionType
+) {
+  def asJava: JAccessControlEntry = new JAccessControlEntry(principal, host, operation.asJava, permissionType.asJava)
+}
+
+object AccessControlEntry {
+  def apply(jAccessControlEntry: JAccessControlEntry): AccessControlEntry =
+    AccessControlEntry(
+      jAccessControlEntry.principal(),
+      jAccessControlEntry.host(),
+      AclOperation(jAccessControlEntry.operation()),
+      AclPermissionType(jAccessControlEntry.permissionType())
+    )
+}

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AclBindingFilter.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AclBindingFilter.scala
@@ -1,0 +1,51 @@
+package zio.kafka.admin
+
+import org.apache.kafka.common.acl.{
+  AccessControlEntryFilter => JAccessControlEntryFilter,
+  AclBindingFilter => JAclBindingFilter
+}
+import org.apache.kafka.common.resource.{
+  ResourcePattern => JResourcePattern,
+  ResourcePatternFilter => JResourcePatternFilter
+}
+
+case class AclBindingFilter(pattern: ResourcePatternFilter, entry: AccessControlEntryFilter) {
+  def asJava: JAclBindingFilter = new JAclBindingFilter(pattern.asJava, entry.asJava)
+}
+
+case class ResourcePatternFilter(
+  resourceType: ResourceType,
+  name: String,
+  patternType: PatternType
+) {
+  def asJava: JResourcePatternFilter = new JResourcePatternFilter(resourceType.asJava, name, patternType.asJava)
+}
+
+object ResourcePatternFilter {
+  def apply(jResourcePattern: JResourcePattern): ResourcePattern =
+    ResourcePattern(
+      ResourceType(jResourcePattern.resourceType()),
+      jResourcePattern.name(),
+      PatternType(jResourcePattern.patternType())
+    )
+}
+
+case class AccessControlEntryFilter(
+  principal: String,
+  host: String,
+  operation: AclOperation,
+  permissionType: AclPermissionType
+) {
+  def asJava: JAccessControlEntryFilter =
+    new JAccessControlEntryFilter(principal, host, operation.asJava, permissionType.asJava)
+}
+
+object AccessControlEntryFilter {
+  def apply(jAccessControlEntryFilter: JAccessControlEntryFilter): AccessControlEntry =
+    AccessControlEntry(
+      jAccessControlEntryFilter.principal(),
+      jAccessControlEntryFilter.host(),
+      AclOperation(jAccessControlEntryFilter.operation()),
+      AclPermissionType(jAccessControlEntryFilter.permissionType())
+    )
+}

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AclOperation.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AclOperation.scala
@@ -2,7 +2,23 @@ package zio.kafka.admin
 
 import org.apache.kafka.common.acl.{ AclOperation => JAclOperation }
 
-sealed trait AclOperation
+sealed trait AclOperation {
+  def asJava: JAclOperation = this match {
+    case AclOperation.Unknown         => JAclOperation.UNKNOWN
+    case AclOperation.Any             => JAclOperation.ANY
+    case AclOperation.Read            => JAclOperation.READ
+    case AclOperation.Write           => JAclOperation.WRITE
+    case AclOperation.All             => JAclOperation.ALL
+    case AclOperation.Create          => JAclOperation.CREATE
+    case AclOperation.Delete          => JAclOperation.DELETE
+    case AclOperation.Alter           => JAclOperation.ALTER
+    case AclOperation.Describe        => JAclOperation.DESCRIBE
+    case AclOperation.ClusterAction   => JAclOperation.CLUSTER_ACTION
+    case AclOperation.DescribeConfigs => JAclOperation.DESCRIBE_CONFIGS
+    case AclOperation.AlterConfigs    => JAclOperation.ALTER_CONFIGS
+    case AclOperation.IdempotentWrite => JAclOperation.IDEMPOTENT_WRITE
+  }
+}
 
 object AclOperation {
   case object Unknown         extends AclOperation

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AclPermissionType.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AclPermissionType.scala
@@ -1,0 +1,27 @@
+package zio.kafka.admin
+
+import org.apache.kafka.common.acl.{ AclPermissionType => JAclPermissionType }
+
+sealed trait AclPermissionType {
+  def asJava: JAclPermissionType = this match {
+    case AclPermissionType.Allow   => JAclPermissionType.ALLOW
+    case AclPermissionType.Any     => JAclPermissionType.ANY
+    case AclPermissionType.Deny    => JAclPermissionType.DENY
+    case AclPermissionType.Unknown => JAclPermissionType.UNKNOWN
+  }
+}
+
+object AclPermissionType {
+  case object Unknown extends AclPermissionType
+  case object Any     extends AclPermissionType
+  case object Deny    extends AclPermissionType
+  case object Allow   extends AclPermissionType
+
+  def apply(jAclPermissionType: JAclPermissionType): AclPermissionType =
+    jAclPermissionType match {
+      case JAclPermissionType.ALLOW   => Allow
+      case JAclPermissionType.ANY     => Any
+      case JAclPermissionType.DENY    => Deny
+      case JAclPermissionType.UNKNOWN => Unknown
+    }
+}

--- a/zio-kafka/src/main/scala/zio/kafka/admin/PatternType.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/PatternType.scala
@@ -1,0 +1,30 @@
+package zio.kafka.admin
+
+import org.apache.kafka.common.resource.{ PatternType => JPatternType }
+
+sealed trait PatternType {
+  def asJava: JPatternType = this match {
+    case PatternType.Any      => JPatternType.ANY
+    case PatternType.Literal  => JPatternType.LITERAL
+    case PatternType.Match    => JPatternType.MATCH
+    case PatternType.Prefixed => JPatternType.PREFIXED
+    case PatternType.Unknown  => JPatternType.UNKNOWN
+  }
+}
+
+object PatternType {
+  case object Any      extends PatternType
+  case object Literal  extends PatternType
+  case object Match    extends PatternType
+  case object Prefixed extends PatternType
+  case object Unknown  extends PatternType
+
+  def apply(jPatternType: JPatternType): PatternType =
+    jPatternType match {
+      case JPatternType.ANY      => Any
+      case JPatternType.LITERAL  => Literal
+      case JPatternType.MATCH    => Match
+      case JPatternType.PREFIXED => Prefixed
+      case JPatternType.UNKNOWN  => Unknown
+    }
+}

--- a/zio-kafka/src/main/scala/zio/kafka/admin/ResourceType.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/ResourceType.scala
@@ -1,0 +1,36 @@
+package zio.kafka.admin
+
+import org.apache.kafka.common.resource.{ ResourceType => JResourceType }
+
+sealed trait ResourceType {
+  def asJava: JResourceType = this match {
+    case ResourceType.Any             => JResourceType.ANY
+    case ResourceType.Cluster         => JResourceType.CLUSTER
+    case ResourceType.DelegationToken => JResourceType.DELEGATION_TOKEN
+    case ResourceType.Group           => JResourceType.GROUP
+    case ResourceType.Topic           => JResourceType.TOPIC
+    case ResourceType.TransactionalId => JResourceType.TRANSACTIONAL_ID
+    case ResourceType.Unknown         => JResourceType.UNKNOWN
+  }
+}
+
+object ResourceType {
+  case object Any             extends ResourceType
+  case object Cluster         extends ResourceType
+  case object DelegationToken extends ResourceType
+  case object Group           extends ResourceType
+  case object Topic           extends ResourceType
+  case object TransactionalId extends ResourceType
+  case object Unknown         extends ResourceType
+
+  def apply(jResourceType: JResourceType): ResourceType =
+    jResourceType match {
+      case JResourceType.ANY              => Any
+      case JResourceType.CLUSTER          => Cluster
+      case JResourceType.DELEGATION_TOKEN => DelegationToken
+      case JResourceType.GROUP            => Group
+      case JResourceType.TOPIC            => Topic
+      case JResourceType.TRANSACTIONAL_ID => TransactionalId
+      case JResourceType.UNKNOWN          => Unknown
+    }
+}


### PR DESCRIPTION
I've added some more wrapper functions around the Java Admin client. Specifically for administering ACLs.

To test this I had to add a couple of ACL specific configs to the Embedded kafka test setup.