### PR TITLE
Bugfix on Serde test

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/serde/SerdeSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/serde/SerdeSpec.scala
@@ -40,7 +40,7 @@ object SerdeSpec extends ZIOSpecDefault {
         for {
           serialized   <- serde.serialize("topic1", new RecordHeaders, value)
           deserialized <- serde.deserialize("topic1", new RecordHeaders, serialized)
-        } yield assert(deserialized)(equalTo(deserialized))
+        } yield assert(deserialized)(equalTo(value))
       }
     }
 


### PR DESCRIPTION
This test will never fail, changed in order to test with the original value which was serialized and then deserialized