### PR TITLE
Remove all rights reserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,4 @@ This library is heavily inspired and made possible by the research and implement
 
 [License](LICENSE)
 
-Copyright 2021 Itamar Ravid and the zio-kafka contributors. All rights reserved.
-<!-- TODO: not all rights reserved, rather Apache 2... -->
+Copyright 2021-2023 Itamar Ravid and the zio-kafka contributors.

--- a/build.sbt
+++ b/build.sbt
@@ -191,8 +191,6 @@ lazy val docs = project
       "This library is heavily inspired and made possible by the research and implementation done in " +
         "[Alpakka Kafka](https://github.com/akka/alpakka-kafka), a library maintained by the Akka team and originally " +
         "written as Reactive Kafka by SoftwareMill.",
-    readmeLicense +=
-      "\n\n" + """|Copyright 2021 Itamar Ravid and the zio-kafka contributors. All rights reserved.
-                  |<!-- TODO: not all rights reserved, rather Apache 2... -->""".stripMargin
+    readmeLicense += s"\n\nCopyright 2021-${java.time.Year.now()} Itamar Ravid and the zio-kafka contributors."
   )
   .enablePlugins(WebsitePlugin)


### PR DESCRIPTION
The phrase 'all rights reserved' is not needed. Also, since this library is provided under the Apache 2 license, it doesn't even make sense.

Also: add current year to copyright statement.