### PR TITLE
Fix restartStreamsOnRebalancing

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -326,13 +326,13 @@ private[consumer] final class Runloop private (
                                       ZIO.succeed(result)
                                     case Some(Runloop.RebalanceEvent.Assigned(_)) =>
                                       // If we get here, `restartStreamsOnRebalancing == true`
-                                      // not treating any partitions as revoked, as endRevokedPartitions was called previously in the rebalance listener
-                                      ZIO.succeed {
-                                        Runloop.RevokeResult(
-                                          pendingRequests = state.pendingRequests,
-                                          assignedStreams = state.assignedStreams
-                                        )
-                                      }
+                                      // endRevokedPartitions was not called yet in the rebalance listener,
+                                      // and all partitions should be revoked
+                                      endRevokedPartitions(
+                                        state.pendingRequests,
+                                        state.assignedStreams,
+                                        isRevoked = _ => true
+                                      )
                                     case None =>
                                       // End streams for partitions that are no longer assigned
                                       val isNotAssigned = (tp: TopicPartition) => !currentAssigned.contains(tp)


### PR DESCRIPTION
When a rebalance only leads to additional partitions, we still need to stop all streams in restartStreamsOnRebalancing mode.