### PR TITLE
Divide allocations: Instantiate the `OffsetImpl` as late as possible to avoid allocatiing one `OffsetImpl` and one `TopicPartition` for each consumed Record

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -317,9 +317,7 @@ object Consumer {
         r <- ZIO.environment[R & R1]
         _ <- partitionedStream(subscription, keyDeserializer, valueDeserializer)
                .flatMapPar(Int.MaxValue, bufferSize = settings.perPartitionChunkPrefetch) { case (_, partitionStream) =>
-                 partitionStream.mapChunksZIO(_.mapZIO { case CommittableRecord(record, offset) =>
-                   f(record).as(offset)
-                 })
+                 partitionStream.mapChunksZIO(_.mapZIO((c: CommittableRecord[K, V]) => f(c.record).as(c.offset)))
                }
                .provideEnvironment(r)
                .aggregateAsync(offsetBatches)


### PR DESCRIPTION
## Top 20 allocations

Before:
```scala
  1336080168   17.35%      480  java.nio.HeapByteBuffer
  1191500688   15.47%      550  byte[]
   860818808   11.18%      300  org.apache.kafka.clients.consumer.ConsumerRecord
   634074728    8.23%      221  org.apache.kafka.common.record.DefaultRecord
   407867984    5.30%      144  org.apache.kafka.common.header.internals.RecordHeaders
   378511944    4.91%      113  java.util.Arrays$ArrayList
   366799384    4.76%      133  zio.kafka.consumer.OffsetImpl             // This is removed by this PR
   363222880    4.72%      122  org.apache.kafka.common.TopicPartition    // This is removed by this PR
   332732040    4.32%      105  java.util.Optional
   312787320    4.06%      113  zio.kafka.consumer.CommittableRecord
   218850968    2.84%      159  java.lang.Object[]
   215880776    2.80%       87  java.util.ArrayList
    44586080    0.58%       70  zio.ZIO$Sync
    42727056    0.55%       53  scala.collection.immutable.$colon$colon
    40930752    0.53%       61  zio.ZIO$OnSuccess
    33432912    0.43%       68  zio.ChunkBuilder$$anon$1
    33134848    0.43%       41  scala.Some
    28144720    0.37%       26  zio.Chunk$AnyRefArray
    26764848    0.35%       36  int[]
    25077088    0.33%       16  zio.Fiber$Status$Running
```

After:
```scala
  1227880272   19.17%      465  java.nio.HeapByteBuffer
   979704352   15.30%      659  byte[]
   748551144   11.69%      242  org.apache.kafka.common.record.DefaultRecord
   708816152   11.07%      248  org.apache.kafka.clients.consumer.ConsumerRecord
   349593280    5.46%      118  java.util.Arrays$ArrayList
   331885408    5.18%       99  org.apache.kafka.common.header.internals.RecordHeaders
   320828184    5.01%      106  zio.kafka.consumer.CommittableRecord
   270539728    4.22%      320  java.lang.Object[]
   264591792    4.13%       78  java.util.Optional
   239107904    3.73%       99  java.util.ArrayList
    50548600    0.79%      114  scala.Some
    41103736    0.64%      177  zio.ZIO$Sync
    39248272    0.61%      196  zio.ZIO$OnSuccess
    34857632    0.54%      123  scala.collection.immutable.$colon$colon
    31566480    0.49%       29  zio.Fiber$Status$Running
    24432520    0.38%       77  zio.ZIO$OnSuccessAndFailure
    23076384    0.36%       63  zio.Chunk$AnyRefArray
    22157080    0.35%       26  zio.Chunk$Slice
    22040776    0.34%       26  zio.ZIO$$Lambda$135+0x0000000800d69930
    17996640    0.28%       43  java.lang.Integer
```

## To reproduce:
```bash
zioKafkaBench/Jmh/run -wi 10 -i 10 -r 1 -w 1 -t 1 -rf json -foe true -prof async:event=alloc
```

## Full profiling results
Before: [summary-alloc_before.txt](https://github.com/zio/zio-kafka/files/11082397/summary-alloc_before.txt)
After: [summary-alloc_after.txt](https://github.com/zio/zio-kafka/files/11082401/summary-alloc_after.txt)