### PR TITLE
Optimization: Do not deserialize the message if the deserializers are `Serde.byteArray` as these deserializers are not doing anything anyway

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -6,7 +6,7 @@ import zio._
 import zio.kafka.consumer.diagnostics.Diagnostics
 import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.kafka.consumer.internal.{ ConsumerAccess, Runloop }
-import zio.kafka.serde.Deserializer
+import zio.kafka.serde.{ Deserializer, Serde }
 import zio.stream._
 
 import scala.jdk.CollectionConverters._
@@ -242,6 +242,8 @@ object Consumer {
         }).as(newSubscriptions.map(_.toSet).getOrElse(Set.empty))
       }
 
+      val onlyByteArraySerdes: Boolean = (keyDeserializer eq Serde.byteArray) && (valueDeserializer eq Serde.byteArray)
+
       ZStream.unwrapScoped {
         for {
           stream <- ZStream.fromHubScoped(partitionAssignments)
@@ -257,7 +259,11 @@ object Consumer {
                   if (settings.perPartitionChunkPrefetch <= 0) partition
                   else partition.bufferChunks(settings.perPartitionChunkPrefetch)
 
-                tp -> partitionStream.mapChunksZIO(_.mapZIO(_.deserializeWith(keyDeserializer, valueDeserializer)))
+                val stream: ZStream[R, Throwable, CommittableRecord[K, V]] =
+                  if (onlyByteArraySerdes) partitionStream.asInstanceOf[ZStream[R, Throwable, CommittableRecord[K, V]]]
+                  else partitionStream.mapChunksZIO(_.mapZIO(_.deserializeWith(keyDeserializer, valueDeserializer)))
+
+                tp -> stream
             }
           }
       }

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serdes.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serdes.scala
@@ -15,20 +15,36 @@ private[zio] trait Serdes {
   lazy val float: Serde[Any, Float]   = convertPrimitiveSerde(KafkaSerdes.Float()).inmap(Float2float)(float2Float)
   lazy val double: Serde[Any, Double] = convertPrimitiveSerde(KafkaSerdes.Double()).inmap(Double2double)(double2Double)
   lazy val string: Serde[Any, String] = convertPrimitiveSerde(KafkaSerdes.String())
-  lazy val byteArray: Serde[Any, Array[Byte]] = convertPrimitiveSerde(KafkaSerdes.ByteArray())
-  lazy val bytes: Serde[Any, Bytes]           = convertPrimitiveSerde(KafkaSerdes.Bytes())
+  lazy val bytes: Serde[Any, Bytes]   = convertPrimitiveSerde(KafkaSerdes.Bytes())
   lazy val byteBuffer: Serde[Any, ByteBuffer] = convertPrimitiveSerde(KafkaSerdes.ByteBuffer())
   lazy val uuid: Serde[Any, UUID]             = convertPrimitiveSerde(KafkaSerdes.UUID())
 
+  /**
+   * Optimisation
+   *
+   * Here, we're not using [[KafkaSerdes.ByteArray()]] because the underlying deserializer and serializer
+   * implementations are just identity functions.
+   *
+   * That allows us to use [[ZIO.succeed]] instead of [[ZIO.attempt]].
+   */
+  lazy val byteArray: Serde[Any, Array[Byte]] =
+    new Serde[Any, Array[Byte]] {
+      override final def serialize(topic: String, headers: Headers, value: Array[Byte]): RIO[Any, Array[Byte]] =
+        ZIO.succeed(value)
+
+      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[Any, Array[Byte]] =
+        ZIO.succeed(data)
+    }
+
   private[this] def convertPrimitiveSerde[T](serde: KafkaSerde[T]): Serde[Any, T] =
     new Serde[Any, T] {
-      val serializer   = serde.serializer()
-      val deserializer = serde.deserializer()
+      private final val serializer   = serde.serializer()
+      private final val deserializer = serde.deserializer()
 
-      override def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[Any, T] =
+      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[Any, T] =
         ZIO.attempt(deserializer.deserialize(topic, headers, data))
 
-      override def serialize(topic: String, headers: Headers, value: T): RIO[Any, Array[Byte]] =
+      override final def serialize(topic: String, headers: Headers, value: T): RIO[Any, Array[Byte]] =
         ZIO.attempt(serializer.serialize(topic, headers, value))
     }
 }


### PR DESCRIPTION
Kafka `ByteArrayDeserializer` implementation:

```java
package org.apache.kafka.common.serialization;

public class ByteArrayDeserializer implements Deserializer<byte[]> {

    @Override
    public byte[] deserialize(String topic, byte[] data) {
        return data;
    }
}
```