### PR TITLE
Small improvements taken from #788

### DIFF
--- a/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
+++ b/zio-kafka-test-utils/src/main/scala/zio/kafka/KafkaTestUtils.scala
@@ -70,7 +70,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
-    `max.poll.records`: Int = 1000,
+    `max.poll.records`: Int = 100, // settings this higher can cause concurrency bugs to go unnoticed
     runloopTimeout: Duration = ConsumerSettings.defaultRunloopTimeout,
     properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -14,6 +14,8 @@ import zio.kafka.security.KafkaCredentialStore
  * @param offsetRetrieval
  * @param rebalanceListener
  * @param restartStreamOnRebalancing
+ *   When `true` _all_ streams are restarted during a rebalance, including those streams that are not revoked. The
+ *   default is `false`.
  * @param runloopTimeout
  *   Internal timeout for each iteration of the command processing and polling loop, use to detect stalling. This should
  *   be much larger than the pollTimeout and the time it takes to process chunks of records. If your consumer is not

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
@@ -6,7 +6,7 @@ import zio.{ Runtime, Task, Unsafe, ZIO }
 import scala.jdk.CollectionConverters._
 
 /**
- * ZIO wrapper around Kafka's `ConsumerRebalanceListener` to work with Scala collection types and ZIO effects
+ * ZIO wrapper around Kafka's `ConsumerRebalanceListener` to work with Scala collection types and ZIO effects.
  */
 final case class RebalanceListener(
   onAssigned: (Set[TopicPartition], RebalanceConsumer) => Task[Unit],
@@ -32,21 +32,27 @@ final case class RebalanceListener(
       override def onPartitionsRevoked(
         partitions: java.util.Collection[TopicPartition]
       ): Unit = Unsafe.unsafe { implicit u =>
-        runtime.unsafe.run(onRevoked(partitions.asScala.toSet, consumer)).getOrThrowFiberFailure()
+        runtime.unsafe
+          .run(onRevoked(partitions.asScala.toSet, consumer))
+          .getOrThrowFiberFailure()
         ()
       }
 
       override def onPartitionsAssigned(
         partitions: java.util.Collection[TopicPartition]
       ): Unit = Unsafe.unsafe { implicit u =>
-        runtime.unsafe.run(onAssigned(partitions.asScala.toSet, consumer)).getOrThrowFiberFailure()
+        runtime.unsafe
+          .run(onAssigned(partitions.asScala.toSet, consumer))
+          .getOrThrowFiberFailure()
         ()
       }
 
       override def onPartitionsLost(
         partitions: java.util.Collection[TopicPartition]
       ): Unit = Unsafe.unsafe { implicit u =>
-        runtime.unsafe.run(onLost(partitions.asScala.toSet, consumer)).getOrThrowFiberFailure()
+        runtime.unsafe
+          .run(onLost(partitions.asScala.toSet, consumer))
+          .getOrThrowFiberFailure()
         ()
       }
     }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -43,10 +43,6 @@ private[internal] final class PartitionStreamControl private (
   def isRunning: ZIO[Any, Nothing, Boolean] =
     isCompleted.negate
 
-  /** Wait till the stream is done. */
-  def awaitCompleted(): ZIO[Any, Nothing, Unit] =
-    completedPromise.await
-
   val tpStream: (TopicPartition, ZStream[Any, Throwable, ByteArrayCommittableRecord]) =
     (tp, stream)
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -38,13 +38,6 @@ private[consumer] final class Runloop private (
   def gracefulShutdown: UIO[Unit] =
     commandQueue.offer(Command.StopAllStreams).unit
 
-  /** Wait until graceful shutdown completes. */
-  def awaitShutdown: UIO[Unit] =
-    for {
-      state <- currentState.get
-      _     <- ZIO.foreachDiscard(state.assignedStreams)(_.awaitCompleted())
-    } yield ()
-
   def changeSubscription(
     subscription: Option[Subscription]
   ): Task[Unit] =
@@ -253,7 +246,7 @@ private[consumer] final class Runloop private (
     if (toPause.nonEmpty) c.pause(toPause.asJava)
   }
 
-  private def doPoll(c: ByteArrayKafkaConsumer) = {
+  private def doPoll(c: ByteArrayKafkaConsumer): ConsumerRecords[Array[Byte], Array[Byte]] = {
     val records = c.poll(pollTimeout)
 
     if (records eq null) ConsumerRecords.empty[Array[Byte], Array[Byte]]() else records
@@ -261,6 +254,10 @@ private[consumer] final class Runloop private (
 
   private def handlePoll(state: State): Task[State] =
     for {
+      _ <-
+        ZIO.logTrace(
+          s"Starting poll with ${state.pendingRequests.size} pending requests and ${state.pendingCommits.size} pending commits"
+        )
       _ <- currentState.set(state)
       pollResult <-
         consumer.runloopAccess { c =>
@@ -463,32 +460,24 @@ private[consumer] final class Runloop private (
    *   - Poll periodically when we are subscribed but do not have assigned streams yet. This happens after
    *     initialization and rebalancing
    */
-  def run: ZIO[Scope, Throwable, Any] = {
-    def logPollStart(state: State): UIO[Unit] =
-      ZIO
-        .logTrace(
-          s"Starting poll with ${state.pendingRequests.size} pending requests and ${state.pendingCommits.size} pending commits"
-        )
-
+  def run: ZIO[Scope, Throwable, Any] =
     ZStream
       .fromQueue(commandQueue)
       .timeoutFail[Throwable](RunloopTimeout)(runloopTimeout)
       .takeWhile(_ != StopRunloop)
       .runFoldChunksDiscardZIO(State.initial) { (state, commands) =>
         for {
-          _            <- ZIO.logTrace(s"Processing ${commands.size} commands: ${commands.mkString(",")}")
-          updatedState <- ZIO.foldLeft(commands)(state)(handleCommand)
+          _                  <- ZIO.logTrace(s"Processing ${commands.size} commands: ${commands.mkString(",")}")
+          stateAfterCommands <- ZIO.foldLeft(commands)(state)(handleCommand)
 
-          updatedStateAfterPoll <- if (updatedState.shouldPoll)
-                                     logPollStart(updatedState) *> handlePoll(updatedState)
-                                   else ZIO.succeed(updatedState)
+          updatedStateAfterPoll <- if (stateAfterCommands.shouldPoll) handlePoll(stateAfterCommands)
+                                   else ZIO.succeed(stateAfterCommands)
           // Immediately poll again, after processing all new queued commands
           _ <- commandQueue.offer(Command.Poll).when(updatedStateAfterPoll.shouldPoll)
         } yield updatedStateAfterPoll
       }
       .tapErrorCause(cause => ZIO.logErrorCause("Error in Runloop", cause))
       .onError(cause => partitions.offer(Take.failCause(cause)))
-  }
 }
 
 private[consumer] object Runloop {
@@ -544,10 +533,13 @@ private[consumer] object Runloop {
 
   sealed trait Command
   object Command {
-    // Used for internal control of the runloop
+
+    /** Used for internal control of the runloop. */
     sealed trait Control extends Command
 
-    case object Poll           extends Control
+    /** Used as a signal that another poll is needed. */
+    case object Poll extends Control
+
     case object StopRunloop    extends Control
     case object StopAllStreams extends Control
 
@@ -556,6 +548,7 @@ private[consumer] object Runloop {
       @inline def isPending: UIO[Boolean] = isDone.negate
     }
 
+    /** Used by a stream to request more records. */
     final case class Request(tp: TopicPartition) extends Command
 
     final case class ChangeSubscription(


### PR DESCRIPTION
Since #788 will need another approach, here are a few small things that we can already merge.

 - Make private when possible.
 - Better values for max.poll.records in tests and bench.
 - A bit of scaladoc here and there.
 - Remove unused code.