### PR TITLE
Add transactional test

### DIFF
--- a/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
+++ b/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
@@ -69,7 +69,8 @@ object KafkaTestUtils {
     clientInstanceId: Option[String] = None,
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
-    restartStreamOnRebalancing: Boolean = false
+    restartStreamOnRebalancing: Boolean = false,
+    properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =
     ZIO.serviceWith[Kafka] { (kafka: Kafka) =>
       val settings = ConsumerSettings(kafka.bootstrapServers)
@@ -86,6 +87,7 @@ object KafkaTestUtils {
         .withPerPartitionChunkPrefetch(16)
         .withOffsetRetrieval(offsetRetrieval)
         .withRestartStreamOnRebalancing(restartStreamOnRebalancing)
+        .withProperties(properties)
 
       val withClientInstanceId = clientInstanceId.fold(settings)(settings.withGroupInstanceId)
       groupId.fold(withClientInstanceId)(withClientInstanceId.withGroupId)
@@ -96,9 +98,19 @@ object KafkaTestUtils {
     clientId: String,
     clientInstanceId: Option[String] = None,
     allowAutoCreateTopics: Boolean = true,
-    offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto()
+    offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
+    restartStreamOnRebalancing: Boolean = false,
+    properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =
-    consumerSettings(clientId, Some(groupId), clientInstanceId, allowAutoCreateTopics, offsetRetrieval)
+    consumerSettings(
+      clientId,
+      Some(groupId),
+      clientInstanceId,
+      allowAutoCreateTopics,
+      offsetRetrieval,
+      restartStreamOnRebalancing,
+      properties
+    )
       .map(
         _.withProperties(
           ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed"
@@ -131,7 +143,10 @@ object KafkaTestUtils {
     clientInstanceId: Option[String] = None,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     allowAutoCreateTopics: Boolean = true,
-    diagnostics: Diagnostics = Diagnostics.NoOp
+    diagnostics: Diagnostics = Diagnostics.NoOp,
+    restartStreamOnRebalancing: Boolean = false,
+    properties: Map[String, String] = Map.empty,
+    rebalanceListener: RebalanceListener = RebalanceListener.noop
   ): ZLayer[Kafka, Throwable, Consumer] =
     (ZLayer(
       transactionalConsumerSettings(
@@ -139,8 +154,10 @@ object KafkaTestUtils {
         clientId,
         clientInstanceId,
         allowAutoCreateTopics,
-        offsetRetrieval
-      )
+        offsetRetrieval,
+        restartStreamOnRebalancing,
+        properties
+      ).map(_.withRebalanceListener(rebalanceListener))
     ) ++ ZLayer.succeed(diagnostics)) >>> Consumer.live
 
   def consumeWithStrings[RC](clientId: String, groupId: Option[String] = None, subscription: Subscription)(

--- a/zio-kafka-test/src/test/resources/logback.xml
+++ b/zio-kafka-test/src/test/resources/logback.xml
@@ -6,6 +6,7 @@
     </appender>
 
     <logger name="org.apache.kafka" level="ERROR" />
+    <logger name="state.change.logger" level="WARN" />
 
     <logger name="kafka" level="WARN" />
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ConsumerSpec.scala
@@ -994,21 +994,6 @@ object ConsumerSpec extends ZIOKafkaSpec {
               _ <- ZIO.logInfo("Waiting for copier 2 to start")
               _ <- copier2Created.await
 
-//              _               <- ZIO.logInfo("Starting copier 3")
-//              copier3ClientId <- randomClient
-//              copier3Created  <- Promise.make[Nothing, Unit]
-//              copier3 <- makeCopyingTransactionalConsumer(
-//                           "3",
-//                           copyingGroup,
-//                           copier3ClientId,
-//                           topicA,
-//                           topicB,
-//                           tProducer,
-//                           copier3Created
-//                         ).fork
-//              _ <- ZIO.logInfo("Waiting for copier 3 to start")
-//              _ <- copier3Created.await
-
               _ <- ZIO.logInfo("Producing some more messages")
               _ <- produceMany(topicA, messagesAfterRebalance)
 
@@ -1034,7 +1019,6 @@ object ConsumerSpec extends ZIOKafkaSpec {
                                   }
               _ <- copier1.interrupt
               _ <- copier2.interrupt
-//              _ <- copier3.interrupt
               messagesOnTopicBCount         = messagesOnTopicB.size
               messagesOnTopicBDistinctCount = messagesOnTopicB.distinct.size
             } yield assertTrue(messageCount == messagesOnTopicBCount && messageCount == messagesOnTopicBDistinctCount)

--- a/zio-kafka-test/src/test/scala/zio/kafka/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ConsumerSpec.scala
@@ -1042,8 +1042,8 @@ object ConsumerSpec extends ZIOKafkaSpec {
 
         // Test for both default partition assignment strategies
         Seq(
-          testForPartitionAssignmentStrategy[RangeAssignor],
-          testForPartitionAssignmentStrategy[CooperativeStickyAssignor]
+          testForPartitionAssignmentStrategy[RangeAssignor]
+//          testForPartitionAssignmentStrategy[CooperativeStickyAssignor] // TODO not yet supported
         )
 
       }: _*) @@ TestAspect.nonFlaky(3)


### PR DESCRIPTION
Add test "does not process messages twice for transactional producer, even when rebalancing".

This replaces #440 . Also, it will help in testing #591 .

~Unfortunately, the test is very flaky. In fact it almost never passes on my machine. It works best when run in isolation (for a single partition assigner).~

We need to run the ConsumerSpec tests sequentially. Otherwise the tests interfere each other too much. This, and logging changes were pulled forward from #591 in [#296051b](https://github.com/zio/zio-kafka/pull/644/commits/296051ba3896be9fe137f01130d3f26b10e195d7). 