### PR TITLE
Improve stream restart in restartStreamsOnRebalancing mode

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -156,7 +156,7 @@ private[consumer] final class Runloop private (
       assignedStreams.partition(control => isRevoked(control.tp))
 
     ZIO
-      .foreachDiscard(revokedStreams)(control => control.end())
+      .foreachDiscard(revokedStreams)(_.end())
       .as(
         Runloop.RevokeResult(
           pendingRequests = pendingRequests.filter(req => !isRevoked(req.tp)),

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -329,14 +329,6 @@ private[consumer] final class Runloop private (
             )
           }
         }
-      _ <- {
-        val restartingStreams =
-          state.assignedStreams.filter(control => pollResult.startingTps.contains(control.tp))
-        ZIO.when(restartingStreams.nonEmpty) {
-          ZIO.logDebug(s"Awaiting end of ${restartingStreams.size} restarting streams") *>
-            ZIO.foreachDiscard(restartingStreams)(_.awaitCompleted())
-        }
-      }
       startingStreams <-
         if (pollResult.startingTps.isEmpty) {
           ZIO.succeed(Chunk.empty[PartitionStreamControl])

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -302,7 +302,10 @@ private[consumer] final class Runloop private (
                               case Some(_) =>
                                 // If we get here, `restartStreamsOnRebalancing == true`,
                                 // some partitions were revoked and/or assigned and
-                                // all streams were ended.
+                                // all already assigned streams were ended.
+                                // Therefore, all currently assigned tps are starting,
+                                // either because they are restarting, or because they
+                                // are new.
                                 currentAssigned
                               case None =>
                                 newlyAssigned

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -300,8 +300,9 @@ private[consumer] final class Runloop private (
 
               startingTps = rebalanceEvent match {
                               case Some(_) =>
-                                // If we get here, `restartStreamsOnRebalancing == true` and
-                                // some partitions were revoked and/or assigned.
+                                // If we get here, `restartStreamsOnRebalancing == true`,
+                                // some partitions were revoked and/or assigned and
+                                // all streams were ended.
                                 currentAssigned
                               case None =>
                                 newlyAssigned


### PR DESCRIPTION
When a stream is restarted (in restartStreamsOnRebalancing mode) do not seek to the commit offset (only do this for actually newly assigned streams).

Also: remove double logging.