### PR TITLE
Direct access to underlying consumer when already on a blocking threadpool

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -224,7 +224,6 @@ private[consumer] final class Runloop private (
             )
         }
       }
-      .fork // Do not await fulfilling of results
       .as(Runloop.FulfillResult(unfulfilledRequests))
   }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -200,16 +200,16 @@ private[consumer] final class Runloop private (
     val committableRecords = Chunk.fromIterable(tps).map { tp =>
       val committableRecordsForTp = Chunk
         .fromJavaIterable(polledRecords.records(tp))
-            .map { consumerRecord =>
-              CommittableRecord[Array[Byte], Array[Byte]](
-                record = consumerRecord,
-                commitHandle = commit _,
-                consumerGroupMetadata = consumerGroupMetadata
-              )
-            }
+        .map { consumerRecord =>
+          CommittableRecord[Array[Byte], Array[Byte]](
+            record = consumerRecord,
+            commitHandle = commit _,
+            consumerGroupMetadata = consumerGroupMetadata
+          )
+        }
 
-        tp -> committableRecordsForTp
-      }
+      tp -> committableRecordsForTp
+    }
 
     val unfulfilledRequests = pendingRequests.filter(req => !tps.contains(req.tp))
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -214,7 +214,7 @@ private[consumer] final class Runloop private (
     val unfulfilledRequests = pendingRequests.filter(req => !tps.contains(req.tp))
 
     ZIO
-      .foreachParDiscard(committableRecords) { case (tp, records) =>
+      .foreachDiscard(committableRecords) { case (tp, records) =>
         streams.get(tp) match {
           case Some(streamControl) =>
             streamControl.offerRecords(records)
@@ -224,7 +224,6 @@ private[consumer] final class Runloop private (
             )
         }
       }
-      .withParallelism(committableRecords.size)
       .fork // Do not await fulfilling of results
       .as(Runloop.FulfillResult(unfulfilledRequests))
   }


### PR DESCRIPTION
* More direct access to ZIO consumer when already on a blocking threadpool (in the poll loop)