### PR TITLE
ZStream based implementation of poll loop

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,6 +129,7 @@ lazy val zioKafkaBench =
     .enablePlugins(JmhPlugin)
     .settings(stdSettings("zio-kafka-bench"))
     .settings(publish / skip := true)
+    .settings(libraryDependencies += logback)
     .dependsOn(zioKafka, zioKafkaTestUtils)
 
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")

--- a/zio-kafka-bench/src/main/resources/logback.xml
+++ b/zio-kafka-bench/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.kafka" level="WARN" />
+    <logger name="state.change.logger" level="WARN" />
+    <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>
+
+    <logger name="kafka" level="WARN" />
+
+    <logger name="org.apache.zookeeper" level="ERROR" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ConsumerBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ConsumerBenchmark.scala
@@ -49,7 +49,6 @@ class ConsumerBenchmark extends ZioBenchmark[Kafka with Producer] {
                  properties = Map(ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> "1000")
                )
              )
-             .timeoutFail(new RuntimeException("Timeout"))(30.seconds)
     } yield ()
   }
 
@@ -75,7 +74,6 @@ class ConsumerBenchmark extends ZioBenchmark[Kafka with Producer] {
                    properties = Map(ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> "1000")
                  )
                )
-               .timeoutFail(new RuntimeException("Timeout"))(30.seconds)
            }
     } yield ()
   }

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioBenchmark.scala
@@ -1,17 +1,25 @@
 package zio.kafka.bench
 import org.openjdk.jmh.annotations.{ Setup, TearDown }
-import zio.{ Runtime, Unsafe, ZIO, ZLayer }
+import zio.kafka.bench.ZioBenchmark.logger
+import zio.{ ZLayer, _ }
 
 import java.util.UUID
 
 trait ZioBenchmark[Environment] {
   var runtime: Runtime.Scoped[Environment] = _
 
+  protected val enableLogging: Boolean = true
+
+  protected val timeout: Duration = 180.seconds
+
   @Setup
   def setup(): Unit =
     runtime = Unsafe.unsafe(implicit unsafe =>
       zio.Runtime.unsafe.fromLayer(
-        bootstrap >+> Runtime.removeDefaultLoggers >+> ZLayer.fromZIO(initialize)
+        bootstrap >+>
+          (Runtime.removeDefaultLoggers >+>
+            (if (enableLogging) Runtime.addLogger(logger) else ZLayer.empty)) >+>
+          ZLayer.fromZIO(initialize)
       )
     )
 
@@ -24,9 +32,37 @@ trait ZioBenchmark[Environment] {
   protected def initialize: ZIO[Environment, Throwable, Any] = ZIO.unit
 
   protected def runZIO(program: ZIO[Environment, Throwable, Any]): Any =
-    Unsafe.unsafe(implicit unsafe => runtime.unsafe.run(program).getOrThrow())
+    Unsafe.unsafe(implicit unsafe =>
+      runtime.unsafe
+        .run(
+          program
+            .tapErrorCause(e => ZIO.debug("Error in benchmark run: " + e.prettyPrint))
+            .timeoutFail(new RuntimeException("Benchmark run timed out"))(timeout)
+            .tapError(_ => Fiber.dumpAll)
+        )
+        .getOrThrow()
+    )
 }
 
 object ZioBenchmark {
   def randomThing(prefix: String): String = s"$prefix-${UUID.randomUUID()}"
+
+  val logger: ZLogger[String, Unit] =
+    new ZLogger[String, Unit] {
+      override def apply(
+        trace: Trace,
+        fiberId: FiberId,
+        logLevel: LogLevel,
+        message: () => String,
+        cause: Cause[Any],
+        context: FiberRefs,
+        spans: List[LogSpan],
+        annotations: Map[String, String]
+      ): Unit =
+        println(
+          s"${java.time.Instant
+              .now()} ${logLevel.label} [fiber=${fiberId.threadName},${annotations.map { case (k, v) => s"$k=$v" }
+              .mkString(",")}] ${message()} ${if (cause.isEmpty) "" else cause.prettyPrint}"
+        )
+    }.filterLogLevel(_ >= LogLevel.Info).map(_ => ())
 }

--- a/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
+++ b/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
@@ -78,7 +78,6 @@ object KafkaTestUtils {
         .withClientId(clientId)
         .withCloseTimeout(5.seconds)
         .withPollTimeout(100.millis)
-        .withPollInterval(100.millis)
         .withProperties(
           ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "earliest",
           ConsumerConfig.METADATA_MAX_AGE_CONFIG         -> "100",

--- a/zio-kafka-test/src/test/scala/zio/kafka/Benchmarks.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/Benchmarks.scala
@@ -81,7 +81,6 @@ object ZIOKafka extends ZIOAppDefault {
       .withGroupId(s"zio-kafka-${scala.util.Random.nextInt()}")
       .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
       .withProperty("fetch.min.bytes", "128000")
-      .withPollInterval(50.millis)
       .withPollTimeout(50.millis)
       .withPerPartitionChunkPrefetch(4)
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -792,27 +792,30 @@ object ConsumerSpec extends ZIOKafkaSpec {
           subscription = Subscription.topics(topic)
           stopConsumer1 <- Promise.make[Nothing, Unit]
           fib <-
-            Consumer
-              .partitionedAssignmentStream(subscription, Serde.string, Serde.string)
-              .rechunk(1)
-              .mapZIOPar(16) { partitions =>
-                ZIO.logInfo(s"Consumer 1 got new partition assignment: ${partitions.map(_._1.toString)}") *>
-                  ZStream
-                    .fromIterable(partitions.map(_._2))
-                    .flatMapPar(Int.MaxValue)(s => s)
-                    .mapZIO(record => messagesReceivedConsumer1.update(_ + 1).as(record))
-                    .map(_.offset)
-                    .aggregateAsync(Consumer.offsetBatches)
-                    .mapZIO(offsetBatch => offsetBatch.commit)
-                    .runDrain
+            ZIO
+              .logAnnotate("consumer", "1") {
+                Consumer
+                  .partitionedAssignmentStream(subscription, Serde.string, Serde.string)
+                  .rechunk(1)
+                  .mapZIOPar(16) { partitions =>
+                    ZIO.logInfo(s"Consumer 1 got new partition assignment: ${partitions.map(_._1.toString)}") *>
+                      ZStream
+                        .fromIterable(partitions.map(_._2))
+                        .flatMapPar(Int.MaxValue)(s => s)
+                        .mapZIO(record => messagesReceivedConsumer1.update(_ + 1).as(record))
+                        .map(_.offset)
+                        .aggregateAsync(Consumer.offsetBatches)
+                        .mapZIO(offsetBatch => offsetBatch.commit)
+                        .runDrain
+                  }
+                  .mapZIO(_ => drainCount.updateAndGet(_ + 1))
+                  .interruptWhen(stopConsumer1.await)
+                  .runDrain
+                  .provideSomeLayer[Kafka](
+                    customConsumer("consumer1", Some(group)) ++ Scope.default
+                  )
+                  .tapError(e => ZIO.logErrorCause(e.getMessage, Cause.fail(e)))
               }
-              .mapZIO(_ => drainCount.updateAndGet(_ + 1))
-              .interruptWhen(stopConsumer1.await)
-              .runDrain
-              .provideSomeLayer[Kafka](
-                customConsumer("consumer1", Some(group)) ++ Scope.default
-              )
-              .tapError(e => ZIO.logErrorCause(e.getMessage, Cause.fail(e)))
               .forkScoped
 
           _ <- messagesReceivedConsumer1.get
@@ -820,17 +823,20 @@ object ConsumerSpec extends ZIOKafkaSpec {
           _ <- ZIO.logInfo("Starting consumer 2")
 
           fib2 <-
-            Consumer
-              .plainStream(subscription, Serde.string, Serde.string)
-              .mapZIO(record => messagesReceivedConsumer2.update(_ + 1).as(record))
-              .map(_.offset)
-              .aggregateAsync(Consumer.offsetBatches)
-              .mapZIO(offsetBatch => offsetBatch.commit)
-              .runDrain
-              .provideSomeLayer[Kafka](
-                customConsumer("consumer2", Some(group))
-              )
-              .tapError(e => ZIO.logErrorCause("Error in consumer 2", Cause.fail(e)))
+            ZIO
+              .logAnnotate("consumer", "2") {
+                Consumer
+                  .plainStream(subscription, Serde.string, Serde.string)
+                  .mapZIO(record => messagesReceivedConsumer2.update(_ + 1).as(record))
+                  .map(_.offset)
+                  .aggregateAsync(Consumer.offsetBatches)
+                  .mapZIO(offsetBatch => offsetBatch.commit)
+                  .runDrain
+                  .provideSomeLayer[Kafka](
+                    customConsumer("consumer2", Some(group))
+                  )
+                  .tapError(e => ZIO.logErrorCause("Error in consumer 2", Cause.fail(e)))
+              }
               .forkScoped
 
           _ <- messagesReceivedConsumer2.get

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -773,7 +773,6 @@ object ConsumerSpec extends ZIOKafkaSpec {
               _.withProperties(
                 ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG -> classOf[CooperativeStickyAssignor].getName
               )
-                .withPollInterval(500.millis)
                 .withPollTimeout(500.millis)
             )
           ) ++ ZLayer.succeed(Diagnostics.NoOp) >>> Consumer.live

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -371,7 +371,6 @@ object Consumer {
       runloop <- Runloop(
                    hasGroupId = settings.hasGroupId,
                    consumer = wrapper,
-                   pollFrequency = settings.pollInterval,
                    pollTimeout = settings.pollTimeout,
                    diagnostics = diagnostics,
                    offsetRetrieval = settings.offsetRetrieval,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -231,7 +231,7 @@ object Consumer {
             ZIO.logDebug(s"Changing kafka subscription to $union") *>
               subscribe(union).as(newSubscriptions.toSet)
         }
-      }
+      }.uninterruptible
 
       def reduceSubscriptions = subscriptions.updateZIO { existingSubscriptions =>
         val newSubscriptions = NonEmptyChunk.fromIterableOption(existingSubscriptions - subscription)
@@ -243,7 +243,7 @@ object Consumer {
           case None =>
             ZIO.logDebug(s"Unsubscribing kafka consumer") *> unsubscribe
         }).as(newSubscriptions.fold(Set.empty[Subscription])(_.toSet))
-      }
+      }.uninterruptible
 
       val onlyByteArraySerdes: Boolean = (keyDeserializer eq Serde.byteArray) && (valueDeserializer eq Serde.byteArray)
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -10,8 +10,7 @@ import zio.kafka.security.KafkaCredentialStore
  * @param properties
  * @param closeTimeout
  * @param pollInterval
- *   When there are no pending requests from partition streams, the frequency of polling for liveness and getting
- *   partition assignments.
+ *   Deprecated, no longer used.
  * @param pollTimeout
  * @param perPartitionChunkPrefetch
  * @param offsetRetrieval
@@ -27,6 +26,7 @@ case class ConsumerSettings(
   bootstrapServers: List[String],
   properties: Map[String, AnyRef],
   closeTimeout: Duration,
+  @deprecated("Is no longer used", "2.1.3")
   pollInterval: Duration,
   pollTimeout: Duration,
   perPartitionChunkPrefetch: Int,
@@ -70,6 +70,7 @@ case class ConsumerSettings(
   def withPerPartitionChunkPrefetch(prefetch: Int): ConsumerSettings =
     copy(perPartitionChunkPrefetch = prefetch)
 
+  @deprecated("no longer used", "2.1.3")
   def withPollInterval(interval: Duration): ConsumerSettings =
     copy(pollInterval = interval)
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -26,8 +26,6 @@ case class ConsumerSettings(
   bootstrapServers: List[String],
   properties: Map[String, AnyRef],
   closeTimeout: Duration,
-  @deprecated("Is no longer used", "2.1.3")
-  pollInterval: Duration,
   pollTimeout: Duration,
   perPartitionChunkPrefetch: Int,
   offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
@@ -70,10 +68,6 @@ case class ConsumerSettings(
   def withPerPartitionChunkPrefetch(prefetch: Int): ConsumerSettings =
     copy(perPartitionChunkPrefetch = prefetch)
 
-  @deprecated("no longer used", "2.1.3")
-  def withPollInterval(interval: Duration): ConsumerSettings =
-    copy(pollInterval = interval)
-
   def withPollTimeout(timeout: Duration): ConsumerSettings =
     copy(pollTimeout = timeout)
 
@@ -102,7 +96,6 @@ object ConsumerSettings {
       bootstrapServers = bootstrapServers,
       properties = Map.empty,
       closeTimeout = 30.seconds,
-      pollInterval = 50.millis,
       pollTimeout = 50.millis,
       perPartitionChunkPrefetch = 2,
       offsetRetrieval = OffsetRetrieval.Auto(),

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -9,8 +9,6 @@ import zio.kafka.security.KafkaCredentialStore
  * @param bootstrapServers
  * @param properties
  * @param closeTimeout
- * @param pollInterval
- *   Deprecated, no longer used.
  * @param pollTimeout
  * @param perPartitionChunkPrefetch
  * @param offsetRetrieval

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -704,7 +704,7 @@ private[consumer] object Runloop {
                 )
       _    <- ZIO.logDebug("Starting Runloop").withFinalizer(_ => ZIO.logDebug("Shut down Runloop"))
       stop <- Ref.make(false)
-      fib  <- runloop.run(stop).forkScoped
+      fib  <- ZIO.blocking(runloop.run(stop)).forkScoped
       _    <- ZIO.addFinalizer(ZIO.logTrace("Shutting down Runloop") *> stop.set(true) *> fib.join.orDie)
     } yield runloop
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -645,7 +645,7 @@ private[consumer] object Runloop {
 
   sealed trait Command
   object Command {
-    final case object PeriodicPoll extends Command
+    case object PeriodicPoll extends Command
     final case class Commit(offsets: Map[TopicPartition, Long], cont: Promise[Throwable, Unit]) extends Command {
       @inline def isDone: UIO[Boolean]    = cont.isDone
       @inline def isPending: UIO[Boolean] = isDone.negate


### PR DESCRIPTION
This avoids a race condition between commandQueue.takeAll and timeout, which could result in lost commands and therefore timeouts or stuck partition streams (data loss was not a risk).

Also, to fix flaky benchmark runs:

* Later confirmation of change subscription command
* Cleaner shutdown of runloop (is diferent from the graceful shutdown)
* Add logging (off by default) to benchmark for troubleshooting purposes

Note that before #683 we already had a stream-based poll loop, now we do again but with more optimized behavior.