### PR TITLE
Improve performances: Remove the `aggregateAsync` call

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -491,11 +491,14 @@ private[consumer] final class Runloop private (
           s"Starting poll with ${state.pendingRequests.size} pending requests and ${state.pendingCommits.size} pending commits"
         )
 
-    ZStream
-      .fromQueue(commandQueue)
-      .timeoutFail[Throwable](RunloopTimeout)(runloopTimeout)
-      .takeWhile(_ != StopRunloop)
-      .runChunksFoldZIO(State.initial) { case (state, commands) =>
+    /**
+     * Inlined, simplified and specialized for our needs version of [[ZSink.foldChunksZIO]]
+     *
+     * Code initially inspired by the implementation of [[ZStream.runFoldZIO]] with everything we don't need removed and
+     * with chunking added
+     */
+    val sink = {
+      def execute(state: State, commands: Chunk[Command]): Task[State] =
         for {
           _          <- ZIO.logTrace(s"Processing ${commands.size} commands: ${commands.mkString(",")}")
           isShutdown <- isShutdown
@@ -508,31 +511,28 @@ private[consumer] final class Runloop private (
           // Immediately poll again, after processing all new queued commands
           _ <- commandQueue.offer(Command.Poll).when(updatedStateAfterPoll.shouldPoll)
         } yield updatedStateAfterPoll
-      }
+
+      def reader(s: State): ZChannel[Any, Throwable, Chunk[Command], Any, Throwable, Nothing, Unit] =
+        ZChannel.readWith(
+          (in: Chunk[Command]) => ZChannel.fromZIO(execute(s, in)).flatMap(reader),
+          (err: Throwable) => ZChannel.fail(err),
+          (_: Any) => ZChannel.unit
+        )
+
+      ZSink.fromChannel(reader(State.initial))
+    }
+
+    ZStream
+      .fromQueue(commandQueue)
+      .timeoutFail[Throwable](RunloopTimeout)(runloopTimeout)
+      .takeWhile(_ != StopRunloop)
+      .run(sink)
       .tapErrorCause(cause => ZIO.logErrorCause("Error in Runloop", cause))
       .onError(cause => partitions.offer(Take.failCause(cause)))
   }
 }
 
 private[consumer] object Runloop {
-  private implicit final class RichZStream[R, E, A](private val stream: ZStream[R, E, A]) extends AnyVal {
-
-    /**
-     * Adapted from [[ZStream.runFoldZIO]]
-     */
-    def runChunksFoldZIO[R1 <: R, E1 >: E, S](s: => S)(f: (S, Chunk[A]) => ZIO[R1, E1, S])(implicit
-      trace: Trace
-    ): ZIO[R1, E1, S] = ZIO.scoped[R1](runChunksFoldWhileScopedZIO[R1, E1, S](s)(_ => true)(f))
-
-    /**
-     * Adapted from [[ZStream.runFoldWhileScopedZIO]]
-     */
-    private def runChunksFoldWhileScopedZIO[R1 <: R, E1 >: E, S](
-      s: => S
-    )(cont: S => Boolean)(f: (S, Chunk[A]) => ZIO[R1, E1, S])(implicit trace: Trace): ZIO[R1 with Scope, E1, S] =
-      stream.runScoped(ZSink.foldChunksZIO(s)(cont)(f))
-  }
-
   type ByteArrayCommittableRecord = CommittableRecord[Array[Byte], Array[Byte]]
 
   // Internal parameters, should not be necessary to tune

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -491,14 +491,11 @@ private[consumer] final class Runloop private (
           s"Starting poll with ${state.pendingRequests.size} pending requests and ${state.pendingCommits.size} pending commits"
         )
 
-    /**
-     * Inlined, simplified and specialized for our needs version of [[ZSink.foldChunksZIO]]
-     *
-     * Code initially inspired by the implementation of [[ZStream.runFoldZIO]] with everything we don't need removed and
-     * with chunking added
-     */
-    val sink = {
-      def execute(state: State, commands: Chunk[Command]): Task[State] =
+    ZStream
+      .fromQueue(commandQueue)
+      .timeoutFail[Throwable](RunloopTimeout)(runloopTimeout)
+      .takeWhile(_ != StopRunloop)
+      .runFoldChunksDiscardZIO(State.initial) { (state, commands) =>
         for {
           _          <- ZIO.logTrace(s"Processing ${commands.size} commands: ${commands.mkString(",")}")
           isShutdown <- isShutdown
@@ -511,28 +508,33 @@ private[consumer] final class Runloop private (
           // Immediately poll again, after processing all new queued commands
           _ <- commandQueue.offer(Command.Poll).when(updatedStateAfterPoll.shouldPoll)
         } yield updatedStateAfterPoll
-
-      def reader(s: State): ZChannel[Any, Throwable, Chunk[Command], Any, Throwable, Nothing, Unit] =
-        ZChannel.readWith(
-          (in: Chunk[Command]) => ZChannel.fromZIO(execute(s, in)).flatMap(reader),
-          (err: Throwable) => ZChannel.fail(err),
-          (_: Any) => ZChannel.unit
-        )
-
-      ZSink.fromChannel(reader(State.initial))
-    }
-
-    ZStream
-      .fromQueue(commandQueue)
-      .timeoutFail[Throwable](RunloopTimeout)(runloopTimeout)
-      .takeWhile(_ != StopRunloop)
-      .run(sink)
+      }
       .tapErrorCause(cause => ZIO.logErrorCause("Error in Runloop", cause))
       .onError(cause => partitions.offer(Take.failCause(cause)))
   }
 }
 
 private[consumer] object Runloop {
+  private implicit final class StreamOps[R, E, A](private val stream: ZStream[R, E, A]) extends AnyVal {
+
+    /**
+     * Inlined, simplified and specialized for our needs version of [[ZSink.foldChunksZIO]]
+     *
+     * Code initially inspired by the implementation of [[ZStream.runFoldZIO]] with everything we don't need removed and
+     * with chunking added
+     */
+    def runFoldChunksDiscardZIO[R1 <: R, E1 >: E, S](s: S)(f: (S, Chunk[A]) => ZIO[R1, E1, S]): ZIO[R1, E1, Unit] = {
+      def reader(s: S): ZChannel[R1, E1, Chunk[A], Any, E1, Nothing, Unit] =
+        ZChannel.readWith(
+          (in: Chunk[A]) => ZChannel.fromZIO(f(s, in)).flatMap(reader),
+          (err: E1) => ZChannel.fail(err),
+          (_: Any) => ZChannel.unit
+        )
+
+      stream.run(ZSink.fromChannel(reader(s)))
+    }
+  }
+
   type ByteArrayCommittableRecord = CommittableRecord[Array[Byte], Array[Byte]]
 
   // Internal parameters, should not be necessary to tune


### PR DESCRIPTION
To replicate the benchmark results:
```bash
sbt "zioKafkaBench/Jmh/run -wi 10 -i 10 -r 1 -w 1 -t 1 -f 5 -foe true zio.kafka.bench.ConsumersComparisonBenchmark"
```

The benchmark results **BEFORE** these changes (based on these changed: https://github.com/zio/zio-kafka/pull/749) are quite **stable**, and the average performance is quite good:

```scala
[info] # Fork: 5 of 5
[info] OpenJDK 64-Bit Server VM warning: -XX:ThreadPriorityPolicy=1 may require system level permission, e.g., being the root user. If the necessary permission is not possessed, changes to priority will be silently ignored.
[error] SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
[error] SLF4J: Defaulting to no-operation (NOP) logger implementation
[error] SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[error] SLF4J: Failed to load class "org.slf4j.impl.StaticMDCBinder".
[error] SLF4J: Defaulting to no-operation MDCAdapter implementation.
[error] SLF4J: See http://www.slf4j.org/codes.html#no_static_mdc_binder for further details.
[info] # Warmup Iteration   1: 2782.623 ms/op
[info] # Warmup Iteration   2: 2160.183 ms/op
[info] # Warmup Iteration   3: 2410.273 ms/op
[info] # Warmup Iteration   4: 2087.847 ms/op
[info] # Warmup Iteration   5: 1564.117 ms/op
[info] # Warmup Iteration   6: 1626.549 ms/op
[info] # Warmup Iteration   7: 2345.690 ms/op
[info] # Warmup Iteration   8: 2324.042 ms/op
[info] # Warmup Iteration   9: 2322.717 ms/op
[info] # Warmup Iteration  10: 1814.914 ms/op
[info] Iteration   1: 1800.236 ms/op
[info] Iteration   2: 1605.795 ms/op
[info] Iteration   3: 1887.400 ms/op
[info] Iteration   4: 1471.681 ms/op
[info] Iteration   5: 1265.121 ms/op
[info] Iteration   6: 1603.288 ms/op
[info] Iteration   7: 2387.570 ms/op
[info] Iteration   8: 1711.696 ms/op
[info] Iteration   9: 2411.515 ms/op
[info] Iteration  10: 2272.847 ms/op
[info] Result "zio.kafka.bench.ConsumersComparisonBenchmark.zioKafka":
[info]   1849.335 ±(99.9%) 185.495 ms/op [Average]
[info]   (min, avg, max) = (1170.867, 1849.335, 2703.178), stdev = 374.709
[info]   CI (99.9%): [1663.840, 2034.830] (assumes normal distribution)
[info] # Run complete. Total time: 00:06:39
```

The benchmark results **AFTER** these changes are quite **unstable**, but the peak performance is quite better:
```scala
[info] # Fork: 5 of 5
[info] OpenJDK 64-Bit Server VM warning: -XX:ThreadPriorityPolicy=1 may require system level permission, e.g., being the root user. If the necessary permission is not possessed, changes to priority will be silently ignored.
[error] SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
[error] SLF4J: Defaulting to no-operation (NOP) logger implementation
[error] SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[error] SLF4J: Failed to load class "org.slf4j.impl.StaticMDCBinder".
[error] SLF4J: Defaulting to no-operation MDCAdapter implementation.
[error] SLF4J: See http://www.slf4j.org/codes.html#no_static_mdc_binder for further details.
[info] # Warmup Iteration   1: 3443.871 ms/op
[info] # Warmup Iteration   2: 1770.033 ms/op
[info] # Warmup Iteration   3: 3526.743 ms/op
[info] # Warmup Iteration   4: 1888.485 ms/op
[info] # Warmup Iteration   5: 5033.633 ms/op
[info] # Warmup Iteration   6: 4413.383 ms/op
[info] # Warmup Iteration   7: 1503.804 ms/op
[info] # Warmup Iteration   8: 2806.786 ms/op
[info] # Warmup Iteration   9: 3364.834 ms/op
[info] # Warmup Iteration  10: 1269.350 ms/op
[info] Iteration   1: 686.590 ms/op
[info] Iteration   2: 3273.708 ms/op
[info] Iteration   3: 1413.702 ms/op
[info] Iteration   4: 1310.915 ms/op
[info] Iteration   5: 1307.911 ms/op
[info] Iteration   6: 2215.191 ms/op
[info] Iteration   7: 1435.898 ms/op
[info] Iteration   8: 1017.505 ms/op
[info] Iteration   9: 4297.892 ms/op
[info] Iteration  10: 4327.193 ms/op
[info] Result "zio.kafka.bench.ConsumersComparisonBenchmark.zioKafka":
[info]   1799.058 ±(99.9%) 515.830 ms/op [Average]
[info]   (min, avg, max) = (686.590, 1799.058, 5009.849), stdev = 1042.003
[info]   CI (99.9%): [1283.227, 2314.888] (assumes normal distribution)
[info] # Run complete. Total time: 00:07:31
```

Last run of the benchmarks with the latest version of this code:
```scala
[info] # Fork: 5 of 5
[info] OpenJDK 64-Bit Server VM warning: -XX:ThreadPriorityPolicy=1 may require system level permission, e.g., being the root user. If the necessary permission is not possessed, changes to priority will be silently ignored.
[error] SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
[error] SLF4J: Defaulting to no-operation (NOP) logger implementation
[error] SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[error] SLF4J: Failed to load class "org.slf4j.impl.StaticMDCBinder".
[error] SLF4J: Defaulting to no-operation MDCAdapter implementation.
[error] SLF4J: See http://www.slf4j.org/codes.html#no_static_mdc_binder for further details.
[info] # Warmup Iteration   1: 2049.754 ms/op
[info] # Warmup Iteration   2: 1481.757 ms/op
[info] # Warmup Iteration   3: 1578.479 ms/op
[info] # Warmup Iteration   4: 4836.508 ms/op
[info] # Warmup Iteration   5: 1980.513 ms/op
[info] # Warmup Iteration   6: 4928.249 ms/op
[info] # Warmup Iteration   7: 1472.769 ms/op
[info] # Warmup Iteration   8: 1263.501 ms/op
[info] # Warmup Iteration   9: 5014.016 ms/op
[info] # Warmup Iteration  10: 1258.164 ms/op
[info] Iteration   1: 1958.565 ms/op
[info] Iteration   2: 1735.329 ms/op
[info] Iteration   3: 1414.613 ms/op
[info] Iteration   4: 1224.270 ms/op
[info] Iteration   5: 1404.372 ms/op
[info] Iteration   6: 1236.202 ms/op
[info] Iteration   7: 3817.833 ms/op
[info] Iteration   8: 3835.710 ms/op
[info] Iteration   9: 1841.279 ms/op
[info] Iteration  10: 1332.895 ms/op
[info] Result "zio.kafka.bench.ConsumersComparisonBenchmark.zioKafka":
[info]   1636.533 ±(99.9%) 402.992 ms/op [Average]
[info]   (min, avg, max) = (783.816, 1636.533, 4721.287), stdev = 814.063
[info]   CI (99.9%): [1233.541, 2039.525] (assumes normal distribution)
[info] # Run complete. Total time: 00:07:09
```