### PR TITLE
Improve Logback configuration in benchmarks

### DIFF
--- a/zio-kafka-bench/src/main/resources/logback.xml
+++ b/zio-kafka-bench/src/main/resources/logback.xml
@@ -1,19 +1,28 @@
 <configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+    <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <logger name="org.apache.kafka" level="WARN" />
-    <logger name="state.change.logger" level="WARN" />
+    <appender name="ASYNC_STDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>4096</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <appender-ref ref="STDOUT"/>
+    </appender>
+
+    <logger name="org.apache.kafka" level="WARN"/>
+    <logger name="state.change.logger" level="WARN"/>
     <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>
 
-    <logger name="kafka" level="WARN" />
+    <logger name="kafka" level="WARN"/>
 
-    <logger name="org.apache.zookeeper" level="ERROR" />
+    <logger name="org.apache.zookeeper" level="ERROR"/>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT" />
+        <appender-ref ref="ASYNC_STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
- Make Logback less noisy at boot
- Use an async logger to try to minimize the impact on benchmark results