### PR TITLE
Improve docs for partitionedStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Kafka has a mature Java client for producing and consuming events, but it has a 
 In order to use this library, we need to add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-kafka" % "2.1.1" 
+libraryDependencies += "dev.zio" %% "zio-kafka" % "2.1.2" 
 ```
 
 ## Example

--- a/docs/consuming-kafka-topics-using-zio-streams.md
+++ b/docs/consuming-kafka-topics-using-zio-streams.md
@@ -53,11 +53,11 @@ import zio.Clock, zio.Console.printLine
 import zio.kafka.consumer._
 
 Consumer.partitionedStream(Subscription.topics("topic150"), Serde.string, Serde.string)
-  .tap(tpAndStr => printLine(s"topic: ${tpAndStr._1.topic}, partition: ${tpAndStr._1.partition}"))
-  .flatMapPar(Int.MaxValue) { case (topicPartition, partitionStream) => 
-    partitionStream
-      .tap(cr => printLine(s"key: ${cr.record.key}, value: ${cr.record.value}")) // Replace with a custom message handling effect
-      .map(_.offset)
+  .flatMapPar(Int.MaxValue) { case (topicPartition, partitionStream) =>
+    ZStream.fromZIO(printLine(s"Starting stream for topic '${topicPartition.topic}' partition ${topicPartition.partition}")) *>
+      partitionStream
+        .tap(record => printLine(s"key: ${record.key}, value: ${record.value}")) // Replace with a custom message handling effect
+        .map(_.offset)
   }
   .aggregateAsync(Consumer.offsetBatches)
   .mapZIO(_.commit)

--- a/docs/consuming-kafka-topics-using-zio-streams.md
+++ b/docs/consuming-kafka-topics-using-zio-streams.md
@@ -32,8 +32,7 @@ val data: RIO[Clock,
     .provideSomeLayer(consumer)
 ```
 
-You may stream data from Kafka using the `plainStream`
-methods:
+You may stream data from Kafka using the `plainStream` method:
 
 ```scala
 import zio.Clock, zio.Console.printLine
@@ -47,9 +46,7 @@ Consumer.plainStream(Subscription.topics("topic150"), Serde.string, Serde.string
   .runDrain
 ```
 
-If you need to distinguish between the different partitions assigned
-to the consumer, you may use the `Consumer#partitionedStream` method,
-which creates a nested stream of partitions:
+To process partitions assigned to the consumer in parallel, you may use the `Consumer#partitionedStream` method, which creates a nested stream of partitions:
 
 ```scala
 import zio.Clock, zio.Console.printLine
@@ -57,9 +54,11 @@ import zio.kafka.consumer._
 
 Consumer.partitionedStream(Subscription.topics("topic150"), Serde.string, Serde.string)
   .tap(tpAndStr => printLine(s"topic: ${tpAndStr._1.topic}, partition: ${tpAndStr._1.partition}"))
-  .flatMap(_._2)
-  .tap(cr => printLine(s"key: ${cr.record.key}, value: ${cr.record.value}"))
-  .map(_.offset)
+  .flatMapPar(Int.MaxValue) { case (topicPartition, partitionStream) => 
+    partitionStream
+      .tap(cr => printLine(s"key: ${cr.record.key}, value: ${cr.record.value}")) // Replace with a custom message handling effect
+      .map(_.offset)
+  }
   .aggregateAsync(Consumer.offsetBatches)
   .mapZIO(_.commit)
   .runDrain


### PR DESCRIPTION
The original was introduced in October 2019 and is not showing very well how `partitionedStream` should be used with benefits over `plainStream`