### PR TITLE
Wait for stream end in rebalance listener

### DIFF
--- a/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
+++ b/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
@@ -70,7 +70,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
-    `max.poll.records`: Int = 1000,
+    `max.poll.records`: Int = 100, // settings this higher can cause concurrency bugs to go unnoticed
     runloopTimeout: Duration = ConsumerSettings.defaultRunloopTimeout,
     properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =

--- a/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
+++ b/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
@@ -70,7 +70,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
-    endRevokedStreamsBeforeRebalance: Boolean = true,
+    rebalanceSafeStreamEnd: Boolean = true,
     `max.poll.records`: Int = 100, // settings this higher can cause concurrency bugs to go unnoticed
     runloopTimeout: Duration = ConsumerSettings.defaultRunloopTimeout,
     properties: Map[String, String] = Map.empty
@@ -93,7 +93,7 @@ object KafkaTestUtils {
         .withPerPartitionChunkPrefetch(16)
         .withOffsetRetrieval(offsetRetrieval)
         .withRestartStreamOnRebalancing(restartStreamOnRebalancing)
-        .withEndRevokedStreamsBeforeRebalance(endRevokedStreamsBeforeRebalance)
+        .withRebalanceSafeStreamEnd(rebalanceSafeStreamEnd)
         .withProperties(properties)
 
       val withClientInstanceId = clientInstanceId.fold(settings)(settings.withGroupInstanceId)
@@ -107,7 +107,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
-    endRevokedStreamsBeforeRebalance: Boolean = true,
+    rebalanceSafeStreamEnd: Boolean = true,
     properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =
     consumerSettings(
@@ -117,7 +117,7 @@ object KafkaTestUtils {
       allowAutoCreateTopics = allowAutoCreateTopics,
       offsetRetrieval = offsetRetrieval,
       restartStreamOnRebalancing = restartStreamOnRebalancing,
-      endRevokedStreamsBeforeRebalance = endRevokedStreamsBeforeRebalance,
+      rebalanceSafeStreamEnd = rebalanceSafeStreamEnd,
       properties = properties
     )
       .map(
@@ -139,7 +139,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     diagnostics: Diagnostics = Diagnostics.NoOp,
     restartStreamOnRebalancing: Boolean = false,
-    endRevokedStreamsBeforeRebalance: Boolean = true,
+    rebalanceSafeStreamEnd: Boolean = true,
     properties: Map[String, String] = Map.empty
   ): ZLayer[Kafka, Throwable, Consumer] =
     (ZLayer(
@@ -150,7 +150,7 @@ object KafkaTestUtils {
         allowAutoCreateTopics = allowAutoCreateTopics,
         offsetRetrieval = offsetRetrieval,
         restartStreamOnRebalancing = restartStreamOnRebalancing,
-        endRevokedStreamsBeforeRebalance = endRevokedStreamsBeforeRebalance,
+        rebalanceSafeStreamEnd = rebalanceSafeStreamEnd,
         properties = properties
       )
     ) ++ ZLayer.succeed(diagnostics)) >>> Consumer.live
@@ -163,7 +163,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     diagnostics: Diagnostics = Diagnostics.NoOp,
     restartStreamOnRebalancing: Boolean = false,
-    endRevokedStreamsBeforeRebalance: Boolean = true,
+    rebalanceSafeStreamEnd: Boolean = true,
     properties: Map[String, String] = Map.empty,
     rebalanceListener: RebalanceListener = RebalanceListener.noop
   ): ZLayer[Kafka, Throwable, Consumer] =
@@ -175,7 +175,7 @@ object KafkaTestUtils {
         allowAutoCreateTopics = allowAutoCreateTopics,
         offsetRetrieval = offsetRetrieval,
         restartStreamOnRebalancing = restartStreamOnRebalancing,
-        endRevokedStreamsBeforeRebalance = endRevokedStreamsBeforeRebalance,
+        rebalanceSafeStreamEnd = rebalanceSafeStreamEnd,
         properties = properties
       ).map(_.withRebalanceListener(rebalanceListener))
     ) ++ ZLayer.succeed(diagnostics)) >>> Consumer.live

--- a/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
+++ b/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
@@ -70,6 +70,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
+    endRevokedStreamsBeforeRebalance: Boolean = true,
     `max.poll.records`: Int = 100, // settings this higher can cause concurrency bugs to go unnoticed
     runloopTimeout: Duration = ConsumerSettings.defaultRunloopTimeout,
     properties: Map[String, String] = Map.empty
@@ -92,6 +93,7 @@ object KafkaTestUtils {
         .withPerPartitionChunkPrefetch(16)
         .withOffsetRetrieval(offsetRetrieval)
         .withRestartStreamOnRebalancing(restartStreamOnRebalancing)
+        .withEndRevokedStreamsBeforeRebalance(endRevokedStreamsBeforeRebalance)
         .withProperties(properties)
 
       val withClientInstanceId = clientInstanceId.fold(settings)(settings.withGroupInstanceId)
@@ -105,6 +107,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
+    endRevokedStreamsBeforeRebalance: Boolean = true,
     properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =
     consumerSettings(
@@ -114,6 +117,7 @@ object KafkaTestUtils {
       allowAutoCreateTopics = allowAutoCreateTopics,
       offsetRetrieval = offsetRetrieval,
       restartStreamOnRebalancing = restartStreamOnRebalancing,
+      endRevokedStreamsBeforeRebalance = endRevokedStreamsBeforeRebalance,
       properties = properties
     )
       .map(
@@ -135,6 +139,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     diagnostics: Diagnostics = Diagnostics.NoOp,
     restartStreamOnRebalancing: Boolean = false,
+    endRevokedStreamsBeforeRebalance: Boolean = true,
     properties: Map[String, String] = Map.empty
   ): ZLayer[Kafka, Throwable, Consumer] =
     (ZLayer(
@@ -145,6 +150,7 @@ object KafkaTestUtils {
         allowAutoCreateTopics = allowAutoCreateTopics,
         offsetRetrieval = offsetRetrieval,
         restartStreamOnRebalancing = restartStreamOnRebalancing,
+        endRevokedStreamsBeforeRebalance = endRevokedStreamsBeforeRebalance,
         properties = properties
       )
     ) ++ ZLayer.succeed(diagnostics)) >>> Consumer.live
@@ -157,6 +163,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     diagnostics: Diagnostics = Diagnostics.NoOp,
     restartStreamOnRebalancing: Boolean = false,
+    endRevokedStreamsBeforeRebalance: Boolean = true,
     properties: Map[String, String] = Map.empty,
     rebalanceListener: RebalanceListener = RebalanceListener.noop
   ): ZLayer[Kafka, Throwable, Consumer] =
@@ -168,6 +175,7 @@ object KafkaTestUtils {
         allowAutoCreateTopics = allowAutoCreateTopics,
         offsetRetrieval = offsetRetrieval,
         restartStreamOnRebalancing = restartStreamOnRebalancing,
+        endRevokedStreamsBeforeRebalance = endRevokedStreamsBeforeRebalance,
         properties = properties
       ).map(_.withRebalanceListener(rebalanceListener))
     ) ++ ZLayer.succeed(diagnostics)) >>> Consumer.live

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -1028,8 +1028,8 @@ object ConsumerSpec extends ZIOKafkaSpec {
 
         // Test for both default partition assignment strategies
         Seq(
-          testForPartitionAssignmentStrategy[RangeAssignor]
-//          testForPartitionAssignmentStrategy[CooperativeStickyAssignor] // TODO not yet supported
+          testForPartitionAssignmentStrategy[RangeAssignor],
+          testForPartitionAssignmentStrategy[CooperativeStickyAssignor]
         )
 
       }: _*) @@ TestAspect.nonFlaky(3),

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -371,6 +371,7 @@ object Consumer {
                    offsetRetrieval = settings.offsetRetrieval,
                    userRebalanceListener = settings.rebalanceListener,
                    restartStreamsOnRebalancing = settings.restartStreamOnRebalancing,
+                   endRevokedStreamsBeforeRebalance = settings.endRevokedStreamsBeforeRebalance,
                    runloopTimeout = settings.runloopTimeout
                  )
       subscriptions <- Ref.Synchronized.make(Set.empty[Subscription])

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -371,7 +371,7 @@ object Consumer {
                    offsetRetrieval = settings.offsetRetrieval,
                    userRebalanceListener = settings.rebalanceListener,
                    restartStreamsOnRebalancing = settings.restartStreamOnRebalancing,
-                   endRevokedStreamsBeforeRebalance = settings.endRevokedStreamsBeforeRebalance,
+                   rebalanceSafeStreamEnd = settings.rebalanceSafeStreamEnd,
                    runloopTimeout = settings.runloopTimeout
                  )
       subscriptions <- Ref.Synchronized.make(Set.empty[Subscription])

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -14,6 +14,8 @@ import zio.kafka.security.KafkaCredentialStore
  * @param offsetRetrieval
  * @param rebalanceListener
  * @param restartStreamOnRebalancing
+ *   When `true` _all_ streams are restarted during a rebalance, including those streams that are not revoked. The
+ *   default is `false`.
  * @param runloopTimeout
  *   Internal timeout for each iteration of the command processing and polling loop, use to detect stalling. This should
  *   be much larger than the pollTimeout and the time it takes to process chunks of records. If your consumer is not

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -16,6 +16,18 @@ import zio.kafka.security.KafkaCredentialStore
  * @param restartStreamOnRebalancing
  *   When `true` _all_ streams are restarted during a rebalance, including those streams that are not revoked. The
  *   default is `false`.
+ *
+ * Set both `restartStreamOnRebalancing` and `endRevokedStreamsBeforeRebalance` to `true` for transactional producing.
+ * @param endRevokedStreamsBeforeRebalance
+ *   When `true` (the default) streams that need to end because the partition has been revoked, will be ended before the
+ *   rebalance starts. The consumer that takes over this partition will continue from the committed offset. However, it
+ *   is not possible to commit during a rebalance. So holding up the rebalance until the stream has ended (and done its
+ *   commits) will prevent duplicate processing.
+ *
+ * Set this to `false` when your streams does need commits, or when you need the extra performance and do not care for
+ * duplicate processing.
+ *
+ * Set both `restartStreamOnRebalancing` and `endRevokedStreamsBeforeRebalance` to `true` for transactional producing.
  * @param runloopTimeout
  *   Internal timeout for each iteration of the command processing and polling loop, use to detect stalling. This should
  *   be much larger than the pollTimeout and the time it takes to process chunks of records. If your consumer is not
@@ -31,6 +43,7 @@ case class ConsumerSettings(
   offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
   rebalanceListener: RebalanceListener = RebalanceListener.noop,
   restartStreamOnRebalancing: Boolean = false,
+  endRevokedStreamsBeforeRebalance: Boolean = true,
   runloopTimeout: Duration = ConsumerSettings.defaultRunloopTimeout
 ) {
   private[this] def autoOffsetResetConfig: Map[String, String] = offsetRetrieval match {
@@ -85,6 +98,9 @@ case class ConsumerSettings(
 
   def withRestartStreamOnRebalancing(value: Boolean): ConsumerSettings =
     copy(restartStreamOnRebalancing = value)
+
+  def withEndRevokedStreamsBeforeRebalance(value: Boolean): ConsumerSettings =
+    copy(endRevokedStreamsBeforeRebalance = value)
 
   def withCredentials(credentialsStore: KafkaCredentialStore): ConsumerSettings =
     withProperties(credentialsStore.properties)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
@@ -6,7 +6,7 @@ import zio.{ Runtime, Task, Unsafe, ZIO }
 import scala.jdk.CollectionConverters._
 
 /**
- * ZIO wrapper around Kafka's `ConsumerRebalanceListener` to work with Scala collection types and ZIO effects
+ * ZIO wrapper around Kafka's `ConsumerRebalanceListener` to work with Scala collection types and ZIO effects.
  */
 final case class RebalanceListener(
   onAssigned: (Set[TopicPartition], RebalanceConsumer) => Task[Unit],
@@ -32,21 +32,27 @@ final case class RebalanceListener(
       override def onPartitionsRevoked(
         partitions: java.util.Collection[TopicPartition]
       ): Unit = Unsafe.unsafe { implicit u =>
-        runtime.unsafe.run(onRevoked(partitions.asScala.toSet, consumer)).getOrThrowFiberFailure()
+        runtime.unsafe
+          .run(onRevoked(partitions.asScala.toSet, consumer))
+          .getOrThrowFiberFailure()
         ()
       }
 
       override def onPartitionsAssigned(
         partitions: java.util.Collection[TopicPartition]
       ): Unit = Unsafe.unsafe { implicit u =>
-        runtime.unsafe.run(onAssigned(partitions.asScala.toSet, consumer)).getOrThrowFiberFailure()
+        runtime.unsafe
+          .run(onAssigned(partitions.asScala.toSet, consumer))
+          .getOrThrowFiberFailure()
         ()
       }
 
       override def onPartitionsLost(
         partitions: java.util.Collection[TopicPartition]
       ): Unit = Unsafe.unsafe { implicit u =>
-        runtime.unsafe.run(onLost(partitions.asScala.toSet, consumer)).getOrThrowFiberFailure()
+        runtime.unsafe
+          .run(onLost(partitions.asScala.toSet, consumer))
+          .getOrThrowFiberFailure()
         ()
       }
     }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
@@ -7,6 +7,9 @@ import scala.jdk.CollectionConverters._
 
 /**
  * ZIO wrapper around Kafka's `ConsumerRebalanceListener` to work with Scala collection types and ZIO effects.
+ *
+ * Note that the given ZIO effects are executed directly on the Kafka poll thread. Fork and shift to another executor
+ * when this is not desired.
  */
 final case class RebalanceListener(
   onAssigned: (Set[TopicPartition], RebalanceConsumer) => Task[Unit],

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -19,7 +19,7 @@ private[consumer] final class ConsumerAccess(
   def withConsumerZIO[R, A](f: ByteArrayKafkaConsumer => RIO[R, A]): RIO[R, A] =
     access.withPermit(withConsumerNoPermit(f))
 
-  private[consumer] def withConsumerNoPermit[R, A](
+  private def withConsumerNoPermit[R, A](
     f: ByteArrayKafkaConsumer => RIO[R, A]
   ): RIO[R, A] =
     ZIO
@@ -31,10 +31,17 @@ private[consumer] final class ConsumerAccess(
       .flatMap(fib => fib.join.onInterrupt(ZIO.succeed(consumer.wakeup()) *> fib.interrupt))
 
   /**
-   * Do not use this method outside of the Runloop
+   * Use this method only from Runloop.
    */
   private[internal] def runloopAccess[R, E, A](f: ByteArrayKafkaConsumer => ZIO[R, E, A]): ZIO[R, E, A] =
     access.withPermit(f(consumer))
+
+  /**
+   * Use this method ONLY from the rebalance handler.
+   */
+  private[internal] def rebalanceHandlerAccess[R, A](f: ByteArrayKafkaConsumer => RIO[R, A]): RIO[R, A] =
+    withConsumerNoPermit(f)
+
 }
 
 private[consumer] object ConsumerAccess {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -37,9 +37,9 @@ private[consumer] final class ConsumerAccess(
     access.withPermit(f(consumer))
 
   /**
-   * Use this method ONLY from the rebalance handler.
+   * Use this method ONLY from the rebalance listener.
    */
-  private[internal] def rebalanceHandlerAccess[R, A](f: ByteArrayKafkaConsumer => RIO[R, A]): RIO[R, A] =
+  private[internal] def rebalanceListenerAccess[R, A](f: ByteArrayKafkaConsumer => RIO[R, A]): RIO[R, A] =
     withConsumerNoPermit(f)
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -43,10 +43,6 @@ private[internal] final class PartitionStreamControl private (
   def isRunning: ZIO[Any, Nothing, Boolean] =
     isCompleted.negate
 
-  /** Wait till the stream is done. */
-  def awaitCompleted(): ZIO[Any, Nothing, Unit] =
-    completedPromise.await
-
   val tpStream: (TopicPartition, ZStream[Any, Throwable, ByteArrayCommittableRecord]) =
     (tp, stream)
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -11,8 +11,10 @@ private[internal] final class PartitionStreamControl private (
   val tp: TopicPartition,
   stream: ZStream[Any, Throwable, ByteArrayCommittableRecord],
   dataQueue: Queue[Take[Throwable, ByteArrayCommittableRecord]],
-  interruptPromise: Promise[Throwable, Unit],
-  completedPromise: Promise[Nothing, Unit]
+  startedPromise: Promise[Nothing, Unit],
+  endedPromise: Promise[Nothing, Unit],
+  completedPromise: Promise[Nothing, Unit],
+  interruptPromise: Promise[Throwable, Unit]
 ) {
 
   private val logAnnotate = ZIO.logAnnotate(
@@ -32,16 +34,27 @@ private[internal] final class PartitionStreamControl private (
   def end(): ZIO[Any, Nothing, Unit] =
     logAnnotate {
       ZIO.logTrace(s"Partition ${tp.toString} ending") *>
-        dataQueue.offer(Take.end).unit
+        ZIO
+          .whenZIO(endedPromise.succeed(())) {
+            dataQueue.offer(Take.end)
+          }
+          .unit
     }
 
-  /** Returns true when the stream is done. */
-  def isCompleted: ZIO[Any, Nothing, Boolean] =
-    completedPromise.isDone
+  /** Returns true when the stream accepts new data. */
+  def acceptsData: ZIO[Any, Nothing, Boolean] =
+    for {
+      ended       <- endedPromise.isDone
+      completed   <- completedPromise.isDone
+      interrupted <- interruptPromise.isDone
+    } yield !(ended || completed || interrupted)
 
-  /** Returns true when the stream is running. */
-  def isRunning: ZIO[Any, Nothing, Boolean] =
-    isCompleted.negate
+  /** Returns true when the stream is done (or when it didn't even start). */
+  def isCompletedAfterStart: ZIO[Any, Nothing, Boolean] =
+    for {
+      started   <- startedPromise.isDone
+      completed <- completedPromise.isDone
+    } yield !started || completed
 
   val tpStream: (TopicPartition, ZStream[Any, Throwable, ByteArrayCommittableRecord]) =
     (tp, stream)
@@ -56,8 +69,10 @@ private[internal] object PartitionStreamControl {
   ): ZIO[Any, Nothing, PartitionStreamControl] =
     for {
       _                   <- ZIO.logTrace(s"Creating partition stream ${tp.toString}")
-      interruptionPromise <- Promise.make[Throwable, Unit]
+      startedPromise      <- Promise.make[Nothing, Unit]
+      endedPromise        <- Promise.make[Nothing, Unit]
       completedPromise    <- Promise.make[Nothing, Unit]
+      interruptionPromise <- Promise.make[Throwable, Unit]
       dataQueue           <- Queue.unbounded[Take[Throwable, ByteArrayCommittableRecord]]
       requestAndAwaitData =
         for {
@@ -74,12 +89,21 @@ private[internal] object PartitionStreamControl {
                    completedPromise.succeed(()) <*
                      ZIO.logDebug(s"Partition stream ${tp.toString} has ended")
                  ) *>
+                 ZStream.fromZIO(startedPromise.succeed(())) *>
                  ZStream.repeatZIOChunk {
                    // First try to take all records that are available right now.
                    // When no data is available, request more data and await its arrival.
                    dataQueue.takeAll.flatMap(data => if (data.isEmpty) requestAndAwaitData else ZIO.succeed(data))
                  }.flattenTake
                    .interruptWhen(interruptionPromise)
-    } yield new PartitionStreamControl(tp, stream, dataQueue, interruptionPromise, completedPromise)
+    } yield new PartitionStreamControl(
+      tp,
+      stream,
+      dataQueue,
+      startedPromise,
+      endedPromise,
+      completedPromise,
+      interruptionPromise
+    )
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -38,13 +38,6 @@ private[consumer] final class Runloop private (
   def gracefulShutdown: UIO[Unit] =
     commandQueue.offer(Command.StopAllStreams).unit
 
-  /** Wait until graceful shutdown completes. */
-  def awaitShutdown: UIO[Unit] =
-    for {
-      state <- currentState.get
-      _     <- ZIO.foreachDiscard(state.assignedStreams)(_.awaitCompleted())
-    } yield ()
-
   def changeSubscription(
     subscription: Option[Subscription]
   ): Task[Unit] =
@@ -253,7 +246,7 @@ private[consumer] final class Runloop private (
     if (toPause.nonEmpty) c.pause(toPause.asJava)
   }
 
-  private def doPoll(c: ByteArrayKafkaConsumer) = {
+  private def doPoll(c: ByteArrayKafkaConsumer): ConsumerRecords[Array[Byte], Array[Byte]] = {
     val records = c.poll(pollTimeout)
 
     if (records eq null) ConsumerRecords.empty[Array[Byte], Array[Byte]]() else records
@@ -261,6 +254,10 @@ private[consumer] final class Runloop private (
 
   private def handlePoll(state: State): Task[State] =
     for {
+      _ <-
+        ZIO.logTrace(
+          s"Starting poll with ${state.pendingRequests.size} pending requests and ${state.pendingCommits.size} pending commits"
+        )
       _ <- currentState.set(state)
       pollResult <-
         consumer.runloopAccess { c =>
@@ -463,32 +460,24 @@ private[consumer] final class Runloop private (
    *   - Poll periodically when we are subscribed but do not have assigned streams yet. This happens after
    *     initialization and rebalancing
    */
-  def run: ZIO[Scope, Throwable, Any] = {
-    def logPollStart(state: State): UIO[Unit] =
-      ZIO
-        .logTrace(
-          s"Starting poll with ${state.pendingRequests.size} pending requests and ${state.pendingCommits.size} pending commits"
-        )
-
+  def run: ZIO[Scope, Throwable, Any] =
     ZStream
       .fromQueue(commandQueue)
       .timeoutFail[Throwable](RunloopTimeout)(runloopTimeout)
       .takeWhile(_ != StopRunloop)
       .runFoldChunksDiscardZIO(State.initial) { (state, commands) =>
         for {
-          _            <- ZIO.logTrace(s"Processing ${commands.size} commands: ${commands.mkString(",")}")
-          updatedState <- ZIO.foldLeft(commands)(state)(handleCommand)
+          _                  <- ZIO.logTrace(s"Processing ${commands.size} commands: ${commands.mkString(",")}")
+          stateAfterCommands <- ZIO.foldLeft(commands)(state)(handleCommand)
 
-          updatedStateAfterPoll <- if (updatedState.shouldPoll)
-                                     logPollStart(updatedState) *> handlePoll(updatedState)
-                                   else ZIO.succeed(updatedState)
+          updatedStateAfterPoll <- if (stateAfterCommands.shouldPoll) handlePoll(stateAfterCommands)
+                                   else ZIO.succeed(stateAfterCommands)
           // Immediately poll again, after processing all new queued commands
           _ <- commandQueue.offer(Command.Poll).when(updatedStateAfterPoll.shouldPoll)
         } yield updatedStateAfterPoll
       }
       .tapErrorCause(cause => ZIO.logErrorCause("Error in Runloop", cause))
       .onError(cause => partitions.offer(Take.failCause(cause)))
-  }
 }
 
 private[consumer] object Runloop {
@@ -544,10 +533,13 @@ private[consumer] object Runloop {
 
   sealed trait Command
   object Command {
-    // Used for internal control of the runloop
+
+    /** Used for internal control of the runloop. */
     sealed trait Control extends Command
 
-    case object Poll           extends Control
+    /** Used as a signal that another poll is needed. */
+    case object Poll extends Control
+
     case object StopRunloop    extends Control
     case object StopAllStreams extends Control
 
@@ -556,6 +548,7 @@ private[consumer] object Runloop {
       @inline def isPending: UIO[Boolean] = isDone.negate
     }
 
+    /** Used by a stream to request more records. */
     final case class Request(tp: TopicPartition) extends Command
 
     final case class ChangeSubscription(

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/package.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/package.scala
@@ -1,0 +1,28 @@
+package zio.kafka.consumer
+
+import zio._
+import zio.internal.ExecutionMetrics
+
+package object internal {
+
+  /**
+   * A runtime layer that can be used to run everything on the thread of the caller.
+   *
+   * Provided by Adam Fraser in Discord:
+   * https://discord.com/channels/629491597070827530/630498701860929559/1094279123880386590 but with cooperative
+   * yielding enabled.
+   */
+  private[internal] val SameThreadRuntimeLayer: ZLayer[Any, Nothing, Unit] = {
+    val sameThreadExecutor = new Executor() {
+      override def metrics(implicit unsafe: Unsafe): Option[ExecutionMetrics] = None
+
+      override def submit(runnable: Runnable)(implicit unsafe: Unsafe): Boolean = {
+        runnable.run()
+        true
+      }
+    }
+
+    Runtime.setExecutor(sameThreadExecutor) ++ Runtime.setBlockingExecutor(sameThreadExecutor)
+  }
+
+}


### PR DESCRIPTION
This PR adds the setting `rebalanceSafeStreamEnd`. When set to true rebalances are hold up until the streams that handle the revoked partitions have ended. This prevents duplicate processing.

While waiting for the streams to end we need to continuously poll the broker. We do this by calling `commitAsync`. By inspecting the Java consumer code I found that when the passed Map of offsets is empty, the Java consumer will still poll the broker which is exactly what we need.

Commits are send to a separate queue (separate from commands) so that it is easier to access them while waiting for the streams to end.

The rebalance listener no longer calculates the next state. Instead, it only records what happened. The caller of poll then handles this data and calculates the next state. In case the rebalance listener was not invoked, we can skip the handling for a small performance improvement.

This fixes most of #706 

Tasks:

- [x] avoid the confusing terminology 'before rebalance'
- [x] find a nicer way to pass the consumer to the rebalance listener
- [x] remove methods on RebalanceConsumer (note, did not remove RebalanceConsumer itself)
- [x] add timeout in the commit-loop inside rebalance listener
- [ ] experiment with alternative approach (using only command-queue plus buffered commands)
- [x] extract ConsumerSpec.scala to a separate PR
- [ ] reduce logging on INFO and DEBUG level
- [ ] run all tests on ConsumerSpec and SubscriptionSpec twice: with rebalanceSafeStreamEnd true and false (note: locally all tests pass for both)


Alternative for the last bullet: we could decide to not support `rebalanceSafeStreamEnd` = false.

For a later PR:
 * configure zio-kafka via use-case profiles
 * experiment with removing transactionalRebalanceListener from consumerSpec
 * see if we can support the CooperativeStickyAssignor

