### PR TITLE
Avoid extra latency potentially happening between `Poll` calls

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -1,0 +1,61 @@
+package zio.kafka.consumer.internal
+
+import zio.kafka.ZIOKafkaSpec
+import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
+import zio.kafka.consumer.internal.Runloop.Command
+import zio.kafka.consumer.{ Consumer, ConsumerSettings }
+import zio.kafka.embedded.Kafka
+import zio.test._
+import zio.{ &, durationInt, Scope, ZIO }
+
+object RunloopSpec extends ZIOKafkaSpec {
+  override val kafkaPrefix: String = "runloopspec"
+
+  /**
+   * Note: the [[Runloop.run]] call is made in the [[Consumer.make]] method (when calling the [[Runloop.apply]]), so we
+   * dont need to call it explicitly.
+   */
+  private val runSpec =
+    suite("::run")(
+      test("Immediately triggers a first Poll command, doesn't wait an initial `pollFrequency` to trigger it") {
+        val oneCycle  = 1.second
+        val twoCycles = 2.seconds
+
+        for {
+          kafka       <- ZIO.service[Kafka]
+          diagnostics <- Diagnostics.SlidingQueue.make()
+          diagnosticsQueue = diagnostics.queue
+          _ <- Consumer.make(ConsumerSettings(kafka.bootstrapServers).withPollInterval(twoCycles), diagnostics)
+
+          before <- diagnosticsQueue.takeAll
+
+          _             <- TestClock.adjust(10.milliseconds)
+          justAfterBoot <- diagnosticsQueue.takeAll
+
+          _            <- TestClock.adjust(oneCycle)
+          afterCycle_1 <- diagnosticsQueue.takeAll
+
+          _            <- TestClock.adjust(oneCycle)
+          afterCycle_2 <- diagnosticsQueue.takeAll
+
+          _            <- TestClock.adjust(oneCycle)
+          afterCycle_3 <- diagnosticsQueue.takeAll
+
+          _            <- TestClock.adjust(oneCycle)
+          afterCycle_4 <- diagnosticsQueue.takeAll
+        } yield assertTrue(
+          before.isEmpty,
+          justAfterBoot.size == 1 && justAfterBoot.head == DiagnosticEvent.RunloopEvent(Command.Poll),
+          afterCycle_1.isEmpty,
+          afterCycle_2.size == 1 && afterCycle_2.head == DiagnosticEvent.RunloopEvent(Command.Poll),
+          afterCycle_3.isEmpty,
+          afterCycle_4.size == 1 && afterCycle_4.head == DiagnosticEvent.RunloopEvent(Command.Poll)
+        )
+      }
+    )
+
+  override def spec: Spec[TestEnvironment & Kafka & Scope, Any] =
+    suite("Runloop")(
+      runSpec
+    )
+}

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -6,7 +6,7 @@ import zio.kafka.consumer.internal.Runloop.Command
 import zio.kafka.consumer.{ Consumer, ConsumerSettings }
 import zio.kafka.embedded.Kafka
 import zio.test._
-import zio.{ &, durationInt, Scope, ZIO }
+import zio.{ durationInt, Scope, ZIO }
 
 object RunloopSpec extends ZIOKafkaSpec {
   override val kafkaPrefix: String = "runloopspec"
@@ -54,7 +54,7 @@ object RunloopSpec extends ZIOKafkaSpec {
       }
     )
 
-  override def spec: Spec[TestEnvironment & Kafka & Scope, Any] =
+  override def spec: Spec[TestEnvironment with Kafka with Scope, Any] =
     suite("Runloop")(
       runSpec
     )

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -351,14 +351,14 @@ object Consumer {
     for {
       wrapper <- ConsumerAccess.make(settings)
       runloop <- Runloop(
-                   settings.hasGroupId,
-                   wrapper,
-                   settings.pollInterval,
-                   settings.pollTimeout,
-                   diagnostics,
-                   settings.offsetRetrieval,
-                   settings.rebalanceListener,
-                   settings.restartStreamOnRebalancing
+                   hasGroupId = settings.hasGroupId,
+                   consumer = wrapper,
+                   pollFrequency = settings.pollInterval,
+                   pollTimeout = settings.pollTimeout,
+                   diagnostics = diagnostics,
+                   offsetRetrieval = settings.offsetRetrieval,
+                   userRebalanceListener = settings.rebalanceListener,
+                   restartStreamsOnRebalancing = settings.restartStreamOnRebalancing
                  )
     } yield Live(wrapper, settings, runloop)
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
@@ -2,6 +2,7 @@ package zio.kafka.consumer.diagnostics
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
+import zio.kafka.consumer.internal.Runloop.Command
 
 sealed trait DiagnosticEvent
 object DiagnosticEvent {
@@ -25,4 +26,6 @@ object DiagnosticEvent {
     final case class Assigned(partitions: Set[TopicPartition]) extends Rebalance
     final case class Lost(partitions: Set[TopicPartition])     extends Rebalance
   }
+
+  final case class RunloopEvent(command: Command) extends DiagnosticEvent
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
@@ -6,26 +6,38 @@ import zio.kafka.consumer.internal.Runloop.Command
 
 sealed trait DiagnosticEvent
 object DiagnosticEvent {
+
+  /**
+   * Stable diagnostic events are events we consider stable so that you can use them in your apps if you want to.
+   */
+  sealed trait StableDiagnosticEvent extends DiagnosticEvent
+
+  /**
+   * Internal diagnostic events are events we advise you not to use/rely on in your apps. We may change/remove them at
+   * any time based on our internal needs.
+   */
+  sealed trait InternalDiagnosticEvent extends DiagnosticEvent
+
   final case class Poll(
     tpRequested: Set[TopicPartition],
     tpWithData: Set[TopicPartition],
     tpWithoutData: Set[TopicPartition]
   ) extends DiagnosticEvent
-  final case class Request(partition: TopicPartition) extends DiagnosticEvent
+  final case class Request(partition: TopicPartition) extends StableDiagnosticEvent
 
-  sealed trait Commit extends DiagnosticEvent
+  sealed trait Commit extends StableDiagnosticEvent
   object Commit {
     final case class Started(offsets: Map[TopicPartition, Long])                                extends Commit
     final case class Success(offsets: Map[TopicPartition, OffsetAndMetadata])                   extends Commit
     final case class Failure(offsets: Map[TopicPartition, OffsetAndMetadata], cause: Throwable) extends Commit
   }
 
-  sealed trait Rebalance extends DiagnosticEvent
+  sealed trait Rebalance extends StableDiagnosticEvent
   object Rebalance {
     final case class Revoked(partitions: Set[TopicPartition])  extends Rebalance
     final case class Assigned(partitions: Set[TopicPartition]) extends Rebalance
     final case class Lost(partitions: Set[TopicPartition])     extends Rebalance
   }
 
-  final case class RunloopEvent(command: Command) extends DiagnosticEvent
+  final case class RunloopEvent(command: Command) extends InternalDiagnosticEvent
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -548,10 +548,11 @@ private[consumer] final class Runloop(
   def run: ZIO[Scope, Nothing, Fiber.Runtime[Throwable, Unit]] =
     ZStream
       .mergeAll(3, 1)(
-        ZStream(Command.Poll).repeat(Schedule.spaced(pollFrequency)),
+        ZStream.repeatWithSchedule(Command.Poll, Schedule.fixed(pollFrequency)),
         ZStream.fromQueue(requestQueue).mapChunks(c => Chunk.single(Command.Requests(c))),
         ZStream.fromQueue(commitQueue)
       )
+      .tap(cmd => diagnostics.emitIfEnabled(DiagnosticEvent.RunloopEvent(cmd)))
       .runFoldZIO(State.initial) { (state, cmd) =>
         ZIO.ifZIO(isShutdown)(onTrue = handleShutdown(state, cmd), onFalse = handleOperational(state, cmd))
       }


### PR DESCRIPTION
Related to work done here: 
- https://github.com/zio/zio-kafka/pull/661

I didn't manage to find a way to test that this "extra latency" is not stacked anymore 🤔

@svroonland I wonder if there's not a risk of generating/stacking a lot of `Poll` in the Stream 🤔
I wonder if using a `Queue.dropping[Command.Poll](1)` wouldn't be a good idea.
At any time, I think that we only need to have 1 or 0 Poll command: if we have one, at the next iteration of the loop, it'll consume it from the queue and will execute the corresponding action. If 0, it'll do nothing.
If the queue was containing 1 Poll command and we're emitting a new one, we're replacing the old one with the new one, so we don't waste memory and we have no risks of stacking too many of them (which could potentially lead to an OOM)

WDYT? 🤔