### PR TITLE
New code owners part 2

### DIFF
--- a/.github/workflows/benchs.yml
+++ b/.github/workflows/benchs.yml
@@ -79,4 +79,4 @@ jobs:
           comment-on-alert: true
           fail-on-alert: true
           # Mention these maintainers in the commit comment
-          alert-comment-cc-users: '@iravid,@svroonland,@guizmaii'
+          alert-comment-cc-users: '@svroonland,@guizmaii,@erikvanoosten'

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,12 @@ inThisBuild(
     ),
     developers := List(
       Developer(
+        "iravid",
+        "Itamar Ravid",
+        "iravid@iravid.com",
+        url("https://github.com/iravid")
+      ),
+      Developer(
         "svroonland",
         "svroonland",
         "",

--- a/build.sbt
+++ b/build.sbt
@@ -25,10 +25,22 @@ inThisBuild(
     ),
     developers := List(
       Developer(
-        "iravid",
-        "Itamar Ravid",
-        "iravid@iravid.com",
-        url("https://github.com/iravid")
+        "svroonland",
+        "svroonland",
+        "",
+        url("https://github.com/svroonland")
+      ),
+      Developer(
+        "guizmaii",
+        "Jules Ivanic",
+        "",
+        url("https://github.com/guizmaii")
+      ),
+      Developer(
+        "erikvanoosten",
+        "Erik van Oosten",
+        "",
+        url("https://github.com/erikvanoosten")
       )
     )
   )


### PR DESCRIPTION
In build.sbt there is also this text:

```
Copyright 2021 Itamar Ravid and the zio-kafka contributors.
```

Should we keep that? Should we update the year to `2021 - <current year>`?