### PR TITLE
Await commits during revoke

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/ZIOSpecDefaultSlf4j.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ZIOSpecDefaultSlf4j.scala
@@ -2,16 +2,21 @@ package zio.kafka
 
 import zio.Chunk
 import zio.logging.backend.SLF4J
-import zio.test.{ TestAspect, TestAspectAtLeastR, TestEnvironment, ZIOSpecDefault }
+import zio.test.{TestAspect, TestAspectAtLeastR, TestEnvironment, ZIOSpecAbstract, ZIOSpecDefault}
 
 /**
  * Use this class instead of `ZIOSpecDefault` if you want your tests to use SLF4J to log.
  *
  * Useful when you want to use logback to configure your logger, for example.
  */
-abstract class ZIOSpecDefaultSlf4j extends ZIOSpecDefault {
+trait ZIOSpecDefaultSlf4j extends ZIOSpecDefault with ZIOSpecAbstractSlf4j
 
-  override def aspects: Chunk[TestAspectAtLeastR[TestEnvironment]] =
+/**
+ * Mix this into your ZIO Spec if you want your tests to use SLF4J to log.
+ */
+trait ZIOSpecAbstractSlf4j extends ZIOSpecAbstract {
+
+  abstract override def aspects: Chunk[TestAspectAtLeastR[Environment with TestEnvironment]] =
     super.aspects :+ TestAspect.fromLayer(zio.Runtime.removeDefaultLoggers >>> SLF4J.slf4j)
 
 }

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -102,6 +102,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
+    rebalanceSafeCommits: Boolean = false,
     `max.poll.records`: Int = 100, // settings this higher can cause concurrency bugs to go unnoticed
     runloopTimeout: Duration = ConsumerSettings.defaultRunloopTimeout,
     properties: Map[String, String] = Map.empty
@@ -123,6 +124,7 @@ object KafkaTestUtils {
         )
         .withOffsetRetrieval(offsetRetrieval)
         .withRestartStreamOnRebalancing(restartStreamOnRebalancing)
+        .withRebalanceSafeCommits(rebalanceSafeCommits)
         .withProperties(properties)
 
       val withClientInstanceId = clientInstanceId.fold(settings)(settings.withGroupInstanceId)
@@ -139,6 +141,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
+    rebalanceSafeCommits: Boolean = false,
     properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =
     consumerSettings(
@@ -148,6 +151,7 @@ object KafkaTestUtils {
       allowAutoCreateTopics = allowAutoCreateTopics,
       offsetRetrieval = offsetRetrieval,
       restartStreamOnRebalancing = restartStreamOnRebalancing,
+      rebalanceSafeCommits = rebalanceSafeCommits,
       properties = properties
     )
       .map(
@@ -187,6 +191,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     diagnostics: Diagnostics = Diagnostics.NoOp,
     restartStreamOnRebalancing: Boolean = false,
+    rebalanceSafeCommits: Boolean = false,
     properties: Map[String, String] = Map.empty
   ): ZLayer[Kafka, Throwable, Consumer] =
     (ZLayer(
@@ -197,6 +202,7 @@ object KafkaTestUtils {
         allowAutoCreateTopics = allowAutoCreateTopics,
         offsetRetrieval = offsetRetrieval,
         restartStreamOnRebalancing = restartStreamOnRebalancing,
+        rebalanceSafeCommits = rebalanceSafeCommits,
         properties = properties
       )
     ) ++ ZLayer.succeed(diagnostics)) >>> Consumer.live
@@ -212,6 +218,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     diagnostics: Diagnostics = Diagnostics.NoOp,
     restartStreamOnRebalancing: Boolean = false,
+    rebalanceSafeCommits: Boolean = false,
     properties: Map[String, String] = Map.empty,
     rebalanceListener: RebalanceListener = RebalanceListener.noop
   ): ZLayer[Kafka, Throwable, Consumer] =
@@ -223,6 +230,7 @@ object KafkaTestUtils {
         allowAutoCreateTopics = allowAutoCreateTopics,
         offsetRetrieval = offsetRetrieval,
         restartStreamOnRebalancing = restartStreamOnRebalancing,
+        rebalanceSafeCommits = rebalanceSafeCommits,
         properties = properties
       ).map(_.withRebalanceListener(rebalanceListener))
     ) ++ ZLayer.succeed(diagnostics)) >>> Consumer.live

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -368,6 +368,7 @@ object Consumer {
                    offsetRetrieval = settings.offsetRetrieval,
                    userRebalanceListener = settings.rebalanceListener,
                    restartStreamsOnRebalancing = settings.restartStreamOnRebalancing,
+                   rebalanceSafeCommits = settings.rebalanceSafeCommits,
                    runloopTimeout = settings.runloopTimeout
                  )
       subscriptions <- Ref.Synchronized.make(Set.empty[Subscription])

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
@@ -9,7 +9,7 @@ sealed trait Offset {
   def partition: Int
   def offset: Long
   def commit: Task[Unit]
-  def batch: OffsetBatch
+  def asOffsetBatch: OffsetBatch
   def consumerGroupMetadata: Option[ConsumerGroupMetadata]
 
   /**
@@ -42,6 +42,6 @@ private final case class OffsetImpl(
   commitHandle: Map[TopicPartition, Long] => Task[Unit],
   consumerGroupMetadata: Option[ConsumerGroupMetadata]
 ) extends Offset {
-  def commit: Task[Unit] = commitHandle(Map(topicPartition -> offset))
-  def batch: OffsetBatch = OffsetBatchImpl(Map(topicPartition -> offset), commitHandle, consumerGroupMetadata)
+  def commit: Task[Unit]         = commitHandle(Map(topicPartition -> offset))
+  def asOffsetBatch: OffsetBatch = OffsetBatchImpl(Map(topicPartition -> offset), commitHandle, consumerGroupMetadata)
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
@@ -58,7 +58,7 @@ private final case class OffsetBatchImpl(
 case object EmptyOffsetBatch extends OffsetBatch {
   override val offsets: Map[TopicPartition, Long]                   = Map.empty
   override val commit: Task[Unit]                                   = ZIO.unit
-  override def add(offset: Offset): OffsetBatch                     = offset.batch
+  override def add(offset: Offset): OffsetBatch                     = offset.asOffsetBatch
   override def merge(offset: Offset): OffsetBatch                   = add(offset)
   override def merge(offsets: OffsetBatch): OffsetBatch             = offsets
   override def consumerGroupMetadata: Option[ConsumerGroupMetadata] = None

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
@@ -7,6 +7,9 @@ import scala.jdk.CollectionConverters._
 
 /**
  * ZIO wrapper around Kafka's `ConsumerRebalanceListener` to work with Scala collection types and ZIO effects.
+ *
+ * Note that the given ZIO effects are executed directly on the Kafka poll thread. Fork and shift to another executor
+ * when this is not desired.
  */
 final case class RebalanceListener(
   onAssigned: (Set[TopicPartition], RebalanceConsumer) => Task[Unit],

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -19,7 +19,7 @@ private[consumer] final class ConsumerAccess(
   def withConsumerZIO[R, A](f: ByteArrayKafkaConsumer => RIO[R, A]): RIO[R, A] =
     access.withPermit(withConsumerNoPermit(f))
 
-  private[consumer] def withConsumerNoPermit[R, A](
+  private def withConsumerNoPermit[R, A](
     f: ByteArrayKafkaConsumer => RIO[R, A]
   ): RIO[R, A] =
     ZIO
@@ -31,10 +31,17 @@ private[consumer] final class ConsumerAccess(
       .flatMap(fib => fib.join.onInterrupt(ZIO.succeed(consumer.wakeup()) *> fib.interrupt))
 
   /**
-   * Do not use this method outside of the Runloop
+   * Use this method only from Runloop.
    */
   private[internal] def runloopAccess[R, E, A](f: ByteArrayKafkaConsumer => ZIO[R, E, A]): ZIO[R, E, A] =
     access.withPermit(f(consumer))
+
+  /**
+   * Use this method ONLY from the rebalance listener.
+   */
+  private[internal] def rebalanceListenerAccess[R, A](f: ByteArrayKafkaConsumer => RIO[R, A]): RIO[R, A] =
+    withConsumerNoPermit(f)
+
 }
 
 private[consumer] object ConsumerAccess {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -1,17 +1,21 @@
 package zio.kafka.consumer.internal
 
 import org.apache.kafka.common.TopicPartition
+import zio.kafka.consumer.Offset
 import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
 import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.stream.{ Take, ZStream }
-import zio.{ Chunk, LogAnnotation, Promise, Queue, UIO, ZIO }
+import zio.{ Chunk, LogAnnotation, Promise, Queue, Ref, UIO, ZIO }
 
 private[internal] final class PartitionStreamControl private (
   val tp: TopicPartition,
   stream: ZStream[Any, Throwable, ByteArrayCommittableRecord],
+  val lastOffset: Ref[Option[Offset]],
   dataQueue: Queue[Take[Throwable, ByteArrayCommittableRecord]],
-  interruptPromise: Promise[Throwable, Unit],
-  completedPromise: Promise[Nothing, Unit]
+  startedPromise: Promise[Nothing, Unit],
+  endedPromise: Promise[Nothing, Unit],
+  completedPromise: Promise[Nothing, Unit],
+  interruptPromise: Promise[Throwable, Unit]
 ) {
 
   private var pollResumedHistory: PollHistory = PollHistory.Empty
@@ -23,7 +27,8 @@ private[internal] final class PartitionStreamControl private (
 
   /** Offer new data for the stream to process. */
   def offerRecords(data: Chunk[ByteArrayCommittableRecord]): ZIO[Any, Nothing, Unit] =
-    dataQueue.offer(Take.chunk(data)).unit
+    data.lastOption.fold(ZIO.unit)(last => lastOffset.set(Some(last.offset))) *>
+      dataQueue.offer(Take.chunk(data)).unit
 
   /** To be invoked when the partition was lost. */
   def lost(): UIO[Boolean] =
@@ -33,16 +38,40 @@ private[internal] final class PartitionStreamControl private (
   def end(): ZIO[Any, Nothing, Unit] =
     logAnnotate {
       ZIO.logTrace(s"Partition ${tp.toString} ending") *>
-        dataQueue.offer(Take.end).unit
+        ZIO
+          .whenZIO(endedPromise.succeed(())) {
+            dataQueue.offer(Take.end)
+          }
+          .unit
     }
 
-  /** Returns true when the stream is done. */
-  def isCompleted: ZIO[Any, Nothing, Boolean] =
-    completedPromise.isDone
+  /** Returns true when the stream accepts new data. */
+  def acceptsData: ZIO[Any, Nothing, Boolean] =
+    for {
+      ended       <- endedPromise.isDone
+      completed   <- completedPromise.isDone
+      interrupted <- interruptPromise.isDone
+    } yield !(ended || completed || interrupted)
 
-  /** Returns true when the stream is running. */
-  def isRunning: ZIO[Any, Nothing, Boolean] =
-    isCompleted.negate
+  /** Returns true when the stream is done (or when it didn't even start). */
+  def isCompletedAfterStart: ZIO[Any, Nothing, Boolean] =
+    for {
+      started   <- startedPromise.isDone
+      completed <- completedPromise.isDone
+    } yield !started || completed
+
+  def lasOffsetIsIn(committedOffsets: Map[TopicPartition, Long]): ZIO[Any, Nothing, Boolean] =
+    lastOffset.get.map(_.forall(offset => committedOffsets.get(offset.topicPartition).exists(_ >= offset.offset))).tap {
+      result =>
+        for {
+          lo <- lastOffset.get
+          _ <- ZIO.logDebug(
+                 s"${tp.partition()} lastOffset: ${lo.map(_.offset.toString).getOrElse("-")} " +
+                   s"in committedOffsets: ${committedOffsets.get(tp).map(_.toString).getOrElse("-")} " +
+                   s"==> $result"
+               )
+        } yield ()
+    }
 
   val tpStream: (TopicPartition, ZStream[Any, Throwable, ByteArrayCommittableRecord]) =
     (tp, stream)
@@ -71,8 +100,11 @@ private[internal] object PartitionStreamControl {
   ): ZIO[Any, Nothing, PartitionStreamControl] =
     for {
       _                   <- ZIO.logTrace(s"Creating partition stream ${tp.toString}")
-      interruptionPromise <- Promise.make[Throwable, Unit]
+      startedPromise      <- Promise.make[Nothing, Unit]
+      endedPromise        <- Promise.make[Nothing, Unit]
       completedPromise    <- Promise.make[Nothing, Unit]
+      interruptionPromise <- Promise.make[Throwable, Unit]
+      lastOffset          <- Ref.make[Option[Offset]](None)
       dataQueue           <- Queue.unbounded[Take[Throwable, ByteArrayCommittableRecord]]
       requestAndAwaitData =
         for {
@@ -89,12 +121,22 @@ private[internal] object PartitionStreamControl {
                    completedPromise.succeed(()) <*
                      ZIO.logDebug(s"Partition stream ${tp.toString} has ended")
                  ) *>
+                 ZStream.fromZIO(startedPromise.succeed(())) *>
                  ZStream.repeatZIOChunk {
                    // First try to take all records that are available right now.
                    // When no data is available, request more data and await its arrival.
                    dataQueue.takeAll.flatMap(data => if (data.isEmpty) requestAndAwaitData else ZIO.succeed(data))
                  }.flattenTake
                    .interruptWhen(interruptionPromise)
-    } yield new PartitionStreamControl(tp, stream, dataQueue, interruptionPromise, completedPromise)
+    } yield new PartitionStreamControl(
+      tp,
+      stream,
+      lastOffset,
+      dataQueue,
+      startedPromise,
+      endedPromise,
+      completedPromise,
+      interruptionPromise
+    )
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
@@ -5,6 +5,7 @@ import zio._
 import zio.kafka.consumer.Subscription
 
 sealed trait RunloopCommand
+
 object RunloopCommand {
 
   /** Used for internal control of the runloop. */
@@ -16,14 +17,11 @@ object RunloopCommand {
   /** Used as a signal that another poll is needed. */
   case object Poll extends Control
 
+  /** Used as a signal to the poll-loop that commits are available in the commit-queue. */
+  case object CommitAvailable extends Control
+
   case object StopRunloop    extends Control
   case object StopAllStreams extends StreamControl
-
-  final case class Commit(offsets: Map[TopicPartition, Long], cont: Promise[Throwable, Unit]) extends StreamControl {
-    @inline def isDone: UIO[Boolean] = cont.isDone
-
-    @inline def isPending: UIO[Boolean] = isDone.negate
-  }
 
   /** Used by a stream to request more records. */
   final case class Request(tp: TopicPartition) extends StreamControl
@@ -33,7 +31,6 @@ object RunloopCommand {
     cont: Promise[Throwable, Unit]
   ) extends StreamControl {
     @inline def succeed: UIO[Boolean] = cont.succeed(())
-
     @inline def fail(throwable: Throwable): UIO[Boolean] = cont.fail(throwable)
   }
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/package.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/package.scala
@@ -1,0 +1,28 @@
+package zio.kafka.consumer
+
+import zio._
+import zio.internal.ExecutionMetrics
+
+package object internal {
+
+  /**
+   * A runtime layer that can be used to run everything on the thread of the caller.
+   *
+   * Provided by Adam Fraser in Discord:
+   * https://discord.com/channels/629491597070827530/630498701860929559/1094279123880386590 but with cooperative
+   * yielding enabled.
+   */
+  private[internal] val SameThreadRuntimeLayer: ZLayer[Any, Nothing, Unit] = {
+    val sameThreadExecutor = new Executor() {
+      override def metrics(implicit unsafe: Unsafe): Option[ExecutionMetrics] = None
+
+      override def submit(runnable: Runnable)(implicit unsafe: Unsafe): Boolean = {
+        runnable.run()
+        true
+      }
+    }
+
+    Runtime.setExecutor(sameThreadExecutor) ++ Runtime.setBlockingExecutor(sameThreadExecutor)
+  }
+
+}


### PR DESCRIPTION
To solve #590, in this PR we introduce a new mode that holds up a rebalance until the offsets of messages provided to streams of revoked partitions have been committed.

### Motivation

Here is a common (single partition) scenario around rebalances:

1. a consumer polls some messages and puts them in the streams (let's say messages with offsets 0 to 100)
1. asynchronously, the user processes these messages. Some of them are committed (let's say up to offset 50), the rest is still being processed when...
1. a rebalance happens, the partition is revoked and assigned to another consumer on another instance
1. the consumer continues to process the remaining messages with offsets 50 to 100, and tries to commit those offsets
1. _at the same time,_ another consumer on another instance, starts consuming from the last committed offset (which is 50) and will process the same messages with offsets 50 to 100

Messages with offsets 50 to 100 are being processed by both consumers simultaneously. Note that both consumers will try to commit these offsets. Until the first consumer is ready, the stored offsets can go up and down and are therefore unreliable.

After merging this PR, the scenario will unfold as follows:

1. a consumer polls some messages and puts them in the streams (let's say messages with offsets 0 to 100). Zio-kafka keeps track of the highest provided offset
1. asynchronously, the user processes these messages. Some of them are committed (let's say up to offset 50), the rest is still being processed when...
1. a rebalance happens, the partition is revoked and assigned to another consumer on another instance
   * the consumer continues to process the remaining messages with offsets 50 to 100, and tries to commit those offsets
   * inside the onRevoked callback, zio-kafka continues to process commit commands from the user
   * zio-kafka continues to do so until the commit with the highest provided offset (offset 100) completes
   * the onRevoked callback completes, signalling to Kafka that the next consumer may start consuming from the partition
1. another consumer on another instance, starts consuming from the last committed offset (which is now 100, problem solved!)

### Complications

1. The chosen solution is not suitable for all consumers.
   - There are uses cases where not all messages are read from the stream. For example, some want to read exactly 100 messages from a topic and then stop consuming. In that case the user has no intention to commit all messages and therefore we should not wait for that to happen. Since stream consumers can basically do whatever they want, the only way we can support such use cases is by letting the consumer tell zio-kafka that they are done with committing. This requires an API change. For example, we can let the user tell zio-kafka that a given commit is the last one.
   - Not all consumers commit offsets (to Kafka) in the first place. In a future PR we could make it work for commits to other stores though. As a workaround, when this PR is merged, these users can commit to both places.
4. Prior to Kafka client 3.6.0 there is no way to wait for commits to complete except for calling poll. However, calling poll from the rebalance listener callback does not work.
5. The Kafka client requires that any nested invocations (that is, from the rebalance listener callback) to the client happens from the same thread. This is at very much at odds with how ZIO works. Attempts to convince the Kafka committers to relax this requirement failed; they could not be convinced that this is a problem. We can somewhat workaround this problem by using a special run-on-caller-thread zio-runtime (already part of zio-kafka). However, some operations, in particular `ZIO.timeout`, still make processing jump to another thread. Therefore, we cannot use `ZIO.timeout` to limit the time we spend in the onRevoke callback.
6. The new functionality is somewhat complicated to test. We need to make sure that there are unprocessed messages in the stream when a rebalance starts.

### Related

The same issue is present in:
- f2s-kafka: https://github.com/fd4s/fs2-kafka/issues/1200
- alpakka-kafka: https://github.com/akka/alpakka-kafka/issues/1038

In fact, every program that does polls and commits asynchronously is likely affected.

### Things to do

- [x] Wait for Kafka 3.6.0 (it contains https://github.com/apache/kafka/pull/13678).
- [ ] Make it work.
- [x] Come up with a better name for the new mode.
- [ ] Rewrite or duplicate existing tests so that they commit everything and can work with this new mode.
- [ ] Add more test specifically for the new mode.
- [ ] Reduce logging.
- [ ] Documentation.

### Non-goals

This PR does not try to solve the following goals. However, these can be addressed in future PRs.

- Support transactional consumer/producer.
- Support external commits.
- Support consumers that want to commit only a portion of the given messages.

This branch is based on the work of abandoned #788.

