### PR TITLE
Optimise `handlePoll` code: Ensure that both `runningStreams` and `newAssignedStreams` are Chunks to take advantage of the optimised version of `++` when computing the `updatedStreams`

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -373,7 +373,7 @@ private[consumer] final class Runloop private (
           ZIO.succeed(Chunk.empty[PartitionStreamControl])
         else
           ZIO
-            .foreach(pollResult.newlyAssigned)(newPartitionStream)
+            .foreach(Chunk.fromIterable(pollResult.newlyAssigned))(newPartitionStream)
             .tap { newStreams =>
               ZIO.logTrace(s"Offering partition assignment ${pollResult.newlyAssigned}") *>
                 partitions.offer(Take.chunk(Chunk.fromIterable(newStreams.map(_.tpStream))))


### PR DESCRIPTION
Seen in a CPU profiling session:
```scala
--- 20000000 ns (0.08%), 2 samples
  [ 0] itable stub
  [ 1] scala.collection.SeqView$Id.length
  [ 2] scala.collection.IndexedSeqView$IndexedSeqViewIterator.<init>
  [ 3] scala.collection.IndexedSeqView.iterator
  [ 4] scala.collection.IndexedSeqView.iterator$
  [ 5] scala.collection.IndexedSeqView$Id.iterator
  [ 6] scala.collection.IndexedSeqOps.iterator
  [ 7] scala.collection.IndexedSeqOps.iterator$
  [ 8] zio.Chunk.iterator
  [ 9] scala.collection.mutable.Growable.addAll
  [10] scala.collection.mutable.Growable.addAll$
  [11] zio.ChunkBuilder.addAll
  [12] scala.collection.StrictOptimizedSeqOps.appendedAll
  [13] scala.collection.StrictOptimizedSeqOps.appendedAll$
  [14] zio.Chunk.appendedAll
  [15] scala.collection.SeqOps.concat
  [16] scala.collection.SeqOps.concat$
  [17] zio.Chunk.concat
  [18] scala.collection.IterableOps.$plus$plus
  [19] scala.collection.IterableOps.$plus$plus$
  [20] zio.Chunk.$plus$plus
  [21] zio.kafka.consumer.internal.Runloop.$anonfun$handlePoll$28
  [22] zio.kafka.consumer.internal.Runloop$$Lambda$2644.0x000000080135f1d8.apply
  [23] zio.ZIO.$anonfun$map$2
  [24] zio.ZIO$$Lambda$126.0x0000000800d697e8.apply
  [25] zio.internal.FiberRuntime.runLoop
  [26] zio.internal.FiberRuntime.runLoop
  [27] zio.internal.FiberRuntime.evaluateEffect
  [28] zio.internal.FiberRuntime.evaluateMessageWhileSuspended
  [29] zio.internal.FiberRuntime.drainQueueOnCurrentThread
  [30] zio.internal.FiberRuntime.run
  [31] java.util.concurrent.ThreadPoolExecutor.runWorker
  [32] java.util.concurrent.ThreadPoolExecutor$Worker.run
  [33] java.lang.Thread.run
```