### PR TITLE
Remove unnecessary nowarn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-* @iravid
-
+* @svroonland
+* @guizmaii
+* @erikvanoosten

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -170,15 +170,20 @@ object Producer {
                 rec,
                 (metadata: RecordMetadata, err: Exception) =>
                   Unsafe.unsafe { implicit u =>
-                    if (err != null) {
-                      runtime.unsafe.run(done.fail(err)).getOrThrowFiberFailure(): Unit
-                    } else {
-                      res(idx) = metadata
-                      if (count.incrementAndGet == length) {
-                        runtime.unsafe.run(done.succeed(Chunk.fromArray(res))).getOrThrowFiberFailure(): Unit
+                    exec {
+                      if (err != null) {
+                        exec {
+                          runtime.unsafe.run(done.fail(err)).getOrThrowFiberFailure()
+                        }
+                      } else {
+                        res(idx) = metadata
+                        if (count.incrementAndGet == length) {
+                          exec {
+                            runtime.unsafe.run(done.succeed(Chunk.fromArray(res))).getOrThrowFiberFailure()
+                          }
+                        }
                       }
                     }
-                    ()
                   }
               )
             }
@@ -350,4 +355,10 @@ object Producer {
    */
   val metrics: RIO[Producer, Map[MetricName, Metric]] =
     ZIO.serviceWithZIO(_.metrics)
+
+  /** Used to prevent warnings about not using the result of an expression. */
+  @inline private def exec[A](f: => A): Unit = {
+    val _ = f
+  }
+
 }

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -8,7 +8,6 @@ import zio.kafka.serde.Serializer
 import zio.stream.{ ZPipeline, ZStream }
 
 import java.util.concurrent.atomic.AtomicLong
-import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
 trait Producer {
@@ -171,13 +170,14 @@ object Producer {
                 rec,
                 (metadata: RecordMetadata, err: Exception) =>
                   Unsafe.unsafe { implicit u =>
-                    (if (err != null) runtime.unsafe.run(done.fail(err)).getOrThrowFiberFailure(): Unit
-                     else {
-                       res(idx) = metadata
-                       if (count.incrementAndGet == length) {
-                         runtime.unsafe.run(done.succeed(Chunk.fromArray(res))).getOrThrowFiberFailure(): Unit
-                       }
-                     }): @nowarn("msg=discarded non-Unit value")
+                    if (err != null) {
+                      runtime.unsafe.run(done.fail(err)).getOrThrowFiberFailure(): Unit
+                    } else {
+                      res(idx) = metadata
+                      if (count.incrementAndGet == length) {
+                        runtime.unsafe.run(done.succeed(Chunk.fromArray(res))).getOrThrowFiberFailure(): Unit
+                      }
+                    }
                     ()
                   }
               )


### PR DESCRIPTION
Intellij complains about the nowarn annotation. As it is indeed not really necessary, this PR removes it.