### PR TITLE
Leaner ZIOSpecWithKafka

### DIFF
--- a/zio-kafka-test-utils/src/main/scala/zio/kafka/ZIOSpecWithKafka.scala
+++ b/zio-kafka-test-utils/src/main/scala/zio/kafka/ZIOSpecWithKafka.scala
@@ -2,23 +2,11 @@ package zio.kafka
 
 import zio.kafka.embedded.Kafka
 import zio.test._
-import zio.{ Task, ZIO, ZLayer }
-
-import java.util.UUID
+import zio.ZLayer
 
 trait ZIOSpecWithKafka extends ZIOSpec[TestEnvironment with Kafka] {
-
-  def kafkaPrefix: String
 
   override val bootstrap: ZLayer[Any, Any, TestEnvironment with Kafka] =
     testEnvironment ++ Kafka.embedded
 
-  def randomThing(prefix: String): Task[String] =
-    ZIO.attempt(UUID.randomUUID()).map(uuid => s"$prefix-$uuid")
-
-  def randomTopic: Task[String] = randomThing(s"$kafkaPrefix-topic")
-
-  def randomGroup: Task[String] = randomThing(s"$kafkaPrefix-group")
-
-  def randomClient: Task[String] = randomThing(s"$kafkaPrefix-client")
 }

--- a/zio-kafka-test/src/test/scala/zio/kafka/AdminSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/AdminSpec.scala
@@ -4,7 +4,7 @@ import org.apache.kafka.clients.admin.ConfigEntry.ConfigSource
 import org.apache.kafka.clients.admin.{ ConfigEntry, RecordsToDelete }
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.{ Node => JNode }
-import zio.kafka.{ KafkaTestUtils, ZIOSpecWithKafka }
+import zio.kafka.{ KafkaTestUtils, ZIOKafkaSpec }
 import zio.kafka.KafkaTestUtils._
 import zio.kafka.admin.AdminClient.{
   AlterConfigOp,
@@ -35,7 +35,7 @@ import zio.kafka.admin.resource.{ PatternType, ResourcePattern, ResourcePatternF
 import java.util.UUID
 import java.util.concurrent.TimeoutException
 
-object AdminSpec extends ZIOSpecWithKafka {
+object AdminSpec extends ZIOKafkaSpec {
 
   override val kafkaPrefix: String = "adminspec"
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ConsumerSpec.scala
@@ -5,7 +5,7 @@ import org.apache.kafka.clients.consumer.{ ConsumerConfig, CooperativeStickyAssi
 import org.apache.kafka.common.TopicPartition
 import zio._
 import zio.kafka.KafkaTestUtils._
-import zio.kafka.ZIOSpecWithKafka
+import zio.kafka.ZIOKafkaSpec
 import zio.kafka.consumer.Consumer.{ AutoOffsetStrategy, OffsetRetrieval }
 import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
 import zio.kafka.embedded.Kafka
@@ -15,7 +15,7 @@ import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
 
-object ConsumerSpec extends ZIOSpecWithKafka {
+object ConsumerSpec extends ZIOKafkaSpec {
   override val kafkaPrefix: String = "consumespec"
 
   override def spec: Spec[TestEnvironment & Kafka, Throwable] =

--- a/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -13,7 +13,7 @@ import zio.test.Assertion._
 import zio.test.TestAspect.withLiveClock
 import zio.test._
 
-object ProducerSpec extends ZIOSpecWithKafka {
+object ProducerSpec extends ZIOKafkaSpec {
   override val kafkaPrefix: String = "producerspec"
 
   def withConsumerInt(subscription: Subscription, settings: ConsumerSettings) =

--- a/zio-kafka-test/src/test/scala/zio/kafka/ZIOKafkaSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ZIOKafkaSpec.scala
@@ -1,0 +1,19 @@
+package zio.kafka
+
+import zio.{ Task, ZIO }
+
+import java.util.UUID
+
+trait ZIOKafkaSpec extends ZIOSpecWithKafka {
+
+  def kafkaPrefix: String
+
+  def randomThing(prefix: String): Task[String] =
+    ZIO.attempt(UUID.randomUUID()).map(uuid => s"$prefix-$uuid")
+
+  def randomTopic: Task[String] = randomThing(s"$kafkaPrefix-topic")
+
+  def randomGroup: Task[String] = randomThing(s"$kafkaPrefix-group")
+
+  def randomClient: Task[String] = randomThing(s"$kafkaPrefix-client")
+}


### PR DESCRIPTION
The new ZIOSpecWithKafka (from #528) is very useful for testing zio-kafka applications, however, it is extended with additional tools for naming which are not useful for everyone. Even so, it does force you to implement `kafkaPrefix`. This PR moves the naming extensions back to the zio-kafka-test module.