### PR TITLE
Remove buffered records

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -14,9 +14,9 @@ private[consumer] class ConsumerAccess(
   access: Semaphore
 ) {
   def withConsumer[A](f: ByteArrayKafkaConsumer => A): Task[A] =
-    withConsumerM[Any, A](c => ZIO.attempt(f(c)))
+    withConsumerZIO[Any, A](c => ZIO.attempt(f(c)))
 
-  def withConsumerM[R, A](f: ByteArrayKafkaConsumer => RIO[R, A]): RIO[R, A] =
+  def withConsumerZIO[R, A](f: ByteArrayKafkaConsumer => RIO[R, A]): RIO[R, A] =
     access.withPermit(withConsumerNoPermit(f))
 
   private[consumer] def withConsumerNoPermit[R, A](


### PR DESCRIPTION
Previously we had to buffer records because the target stream was not created yet, or because it had not requested any data yet. Since #727 we no longer need to wait for a data request. Secondly, we now always create the stream _before_ we try to offer records to it.
As a consequence we no longer need to buffer records.

Streams for manually assigned partitions are now also stored in the runloop state. This was needed to find them for offering new data. A nice side effect is that they now properly end during a shutdown.

TODO: restore diagnostics around line 341?

Also:
- Rename `withConsumerM` to `withConsumerZIO` following ZIO 2 naming conventions.
- Make members private where possible.