### PR TITLE
update zio to 1.0.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '8', '11', '17' ]
-        scala: [ '2.12.15', '2.13.8', '3.1.1' ]
+        scala: [ '2.12.17', '2.13.10', '3.2.2' ]
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
 import sbt.Keys.{ fork, parallelExecution }
 
-lazy val scala212  = "2.12.15"
-lazy val scala213  = "2.13.8"
-lazy val scala3    = "3.1.1"
+lazy val scala212  = "2.12.17"
+lazy val scala213  = "2.13.10"
+lazy val scala3    = "3.2.2"
 lazy val mainScala = scala213
 lazy val allScala  = Seq(scala212, scala3, mainScala)
 
-lazy val zioVersion           = "1.0.13"
+lazy val zioVersion           = "1.0.18"
 lazy val kafkaVersion         = "3.1.0"
 lazy val embeddedKafkaVersion = "3.1.0" // Should be the same as kafkaVersion, except for the patch part
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.8.2

--- a/src/test/scala/zio/kafka/ConsumerSpec.scala
+++ b/src/test/scala/zio/kafka/ConsumerSpec.scala
@@ -507,7 +507,7 @@ object ConsumerSpec extends DefaultRunnableSpec {
             .subscribeAnd(subscription)
             .partitionedStream(Serde.string, Serde.string)
             .map { case (tp, partStream) =>
-              ZStream.fromEffect(allAssignments.update({ current =>
+              ZStream.fromEffect[Any, Nothing, Any](allAssignments.update({ current =>
                 current.get(instance) match {
                   case Some(currentList) => current.updated(instance, currentList :+ tp.partition())
                   case None              => current.updated(instance, List(tp.partition()))


### PR DESCRIPTION
According to release notes of ZIO 1.0.18:

> All Scala 3 users and downstream libraries are advised to update to ZIO 1.0.18 or newer and release newly recompiled versions to avoid stale Tags generated by older versions of izumi-reflect from surfacing https://github.com/zio/zio/issues/7489 on Scala 3.