### PR TITLE
Commit immediately instead of waiting for poll to complete

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -134,7 +134,7 @@ private[consumer] final class Runloop private (
     val onFailure: Throwable => UIO[Unit] = {
       case _: RebalanceInProgressException =>
         ZIO.logDebug(s"Rebalance in progress, retrying commit for offsets $offsets") *>
-          commandQueue.offer(cmd).unit
+          commandQueue.offer(cmd).unit // TODO: retry, but do not add to command queue again
       case err =>
         cont(Exit.fail(err)) <* diagnostics.emitIfEnabled(DiagnosticEvent.Commit.Failure(offsets, err))
     }


### PR DESCRIPTION
Given a situation with a large poll timeout, no consumer lag and no new messages on the topic, when a commit is made, it will have to wait for an in-progress poll to complete before `KafkaConsumer#commitAsync` is called. It will then again have to wait for the duration of the poll timeout before the commit is confirmed. This is up to `2 * pollTimeout`. 

By committing immediately (during the poll), we can reduce the wait duration to max `1 * pollTimeout`.