### PR TITLE
Increase default runloop timeout

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -92,7 +92,7 @@ case class ConsumerSettings(
 }
 
 object ConsumerSettings {
-  val defaultRunloopTimeout: Duration = 30.seconds
+  val defaultRunloopTimeout: Duration = 4.minutes
 
   def apply(bootstrapServers: List[String]): ConsumerSettings =
     new ConsumerSettings(


### PR DESCRIPTION
Accommodate programs that are slow to start or otherwise leave the consumer unused for a longer time. Note that the value is still lower than `max.poll.interval.ms` (which defaults to 5 min).