### PR TITLE
Feed streams through queue instead of promise

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -274,7 +274,7 @@ object ConsumerSpec extends ZIOKafkaSpec {
           client <- randomClient
 
           keepProducing <- Ref.make(true)
-          _             <- (produceOne(topic, "key", "value") *> keepProducing.get).repeatWhile(b => b).fork
+          _             <- produceOne(topic, "key", "value").repeatWhileZIO(_ => keepProducing.get).fork
           _ <- Consumer
                  .plainStream(Subscription.topics(topic), Serde.string, Serde.string)
                  .zipWithIndex

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -1,18 +1,109 @@
 package zio.kafka.consumer.internal
 
-import zio._
-import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
-import zio.stream.Take
+import org.apache.kafka.common.TopicPartition
+import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
+import zio.kafka.consumer.internal.Runloop.Command.Request
+import zio.{ Chunk, LogAnnotation, Promise, Queue, UIO, ZIO }
+import zio.kafka.consumer.internal.Runloop.{ ByteArrayCommittableRecord, Command }
+import zio.stream.{ Take, ZStream }
 
-private[internal] case class PartitionStreamControl(
-  interrupt: Promise[Throwable, Unit],
-  drainQueue: Queue[Take[Nothing, ByteArrayCommittableRecord]]
+private[internal] class PartitionStreamControl private (
+  val tp: TopicPartition,
+  val stream: ZStream[Any, Throwable, ByteArrayCommittableRecord],
+  dataQueue: Queue[Take[Throwable, ByteArrayCommittableRecord]],
+  interruptPromise: Promise[Throwable, Unit],
+  completedPromise: Promise[Throwable, Unit]
 ) {
 
-  def finishWith(remaining: Chunk[ByteArrayCommittableRecord]): ZIO[Any, Nothing, Unit] =
+  /** Offer new data for the stream to process. */
+  def offerRecords(data: Chunk[ByteArrayCommittableRecord]): ZIO[Any, Nothing, Unit] =
+    dataQueue.offer(Take.chunk(data)).unit
+
+  /** To be invoked when the partition was lost. */
+  def lost(): UIO[Boolean] =
+    interruptPromise.fail(new RuntimeException(s"Partition ${tp.toString} was lost"))
+
+  /** To be invoked when the partition was revoked or otherwise needs to be ended. */
+  def end(): ZIO[Any, Nothing, Unit] =
+    ZIO.logTrace(s"Partition ${tp.toString} ending") *>
+      dataQueue.offer(Take.end).unit
+
+  /** To be invoked when the partition was revoked or otherwise needs to be ended, after the last data is processed. */
+  def endWith(data: Chunk[ByteArrayCommittableRecord]): ZIO[Any, Nothing, Unit] =
+    ZIO.logTrace(s"Partition ${tp.toString} ending after ${data.size} records") *> {
+      if (data.isEmpty) {
+        dataQueue.offer(Take.end).unit
+      } else {
+        dataQueue.offerAll(List(Take.chunk(data), Take.end)).unit
+      }
+    }
+
+  /** Returns true when the stream is done. */
+  def isCompleted: ZIO[Any, Nothing, Boolean] =
+    completedPromise.isDone
+
+  /** Wait till the stream is done. */
+  def awaitCompleted(): ZIO[Any, Throwable, Unit] =
+    completedPromise.await
+
+  val tpStream: (TopicPartition, ZStream[Any, Throwable, ByteArrayCommittableRecord]) =
+    (tp, stream)
+}
+
+private[internal] object PartitionStreamControl {
+
+  def newPartitionStream(
+    tp: TopicPartition,
+    commandQueue: Queue[Command],
+    diagnostics: Diagnostics
+  ): ZIO[Any, Nothing, PartitionStreamControl] =
     for {
-      _ <- if (remaining.isEmpty) drainQueue.offer(Take.end)
-           else drainQueue.offerAll(List(Take.chunk(remaining), Take.end))
-      _ <- interrupt.succeed(())
-    } yield ()
+      _                   <- ZIO.logTrace(s"Creating partition stream ${tp.toString}")
+      interruptionPromise <- Promise.make[Throwable, Unit]
+      completedPromise    <- Promise.make[Throwable, Unit]
+      dataQueue           <- Queue.unbounded[Take[Throwable, ByteArrayCommittableRecord]]
+      stream = ZStream.logAnnotate(
+                 LogAnnotation("topic", tp.topic()),
+                 LogAnnotation("partition", tp.partition().toString)
+               ) *>
+                 ZStream.finalizer(
+                   completedPromise.succeed(()) *>
+                     // TODO: I'd like to shutdown the queue here, however, for some reason runloop is still interacting with it during shutdown
+                     // dataQueue.shutdown <*
+                     ZIO.logDebug(s"Partition stream ${tp.toString} has ended")
+                 ) *>
+                 ZStream
+                   .paginateChunkZIO(false) { completed =>
+                     if (completed) ZIO.succeed((Chunk.empty, None))
+                     else {
+                       // First try to take all records that are available right now.
+                       // When no data is available, request more data and await its arrival.
+                       dataQueue.takeAll
+                         .filterOrElse(_.nonEmpty) {
+                           for {
+                             _     <- commandQueue.offer(Request(tp, dataQueue)).unit
+                             _     <- diagnostics.emitIfEnabled(DiagnosticEvent.Request(tp))
+                             taken <- dataQueue.takeBetween(1, Int.MaxValue)
+                           } yield taken
+                         }
+                         // Extract the success values and potential end-of-stream value
+                         .map { takes =>
+                           val (okTakes, endTakes) = takes.splitWhere(!_.isSuccess)
+                           val records = okTakes
+                             .map(
+                               _.fold(
+                                 end = Chunk.empty[ByteArrayCommittableRecord],
+                                 error = _ => Chunk.empty[ByteArrayCommittableRecord],
+                                 value = identity
+                               )
+                             )
+                             .foldLeft(Chunk.empty[ByteArrayCommittableRecord])(_ ++ _)
+                           val isComplete = endTakes.nonEmpty
+                           (records, Some(isComplete))
+                         }
+                     }
+                   }
+                   .interruptWhen(interruptionPromise)
+    } yield new PartitionStreamControl(tp, stream, dataQueue, interruptionPromise, completedPromise)
+
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -80,9 +80,12 @@ private[internal] object PartitionStreamControl {
                        dataQueue.takeAll
                          .filterOrElse(_.nonEmpty) {
                            for {
+                             _     <- ZIO.logDebug(s"Partition stream ${tp.toString} creates data request")
                              _     <- commandQueue.offer(Request(tp, dataQueue)).unit
                              _     <- diagnostics.emitIfEnabled(DiagnosticEvent.Request(tp))
+                             _     <- ZIO.logDebug(s"Partition stream ${tp.toString} has sent data request")
                              taken <- dataQueue.takeBetween(1, Int.MaxValue)
+                             _     <- ZIO.logDebug(s"Partition stream ${tp.toString} received more data")
                            } yield taken
                          }
                          // Extract the success values and potential end-of-stream value

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -439,7 +439,7 @@ private[consumer] final class Runloop(
       updatedPendingCommits <- ZIO.filter(state.pendingCommits)(_.isPending)
       completedTopicPartitions <- ZIO.filter(pollResult.assignedStreams.values)(_.isCompleted).map(_.map(_.tp))
       updatedAssignedStreams =
-        pollResult.assignedStreams.removedAll(completedTopicPartitions) ++
+        pollResult.assignedStreams -- completedTopicPartitions ++
           newAssignedStreams.map(control => control.tp -> control)
     } yield State(
       pendingRequests = pollResult.unfulfilledRequests,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -440,7 +440,7 @@ private[consumer] final class Runloop(
             }
       runningStreams <- ZIO.filter(pollResult.assignedStreams)(_.isRunning)
       updatedStreams = runningStreams ++ newAssignedStreams
-      updatedPendingCommits  <- ZIO.filter(state.pendingCommits)(_.isPending)
+      updatedPendingCommits <- ZIO.filter(state.pendingCommits)(_.isPending)
     } yield State(
       pendingRequests = pollResult.unfulfilledRequests,
       pendingCommits = updatedPendingCommits,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -436,7 +436,7 @@ private[consumer] final class Runloop(
               ZIO.logTrace(s"Offering partition assignment ${pollResult.newlyAssigned}") *>
                 partitions.offer(Take.chunk(Chunk.fromIterable(newStreams.map(_.tpStream))))
             }
-      updatedPendingCommits <- ZIO.filter(state.pendingCommits)(_.isPending)
+      updatedPendingCommits    <- ZIO.filter(state.pendingCommits)(_.isPending)
       completedTopicPartitions <- ZIO.filter(pollResult.assignedStreams.values)(_.isCompleted).map(_.map(_.tp))
       updatedAssignedStreams =
         pollResult.assignedStreams -- completedTopicPartitions ++

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -465,11 +465,7 @@ private[consumer] final class Runloop(
   private def handleOperational(state: State, cmd: Command): Task[State] =
     cmd match {
       case req: Request =>
-        if (state.isSubscribed) {
-          ZIO.succeed(state.addRequest(req))
-        } else {
-          ZIO.succeed(state)
-        }
+        ZIO.succeed(state.addRequest(req))
       case cmd @ Command.Commit(_, _) =>
         doCommit(cmd).as(state.addCommit(cmd))
       case cmd @ Command.ChangeSubscription(_, _, _) =>


### PR DESCRIPTION
Using a queue has the potential to simplify the runloop, and it unlocks new features:
 - runloop no longer needs to 'end' a request when there is no more data (e.g. when we're shutting down),
 - we can remove the concept of 'buffered data',
 - we can proactively get more data when we detect that a stream is paused every 2nd poll.
 
Of these, only the first is implemented. The other points are for future PRs.

This PR is the first step towards solving #706.