### PR TITLE
Performance improvements

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -7,7 +7,6 @@ name: Website
   release:
     types:
     - published
-    
   push:
     branches:
     - master
@@ -23,7 +22,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Setup Scala
-      uses: actions/setup-java@v3.10.0
+      uses: actions/setup-java@v3.9.0
       with:
         distribution: temurin
         java-version: 17
@@ -46,7 +45,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Setup Scala
-      uses: actions/setup-java@v3.10.0
+      uses: actions/setup-java@v3.9.0
       with:
         distribution: temurin
         java-version: 17
@@ -71,7 +70,7 @@ jobs:
         ref: ${{ github.head_ref }}
         fetch-depth: '0'
     - name: Setup Scala
-      uses: actions/setup-java@v3.10.0
+      uses: actions/setup-java@v3.9.0
       with:
         distribution: temurin
         java-version: 17

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -314,8 +314,8 @@ object Consumer {
         r <- ZIO.environment[R & R1]
         _ <- partitionedStream(subscription, keyDeserializer, valueDeserializer)
                .flatMapPar(Int.MaxValue, bufferSize = settings.perPartitionChunkPrefetch) { case (_, partitionStream) =>
-                 partitionStream.mapChunksZIO(_.mapZIO { case CommittableRecord(record, offset) =>
-                   f(record).as(offset)
+                 partitionStream.mapChunksZIO(_.mapZIO { case committable @ CommittableRecord(record, _, _, _) =>
+                   f(record).as(committable.offset)
                  })
                }
                .provideEnvironment(r)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -214,7 +214,7 @@ private[consumer] final class Runloop(
 
         control.finishWith(
           remaining.map(
-            CommittableRecord(_, commit, getConsumerGroupMetadataIfAny)
+            CommittableRecord(_, tp, commit, getConsumerGroupMetadataIfAny)
           )
         )
       }
@@ -258,6 +258,7 @@ private[consumer] final class Runloop(
         fulfillAction = fulfillAction *> req.succeed(concatenatedChunk.map { record =>
           CommittableRecord(
             record = record,
+            req.tp,
             commitHandle = commit,
             consumerGroupMetadata = getConsumerGroupMetadataIfAny
           )


### PR DESCRIPTION
1. Do not allocate new `TopicPartition` instances when we already have them
2. Only allocate `OffsetImpl` instances when necessary