### PR TITLE
Init comparison benchmarks: compare kafka-clients vs zio-kafka consumers

### DIFF
--- a/.github/workflows/benchs.yml
+++ b/.github/workflows/benchs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    types: [ opened, reopened, synchronize ]
 
 permissions:
   # deployments permission to deploy GitHub pages website
@@ -26,6 +28,12 @@ jobs:
           distribution: temurin
           java-version: 17
           check-latest: true
+      - name: Use CI sbt jvmopts
+        shell: bash
+        run: |
+          mv .jvmopts .jvmopts_old
+          mv .jvmopts-ci .jvmopts
+          cat .jvmopts
 
       - name: compile
         run: sbt compile
@@ -34,20 +42,27 @@ jobs:
         # To list all possible options and undestand these configurations, see run `sbt "zioKafkaBench/Jmh/run -h"`
         #
         # Used options meaning:
-        #  - "-wi 5": 5 warmup iterations
-        #  - "-i 3": 3 benchmark iterations
+        #  - "-wi 10": 10 warmup iterations
+        #  - "-i 10": 10 benchmark iterations
         #  - "-r 1": Minimum time to spend at each measurement iteration. 1 second
         #  - "-w 1": Minimum time to spend at each warmup iteration. 1 second
         #  - "-t 1": Number of worker threads to run with. 1 thread
         #  - "-rf json": Format type for machine-readable results. JSON
         #  - "-foe true": Should JMH fail immediately if any benchmark had experienced an unrecoverable error?. True
-        run: sbt "zioKafkaBench/Jmh/run -wi 5 -i 3 -r 1 -w 1 -t 1 -rf json -foe true"
+        run: sbt "zioKafkaBench/Jmh/run -wi 10 -i 10 -r 1 -w 1 -t 1 -rf json -foe true"
 
       - name: Download previous benchmark data
         uses: actions/cache@v3
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark
+
+      - name: Rollback - Use CI sbt jvmopts
+        shell: bash
+        run: |
+          mv .jvmopts .jvmopts-ci
+          mv .jvmopts_old .jvmopts
+          cat .jvmopts
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1.16.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@
 
 name: CI
 env:
-  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xmx6G -Xss4M -XX:+UseG1GC
-  JVM_OPTS: -XX:+PrintCommandLineFlags -Xmx6G -Xss4M -XX:+UseG1GC
+  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -XmS6G -Xmx6G -Xss4M -XX:+UseG1GC
+  JVM_OPTS: -XX:+PrintCommandLineFlags -XmS6G -Xmx6G -Xss4M -XX:+UseG1GC
   NODE_OPTIONS: --max_old_space_size=6144
 'on':
   workflow_dispatch: {}

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,5 @@
+# This is a comment
+-Dfile.encoding=UTF8
+-Xms265M
+-Xmx8G
+-XX:+UseG1GC

--- a/.jvmopts-ci
+++ b/.jvmopts-ci
@@ -1,0 +1,5 @@
+# See GHA machines spec: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+-Dfile.encoding=UTF8
+-Xms5G
+-Xmx5G
+-XX:+UseG1GC

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ConsumerBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ConsumerBenchmark.scala
@@ -20,7 +20,7 @@ class ConsumerBenchmark extends ZioBenchmark[Kafka with Producer] {
   val topic1                      = "topic1"
   val nrPartitions                = 6
   val nrMessages                  = 50000
-  val kvs: List[(String, String)] = (1 to nrMessages).toList.map(i => (s"key$i", s"msg$i"))
+  val kvs: List[(String, String)] = List.tabulate(nrMessages)(i => (s"key$i", s"msg$i"))
 
   override protected def bootstrap: ZLayer[Any, Nothing, Kafka with Producer] =
     ZLayer.make[Kafka with Producer](Kafka.embedded, producer).orDie
@@ -33,32 +33,24 @@ class ConsumerBenchmark extends ZioBenchmark[Kafka with Producer] {
   @Benchmark
   @BenchmarkMode(Array(Mode.AverageTime))
   def throughput(): Any = runZIO {
-    for {
-      client <- randomThing("client")
-      group  <- randomThing("group")
-
-      _ <- Consumer
-             .plainStream(Subscription.topics(topic1), Serde.byteArray, Serde.byteArray)
-             .take(nrMessages.toLong)
-             .runDrain
-             .provideSome[Kafka](
-               consumer(
-                 client,
-                 Some(group),
-                 properties = Map(ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> "1000")
-               )
-             )
-             .timeoutFail(new RuntimeException("Timeout"))(30.seconds)
-    } yield ()
+    Consumer
+      .plainStream(Subscription.topics(topic1), Serde.byteArray, Serde.byteArray)
+      .take(nrMessages.toLong)
+      .runDrain
+      .provideSome[Kafka](
+        consumer(
+          randomThing("client"),
+          Some(randomThing("group")),
+          properties = Map(ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> "1000")
+        )
+      )
+      .timeoutFail(new RuntimeException("Timeout"))(30.seconds)
   }
 
   @Benchmark
   @BenchmarkMode(Array(Mode.AverageTime))
   def throughputWithCommits(): Any = runZIO {
     for {
-      client <- randomThing("client")
-      group  <- randomThing("group")
-
       counter <- Ref.make(0)
       _ <- ZIO.logAnnotate("consumer", "1") {
              Consumer
@@ -72,8 +64,8 @@ class ConsumerBenchmark extends ZioBenchmark[Kafka with Producer] {
                .runDrain
                .provideSome[Kafka](
                  consumer(
-                   client,
-                   Some(group),
+                   randomThing("client"),
+                   Some(randomThing("group")),
                    properties = Map(ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> "1000")
                  )
                )

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ConsumersComparisonBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ConsumersComparisonBenchmark.scala
@@ -1,0 +1,103 @@
+package zio.kafka.bench
+
+import io.github.embeddedkafka.EmbeddedKafka
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.openjdk.jmh.annotations._
+import zio.kafka.KafkaTestUtils.{ consumerSettings, produceMany, producer, simpleConsumer }
+import zio.kafka.bench.ZioBenchmark.randomThing
+import zio.kafka.consumer.{ Consumer, ConsumerSettings, Subscription }
+import zio.kafka.embedded.Kafka
+import zio.kafka.producer.Producer
+import zio.kafka.serde.Serde
+import zio.{ ULayer, ZIO, ZLayer }
+
+import java.util.concurrent.TimeUnit
+import scala.jdk.CollectionConverters._
+
+object ConsumersComparisonBenchmark {
+  type LowLevelKafka = KafkaConsumer[Array[Byte], Array[Byte]]
+
+  type Env = Kafka with Producer with Consumer with LowLevelKafka with ConsumerSettings
+}
+import zio.kafka.bench.ConsumersComparisonBenchmark._
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+class ConsumersComparisonBenchmark extends ZioBenchmark[Env] {
+  val topic1       = "topic1"
+  val nrPartitions = 6
+  val nrMessages   = 1000000
+  val kvs          = List.tabulate(nrMessages)(i => (s"key$i", s"msg$i"))
+
+  val kafkaConsumer: ZLayer[ConsumerSettings, Throwable, LowLevelKafka] =
+    ZLayer.scoped {
+      ZIO.acquireRelease {
+        ZIO.service[ConsumerSettings].flatMap { settings =>
+          ZIO.attemptBlocking {
+            new KafkaConsumer[Array[Byte], Array[Byte]](
+              settings.driverSettings.asJava,
+              new ByteArrayDeserializer(),
+              new ByteArrayDeserializer()
+            )
+          }
+        }
+      }(c => ZIO.attemptBlocking(c.close()).orDie)
+    }
+
+  val settings: ZLayer[Kafka, Nothing, ConsumerSettings] =
+    ZLayer.fromZIO(
+      consumerSettings(
+        clientId = randomThing("client"),
+        groupId = Some(randomThing("client"))
+      )
+    )
+
+  override protected def bootstrap: ULayer[Env] =
+    ZLayer
+      .make[Env](
+        Kafka.embedded,
+        producer,
+        settings,
+        simpleConsumer(),
+        kafkaConsumer
+      )
+      .orDie
+
+  override def initialize: ZIO[Env, Throwable, Any] =
+    for {
+      _ <- ZIO.succeed(EmbeddedKafka.createCustomTopic(topic1, partitions = nrPartitions))
+      _ <- produceMany(topic1, kvs)
+    } yield ()
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def kafkaClients(): Any =
+    runZIO {
+      ZIO.service[ConsumerSettings].flatMap { settings =>
+        ZIO.service[LowLevelKafka].flatMap { consumer =>
+          ZIO.attemptBlocking {
+            consumer.subscribe(java.util.Arrays.asList(topic1))
+
+            var count = 0L
+            while (count < nrMessages) {
+              val records = consumer.poll(settings.pollTimeout)
+              count += records.count()
+            }
+
+            consumer.unsubscribe()
+          }
+        }
+      }
+    }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def zioKafka(): Any =
+    runZIO {
+      Consumer
+        .plainStream(Subscription.topics(topic1), Serde.byteArray, Serde.byteArray)
+        .take(nrMessages.toLong)
+        .runDrain
+    }
+}

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioBenchmark.scala
@@ -1,6 +1,6 @@
 package zio.kafka.bench
 import org.openjdk.jmh.annotations.{ Setup, TearDown }
-import zio.{ Runtime, Task, Unsafe, ZIO, ZLayer }
+import zio.{ Runtime, Unsafe, ZIO, ZLayer }
 
 import java.util.UUID
 
@@ -28,7 +28,5 @@ trait ZioBenchmark[Environment] {
 }
 
 object ZioBenchmark {
-  def randomThing(prefix: String): Task[String] =
-    ZIO.attempt(UUID.randomUUID()).map(uuid => s"$prefix-$uuid")
-
+  def randomThing(prefix: String): String = s"$prefix-${UUID.randomUUID()}"
 }

--- a/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
+++ b/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
@@ -70,6 +70,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
+    `max.poll.records`: Int = 1000,
     properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =
     ZIO.serviceWith[Kafka] { (kafka: Kafka) =>
@@ -84,7 +85,7 @@ object KafkaTestUtils {
           ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG       -> "3000",
           ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG     -> "10000",
           ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG    -> "1000",
-          ConsumerConfig.MAX_POLL_RECORDS_CONFIG         -> "1000",
+          ConsumerConfig.MAX_POLL_RECORDS_CONFIG         -> s"${`max.poll.records`}",
           ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG -> allowAutoCreateTopics.toString
         )
         .withPerPartitionChunkPrefetch(16)
@@ -106,19 +107,24 @@ object KafkaTestUtils {
     properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =
     consumerSettings(
-      clientId,
-      Some(groupId),
-      clientInstanceId,
-      allowAutoCreateTopics,
-      offsetRetrieval,
-      restartStreamOnRebalancing,
-      properties
+      clientId = clientId,
+      groupId = Some(groupId),
+      clientInstanceId = clientInstanceId,
+      allowAutoCreateTopics = allowAutoCreateTopics,
+      offsetRetrieval = offsetRetrieval,
+      restartStreamOnRebalancing = restartStreamOnRebalancing,
+      properties = properties
     )
       .map(
         _.withProperties(
           ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed"
         )
       )
+
+  def simpleConsumer(diagnostics: Diagnostics = Diagnostics.NoOp): ZLayer[ConsumerSettings, Throwable, Consumer] =
+    ZLayer.makeSome[ConsumerSettings, Consumer](
+      ZLayer.succeed(diagnostics) >>> Consumer.live
+    )
 
   def consumer(
     clientId: String,
@@ -132,13 +138,13 @@ object KafkaTestUtils {
   ): ZLayer[Kafka, Throwable, Consumer] =
     (ZLayer(
       consumerSettings(
-        clientId,
-        groupId,
-        clientInstanceId,
-        allowAutoCreateTopics,
-        offsetRetrieval,
-        restartStreamOnRebalancing,
-        properties
+        clientId = clientId,
+        groupId = groupId,
+        clientInstanceId = clientInstanceId,
+        allowAutoCreateTopics = allowAutoCreateTopics,
+        offsetRetrieval = offsetRetrieval,
+        restartStreamOnRebalancing = restartStreamOnRebalancing,
+        properties = properties
       )
     ) ++ ZLayer.succeed(diagnostics)) >>> Consumer.live
 
@@ -155,13 +161,13 @@ object KafkaTestUtils {
   ): ZLayer[Kafka, Throwable, Consumer] =
     (ZLayer(
       transactionalConsumerSettings(
-        groupId,
-        clientId,
-        clientInstanceId,
-        allowAutoCreateTopics,
-        offsetRetrieval,
-        restartStreamOnRebalancing,
-        properties
+        groupId = groupId,
+        clientId = clientId,
+        clientInstanceId = clientInstanceId,
+        allowAutoCreateTopics = allowAutoCreateTopics,
+        offsetRetrieval = offsetRetrieval,
+        restartStreamOnRebalancing = restartStreamOnRebalancing,
+        properties = properties
       ).map(_.withRebalanceListener(rebalanceListener))
     ) ++ ZLayer.succeed(diagnostics)) >>> Consumer.live
 


### PR DESCRIPTION
Results:
```scala
[info] ConsumersComparisonBenchmark.kafkaClients  avgt   50   662.207 ±   7.282  ms/op
[info] ConsumersComparisonBenchmark.zioKafka      avgt   50  2874.359 ± 547.874  ms/op
```