### PR TITLE
[POC] Lazy version that only serialize a Record just before to send it instead of serializing them all and then only to send them all

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -5,8 +5,8 @@ import org.apache.kafka.clients.producer.{ KafkaProducer, RecordMetadata }
 import org.apache.kafka.common.errors.InvalidGroupIdException
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import zio.Cause.Fail
-import zio.kafka.consumer.OffsetBatch
 import zio._
+import zio.kafka.consumer.OffsetBatch
 
 import scala.jdk.CollectionConverters._
 
@@ -86,7 +86,7 @@ object TransactionalProducer {
       semaphore <- Semaphore.make(1)
       runtime   <- ZIO.runtime[Any]
       sendQueue <-
-        Queue.bounded[(Chunk[ByteRecord], Promise[Throwable, Chunk[RecordMetadata]])](
+        Queue.bounded[(Chunk[Task[ByteRecord]], Promise[Throwable, Chunk[RecordMetadata]])](
           settings.producerSettings.sendBufferSize
         )
       live <- ZIO.acquireRelease(


### PR DESCRIPTION
(Interruptible version of this POC available here: #583)

The only issue left to fix in this POC is: what do we do if one of the `serialize` calls fails? It's not handled right now in this POC 🤔