### PR TITLE
Using a Consumer without consuming shouldn't throw a `RunloopTimeout` exception

### DIFF
--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ComparisonBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ComparisonBenchmark.scala
@@ -45,8 +45,8 @@ trait ComparisonBenchmark extends ZioBenchmark[Env] {
         clientId = randomThing("client"),
         groupId = Some(randomThing("client")),
         `max.poll.records` = 1000, // A more production worthy value
-        runloopTimeout =
-          1.hour // Absurdly high timeout to avoid the runloop from being interrupted while we're benchmarking other stuff
+        // Absurdly high timeout to avoid the runloop from being interrupted while we're benchmarking other stuff
+        runloopTimeout = 1.hour
       ).map(_.withMaxPartitionQueueSize(8192))
     )
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -1110,15 +1110,15 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                 consumer <- Consumer.make(settings, diagnostics = diagnostics)
                 _        <- produceOne(topic, "key1", "message1")
                 // Starting a consumption session to start the Runloop.
-                consumed_0 <- consumer
+                consumed0 <- consumer
                                 .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
                                 .take(1)
                                 .runCount
-                consumed_1 <- consumer
+                consumed1 <- consumer
                                 .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
                                 .take(1)
                                 .runCount
-              } yield assert(consumed_0)(equalTo(1L)) && assert(consumed_1)(equalTo(1L))
+              } yield assert(consumed0)(equalTo(1L)) && assert(consumed1)(equalTo(1L))
 
             for {
               diagnostics <- Diagnostics.SlidingQueue.make(1000)
@@ -1160,18 +1160,18 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                            .forkScoped
                 _          <- ZIO.sleep(200.millis)
                 _          <- consumer.stopConsumption
-                consumed_0 <- fiber.join
-                _          <- ZIO.logDebug(s"consumed_0: $consumed_0")
+                consumed0 <- fiber.join
+                _          <- ZIO.logDebug(s"consumed0: $consumed0")
 
                 _ <- ZIO.logDebug("About to sleep 5 seconds")
                 _ <- ZIO.sleep(5.seconds)
                 _ <- ZIO.logDebug("Slept 5 seconds")
-                consumed_1 <- consumer
+                consumed1 <- consumer
                                 .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
                                 .take(numberOfMessages.toLong)
                                 .runCount
-              } yield assert(consumed_0)(isGreaterThan(0L) && isLessThan(numberOfMessages.toLong)) &&
-                assert(consumed_1)(equalTo(numberOfMessages.toLong))
+              } yield assert(consumed0)(isGreaterThan(0L) && isLessThan(numberOfMessages.toLong)) &&
+                assert(consumed1)(equalTo(numberOfMessages.toLong))
 
             for {
               diagnostics <- Diagnostics.SlidingQueue.make(1000)

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -12,8 +12,14 @@ import org.apache.kafka.common.TopicPartition
 import zio._
 import zio.kafka.ZIOSpecDefaultSlf4j
 import zio.kafka.consumer.Consumer.{ AutoOffsetStrategy, OffsetRetrieval }
+import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization
+import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization.{
+  ConsumerFinalized,
+  RunloopFinalized,
+  SubscriptionFinalized
+}
 import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
-import zio.kafka.producer.TransactionalProducer
+import zio.kafka.producer.{ Producer, TransactionalProducer }
 import zio.kafka.serde.Serde
 import zio.kafka.testkit.KafkaTestUtils._
 import zio.kafka.testkit.{ Kafka, KafkaRandom }
@@ -22,8 +28,10 @@ import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
 
+import java.util.concurrent.atomic.AtomicInteger
 import scala.reflect.ClassTag
 
+//noinspection SimplifyAssertInspection
 object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
   override val kafkaPrefix: String = "consumespec"
 
@@ -1052,11 +1060,188 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           _ <- produceOne(topic, "key2", "message2")
           _ <- recordsOut.take
         } yield assertCompletes
-      }
+      },
+      suite("issue #856")(
+        test(
+          "Booting a Consumer to do something else than consuming should not fail with `RunloopTimeout` exception"
+        ) {
+          def test(diagnostics: Diagnostics) =
+            for {
+              clientId <- randomClient
+              settings <- consumerSettings(clientId = clientId, runloopTimeout = 500.millis)
+              _        <- Consumer.make(settings, diagnostics = diagnostics)
+              _        <- ZIO.sleep(1.second)
+            } yield assertCompletes
+
+          for {
+            diagnostics <- Diagnostics.SlidingQueue.make(1000)
+            testResult <- ZIO.scoped {
+                            test(diagnostics)
+                          }
+            finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isInstanceOf[Finalization]))
+          } yield testResult && assert(finalizationEvents)(hasSameElements(Chunk(ConsumerFinalized)))
+        },
+        suite(
+          "Ordering of finalizers matters. If subscriptions are finalized after the runloop, it creates a deadlock"
+        )(
+          test("When not consuming, the Runloop is not started so only the Consumer is finalized") {
+            def test(diagnostics: Diagnostics): ZIO[Scope & Kafka, Throwable, TestResult] =
+              for {
+                clientId <- randomClient
+                settings <- consumerSettings(clientId = clientId)
+                _        <- Consumer.make(settings, diagnostics = diagnostics)
+              } yield assertCompletes
+
+            for {
+              diagnostics <- Diagnostics.SlidingQueue.make(1000)
+              testResult <- ZIO.scoped {
+                              test(diagnostics)
+                            }
+              finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isInstanceOf[Finalization]))
+            } yield testResult && assert(finalizationEvents)(hasSameElements(Chunk(ConsumerFinalized)))
+          },
+          test("When consuming, the Runloop is started. The finalization orders matters to avoid a deadlock") {
+            // This test ensures that we're not inadvertently introducing a deadlock by changing the order of finalizers.
+
+            def test(diagnostics: Diagnostics): ZIO[Producer & Scope & Kafka, Throwable, TestResult] =
+              for {
+                clientId <- randomClient
+                topic    <- randomTopic
+                settings <- consumerSettings(clientId = clientId)
+                consumer <- Consumer.make(settings, diagnostics = diagnostics)
+                _        <- produceOne(topic, "key1", "message1")
+                // Starting a consumption session to start the Runloop.
+                consumed_0 <- consumer
+                                .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
+                                .take(1)
+                                .runCount
+                consumed_1 <- consumer
+                                .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
+                                .take(1)
+                                .runCount
+              } yield assert(consumed_0)(equalTo(1L)) && assert(consumed_1)(equalTo(1L))
+
+            for {
+              diagnostics <- Diagnostics.SlidingQueue.make(1000)
+              testResult <- ZIO.scoped {
+                              test(diagnostics)
+                            }
+              finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isInstanceOf[Finalization]))
+            } yield testResult && assert(finalizationEvents)(
+              // The order is very important.
+              // The subscription must be finalized before the runloop, otherwise it creates a deadlock.
+              equalTo(
+                Chunk(
+                  SubscriptionFinalized,
+                  SubscriptionFinalized,
+                  RunloopFinalized,
+                  ConsumerFinalized
+                )
+              )
+            )
+          },
+          test(
+            "Calling `Consumer::stopConsumption` just after starting a forked consumption session should stop the consumption"
+          ) {
+            val numberOfMessages: Int           = 100000
+            val kvs: Iterable[(String, String)] = Iterable.tabulate(numberOfMessages)(i => (s"key-$i", s"msg-$i"))
+
+            def test(diagnostics: Diagnostics): ZIO[Producer & Scope & Kafka, Throwable, TestResult] =
+              for {
+                clientId <- randomClient
+                topic    <- randomTopic
+                settings <- consumerSettings(clientId = clientId)
+                consumer <- Consumer.make(settings, diagnostics = diagnostics)
+                _        <- produceMany(topic, kvs)
+                ref = new AtomicInteger(0)
+                // Starting a consumption session to start the Runloop.
+                fiber <-
+                  consumer
+                    .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
+                    .mapChunksZIO(chunks => ZIO.logDebug(s"Consumed ${ref.getAndAdd(chunks.size)} messages").as(chunks))
+                    .take(numberOfMessages.toLong)
+                    .runCount
+                    .fork
+                _          <- consumer.stopConsumption
+                consumed_0 <- fiber.join
+              } yield assert(consumed_0)(isLessThan(numberOfMessages.toLong))
+
+            for {
+              diagnostics <- Diagnostics.SlidingQueue.make(1000)
+              testResult <- ZIO.scoped {
+                              test(diagnostics)
+                            }
+              finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isInstanceOf[Finalization]))
+            } yield testResult && assert(finalizationEvents)(
+              // The order is very important.
+              // The subscription must be finalized before the runloop, otherwise it creates a deadlock.
+              equalTo(
+                Chunk(
+                  SubscriptionFinalized,
+                  RunloopFinalized,
+                  ConsumerFinalized
+                )
+              )
+            )
+          } @@ nonFlaky(5),
+          test(
+            "it's possible to start a new consumption session from a Consumer that had a consumption session stopped previously"
+          ) {
+            val numberOfMessages: Int           = 100000
+            val kvs: Iterable[(String, String)] = Iterable.tabulate(numberOfMessages)(i => (s"key-$i", s"msg-$i"))
+
+            def test(diagnostics: Diagnostics): ZIO[Producer & Scope & Kafka, Throwable, TestResult] =
+              for {
+                clientId <- randomClient
+                topic    <- randomTopic
+                settings <- consumerSettings(clientId = clientId)
+                consumer <- Consumer.make(settings, diagnostics = diagnostics)
+                _        <- produceMany(topic, kvs)
+                // Starting a consumption session to start the Runloop.
+                fiber <- consumer
+                           .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
+                           .take(numberOfMessages.toLong)
+                           .runCount
+                           .forkScoped
+                _          <- ZIO.sleep(200.millis)
+                _          <- consumer.stopConsumption
+                consumed_0 <- fiber.join
+                _          <- ZIO.logDebug(s"consumed_0: $consumed_0")
+
+                _ <- ZIO.logDebug("About to sleep 5 seconds")
+                _ <- ZIO.sleep(5.seconds)
+                _ <- ZIO.logDebug("Slept 5 seconds")
+                consumed_1 <- consumer
+                                .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
+                                .take(numberOfMessages.toLong)
+                                .runCount
+              } yield assert(consumed_0)(isGreaterThan(0L) && isLessThan(numberOfMessages.toLong)) &&
+                assert(consumed_1)(equalTo(numberOfMessages.toLong))
+
+            for {
+              diagnostics <- Diagnostics.SlidingQueue.make(1000)
+              testResult <- ZIO.scoped {
+                              test(diagnostics)
+                            }
+              finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isInstanceOf[Finalization]))
+            } yield testResult && assert(finalizationEvents)(
+              // The order is very important.
+              // The subscription must be finalized before the runloop, otherwise it creates a deadlock.
+              equalTo(
+                Chunk(
+                  SubscriptionFinalized,
+                  RunloopFinalized,
+                  ConsumerFinalized
+                )
+              )
+            )
+          }
+        )
+      )
     )
       .provideSome[Scope & Kafka](producer)
       .provideSomeShared[Scope](
         Kafka.embedded
-      ) @@ withLiveClock @@ TestAspect.sequential @@ timeout(2.minutes)
+      ) @@ withLiveClock @@ sequential @@ timeout(2.minutes)
 
 }

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -1111,13 +1111,13 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                 _        <- produceOne(topic, "key1", "message1")
                 // Starting a consumption session to start the Runloop.
                 consumed0 <- consumer
-                                .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
-                                .take(1)
-                                .runCount
+                               .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
+                               .take(1)
+                               .runCount
                 consumed1 <- consumer
-                                .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
-                                .take(1)
-                                .runCount
+                               .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
+                               .take(1)
+                               .runCount
               } yield assert(consumed0)(equalTo(1L)) && assert(consumed1)(equalTo(1L))
 
             for {
@@ -1158,18 +1158,18 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                            .take(numberOfMessages.toLong)
                            .runCount
                            .forkScoped
-                _          <- ZIO.sleep(200.millis)
-                _          <- consumer.stopConsumption
+                _         <- ZIO.sleep(200.millis)
+                _         <- consumer.stopConsumption
                 consumed0 <- fiber.join
-                _          <- ZIO.logDebug(s"consumed0: $consumed0")
+                _         <- ZIO.logDebug(s"consumed0: $consumed0")
 
                 _ <- ZIO.logDebug("About to sleep 5 seconds")
                 _ <- ZIO.sleep(5.seconds)
                 _ <- ZIO.logDebug("Slept 5 seconds")
                 consumed1 <- consumer
-                                .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
-                                .take(numberOfMessages.toLong)
-                                .runCount
+                               .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
+                               .take(numberOfMessages.toLong)
+                               .runCount
               } yield assert(consumed0)(isGreaterThan(0L) && isLessThan(numberOfMessages.toLong)) &&
                 assert(consumed1)(equalTo(numberOfMessages.toLong))
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -318,7 +318,7 @@ object Consumer {
       _              <- ZIO.addFinalizer(diagnostics.emit(Finalization.ConsumerFinalized))
       _              <- SslHelper.validateEndpoint(settings.bootstrapServers, settings.properties)
       consumerAccess <- ConsumerAccess.make(settings)
-      runloopAccess  <- RunloopAccess.make(settings, diagnostics, consumerAccess, settings)
+      runloopAccess  <- RunloopAccess.make(settings, consumerAccess, diagnostics)
     } yield new Live(consumerAccess, runloopAccess)
 
   /**

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -198,7 +198,7 @@ object Consumer {
      */
     override def stopConsumption: UIO[Unit] =
       ZIO.logDebug("stopConsumption called") *>
-        runloopAccess.stopConsumption()
+        runloopAccess.stopConsumption
 
     override def listTopics(timeout: Duration = Duration.Infinity): Task[Map[String, List[PartitionInfo]]] =
       consumer.withConsumer(_.listTopics(timeout.asJava).asScala.map { case (k, v) => k -> v.asScala.toList }.toMap)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
@@ -27,4 +27,11 @@ object DiagnosticEvent {
     final case class Lost(partitions: Set[TopicPartition])     extends Rebalance
   }
 
+  sealed trait Finalization extends DiagnosticEvent
+  object Finalization {
+    case object SubscriptionFinalized extends Finalization
+    case object RunloopFinalized      extends Finalization
+    case object ConsumerFinalized     extends Finalization
+  }
+
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -6,51 +6,64 @@ import org.apache.kafka.common.errors.RebalanceInProgressException
 import zio._
 import zio.kafka.consumer.Consumer.{ OffsetRetrieval, RunloopTimeout }
 import zio.kafka.consumer._
+import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization
 import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
 import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
-import zio.kafka.consumer.internal.Runloop._
+import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
 import zio.stream._
 
 import java.util
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 
-//noinspection SimplifyWhenInspection
-//noinspection SimplifyUnlessInspection
+//noinspection SimplifyWhenInspection,SimplifyUnlessInspection
 private[consumer] final class Runloop private (
   runtime: Runtime[Any],
   hasGroupId: Boolean,
   consumer: ConsumerAccess,
   pollTimeout: Duration,
-  runloopTimeout: Duration,
   commandQueue: Queue[RunloopCommand],
   lastRebalanceEvent: Ref.Synchronized[Option[Runloop.RebalanceEvent]],
-  val partitionsQueue: Queue[Take[Throwable, (TopicPartition, Stream[Throwable, ByteArrayCommittableRecord])]],
+  partitionsHub: Hub[Take[Throwable, PartitionAssignment]],
   diagnostics: Diagnostics,
   offsetRetrieval: OffsetRetrieval,
   userRebalanceListener: RebalanceListener,
   restartStreamsOnRebalancing: Boolean,
   currentStateRef: Ref[State],
-  maxPartitionQueueSize: Int
+  consumerSettings: ConsumerSettings
 ) {
 
   private def newPartitionStream(tp: TopicPartition): UIO[PartitionStreamControl] =
     PartitionStreamControl.newPartitionStream(tp, commandQueue, diagnostics)
 
   def stopConsumption: UIO[Unit] =
-    commandQueue.offer(RunloopCommand.StopAllStreams).unit
+    ZIO.logDebug("stopConsumption called") *>
+      commandQueue.offer(RunloopCommand.StopAllStreams).unit
 
-  def changeSubscription(
-    subscription: Option[Subscription]
-  ): Task[Unit] =
-    Promise
-      .make[Throwable, Unit]
-      .flatMap { cont =>
-        commandQueue.offer(RunloopCommand.ChangeSubscription(subscription, cont)) *>
-          cont.await
-      }
-      .unit
-      .uninterruptible
+  private[consumer] def shutdown: UIO[Unit] =
+    ZIO.logDebug(s"Shutting down runloop initiated") *>
+      commandQueue
+        .offerAll(
+          Chunk(
+            RunloopCommand.RemoveAllSubscriptions,
+            RunloopCommand.StopAllStreams,
+            RunloopCommand.StopRunloop
+          )
+        )
+        .unit
+
+  private[internal] def addSubscription(subscription: Subscription): IO[InvalidSubscriptionUnion, Unit] =
+    for {
+      _       <- ZIO.logDebug(s"Add subscription $subscription")
+      promise <- Promise.make[InvalidSubscriptionUnion, Unit]
+      _       <- commandQueue.offer(RunloopCommand.AddSubscription(subscription, promise))
+      _       <- ZIO.logDebug(s"Waiting for subscription $subscription")
+      _       <- promise.await
+      _       <- ZIO.logDebug(s"Done for subscription $subscription")
+    } yield ()
+
+  private[internal] def removeSubscription(subscription: Subscription): UIO[Unit] =
+    commandQueue.offer(RunloopCommand.RemoveSubscription(subscription)).unit
 
   private val rebalanceListener: RebalanceListener = {
     val emitDiagnostics = RebalanceListener(
@@ -249,7 +262,7 @@ private[consumer] final class Runloop private (
         ZIO
           .foldLeft(state.assignedStreams)(ListBuffer.empty[TopicPartition]) { case (acc, stream) =>
             stream.queueSize.map { queueSize =>
-              if (queueSize < maxPartitionQueueSize) {
+              if (queueSize < consumerSettings.maxPartitionQueueSize) {
                 acc.append(stream.tp)
               }
               acc
@@ -342,7 +355,7 @@ private[consumer] final class Runloop private (
             .foreach(Chunk.fromIterable(pollResult.startingTps))(newPartitionStream)
             .tap { newStreams =>
               ZIO.logDebug(s"Offering partition assignment ${pollResult.startingTps}") *>
-                partitionsQueue.offer(Take.chunk(Chunk.fromIterable(newStreams.map(_.tpStream))))
+                partitionsHub.publish(Take.chunk(Chunk.fromIterable(newStreams.map(_.tpStream))))
             }
         }
       runningStreams <- ZIO.filter(pollResult.assignedStreams)(_.isRunning)
@@ -360,68 +373,107 @@ private[consumer] final class Runloop private (
       assignedStreams = updatedStreams
     )
 
-  private def handleCommand(state: State, cmd: RunloopCommand.StreamCommand): Task[State] =
+  private def handleCommand(state: State, cmd: RunloopCommand.StreamCommand): Task[State] = {
+    def doChangeSubscription(newSubscriptionState: SubscriptionState): Task[State] =
+      applyNewSubscriptionState(newSubscriptionState).flatMap { newAssignedStreams =>
+        val newState = state.copy(
+          assignedStreams = state.assignedStreams ++ newAssignedStreams,
+          subscriptionState = newSubscriptionState
+        )
+        if (newSubscriptionState.isSubscribed) ZIO.succeed(newState)
+        else
+          // End all streams and pending requests
+          endRevokedPartitions(
+            newState.pendingRequests,
+            newState.assignedStreams,
+            isRevoked = _ => true
+          ).map { revokeResult =>
+            newState.copy(
+              pendingRequests = revokeResult.pendingRequests,
+              assignedStreams = revokeResult.assignedStreams
+            )
+          }
+      }
+
     cmd match {
       case req: RunloopCommand.Request => ZIO.succeed(state.addRequest(req))
       case cmd: RunloopCommand.Commit  => doCommit(cmd).as(state.addCommit(cmd))
-      case cmd @ RunloopCommand.ChangeSubscription(subscription, _) =>
-        handleChangeSubscription(subscription).flatMap { newAssignedStreams =>
-          val newState = state.copy(
-            assignedStreams = state.assignedStreams ++ newAssignedStreams,
-            subscription = subscription
-          )
-          if (subscription.isDefined) ZIO.succeed(newState)
-          else {
-            // End all streams and pending requests
-            endRevokedPartitions(
-              newState.pendingRequests,
-              newState.assignedStreams,
-              isRevoked = _ => true
-            ).map { revokeResult =>
-              newState.copy(
-                pendingRequests = revokeResult.pendingRequests,
-                assignedStreams = revokeResult.assignedStreams
-              )
+      case cmd @ RunloopCommand.AddSubscription(newSubscription, _) =>
+        state.subscriptionState match {
+          case SubscriptionState.NotSubscribed =>
+            val newSubState =
+              SubscriptionState.Subscribed(subscriptions = Set(newSubscription), union = newSubscription)
+            cmd.succeed *> doChangeSubscription(newSubState)
+          case SubscriptionState.Subscribed(existingSubscriptions, _) =>
+            val subs = NonEmptyChunk.fromIterable(newSubscription, existingSubscriptions)
+
+            Subscription.unionAll(subs) match {
+              case None => cmd.fail(InvalidSubscriptionUnion(subs)).as(state)
+              case Some(union) =>
+                val newSubState =
+                  SubscriptionState.Subscribed(
+                    subscriptions = existingSubscriptions + newSubscription,
+                    union = union
+                  )
+                cmd.succeed *> doChangeSubscription(newSubState)
             }
-          }
         }
-          .tapBoth(e => cmd.fail(e), _ => cmd.succeed)
-          .uninterruptible
+      case RunloopCommand.RemoveSubscription(subscription) =>
+        state.subscriptionState match {
+          case SubscriptionState.NotSubscribed => ZIO.succeed(state)
+          case SubscriptionState.Subscribed(existingSubscriptions, _) =>
+            val newUnion: Option[(Subscription, NonEmptyChunk[Subscription])] =
+              NonEmptyChunk
+                .fromIterableOption(existingSubscriptions - subscription)
+                .flatMap(subs => Subscription.unionAll(subs).map(_ -> subs))
+
+            newUnion match {
+              case Some((union, newSubscriptions)) =>
+                val newSubState =
+                  SubscriptionState.Subscribed(subscriptions = newSubscriptions.toSet, union = union)
+                doChangeSubscription(newSubState)
+              case None =>
+                ZIO.logDebug(s"Unsubscribing kafka consumer") *>
+                  doChangeSubscription(SubscriptionState.NotSubscribed)
+            }
+        }
+      case RunloopCommand.RemoveAllSubscriptions => doChangeSubscription(SubscriptionState.NotSubscribed)
       case RunloopCommand.StopAllStreams =>
         for {
           _ <- ZIO.logDebug("Stop all streams initiated")
           _ <- ZIO.foreachDiscard(state.assignedStreams)(_.end())
-          _ <- partitionsQueue.offer(Take.end)
+          _ <- partitionsHub.publish(Take.end)
           _ <- ZIO.logDebug("Stop all streams done")
         } yield state.copy(pendingRequests = Chunk.empty)
     }
+  }
 
-  private def handleChangeSubscription(
-    newSubscription: Option[Subscription]
+  private def applyNewSubscriptionState(
+    newSubscriptionState: SubscriptionState
   ): Task[Chunk[PartitionStreamControl]] =
     consumer.runloopAccess { c =>
-      newSubscription match {
-        case None =>
+      newSubscriptionState match {
+        case SubscriptionState.NotSubscribed =>
           ZIO
             .attempt(c.unsubscribe())
             .as(Chunk.empty)
-        case Some(Subscription.Pattern(pattern)) =>
+        case SubscriptionState.Subscribed(_, Subscription.Pattern(pattern)) =>
           val rc = RebalanceConsumer.Live(c)
           ZIO
             .attempt(c.subscribe(pattern.pattern, rebalanceListener.toKafka(runtime, rc)))
             .as(Chunk.empty)
-        case Some(Subscription.Topics(topics)) =>
+        case SubscriptionState.Subscribed(_, Subscription.Topics(topics)) =>
           val rc = RebalanceConsumer.Live(c)
           ZIO
             .attempt(c.subscribe(topics.asJava, rebalanceListener.toKafka(runtime, rc)))
             .as(Chunk.empty)
-        case Some(Subscription.Manual(topicPartitions)) =>
+        case SubscriptionState.Subscribed(_, Subscription.Manual(topicPartitions)) =>
           // For manual subscriptions we have to do some manual work before starting the run loop
           for {
             _                <- ZIO.attempt(c.assign(topicPartitions.asJava))
             _                <- doSeekForNewPartitions(c, topicPartitions)
             partitionStreams <- ZIO.foreach(Chunk.fromIterable(topicPartitions))(newPartitionStream)
-            _                <- partitionsQueue.offer(Take.chunk(partitionStreams.map(_.tpStream)))
+            _                <- partitionsHub.publish(Take.chunk(partitionStreams.map(_.tpStream)))
           } yield partitionStreams
       }
     }
@@ -443,7 +495,7 @@ private[consumer] final class Runloop private (
 
     ZStream
       .fromQueue(commandQueue)
-      .timeoutFail[Throwable](RunloopTimeout)(runloopTimeout)
+      .timeoutFail[Throwable](RunloopTimeout)(consumerSettings.runloopTimeout)
       .takeWhile(_ != RunloopCommand.StopRunloop)
       .runFoldChunksDiscardZIO(State.initial) { (state, commands) =>
         for {
@@ -458,7 +510,7 @@ private[consumer] final class Runloop private (
         } yield updatedStateAfterPoll
       }
       .tapErrorCause(cause => ZIO.logErrorCause("Error in Runloop", cause))
-      .onError(cause => partitionsQueue.offer(Take.failCause(cause)))
+      .onError(cause => partitionsHub.offer(Take.failCause(cause)))
   }
 }
 
@@ -485,9 +537,6 @@ private[consumer] object Runloop {
 
   type ByteArrayCommittableRecord = CommittableRecord[Array[Byte], Array[Byte]]
 
-  // Internal parameters, should not be necessary to tune
-  private val commandQueueSize = 1024
-
   private final case class PollResult(
     startingTps: Set[TopicPartition],
     pendingRequests: Chunk[RunloopCommand.Request],
@@ -513,6 +562,9 @@ private[consumer] object Runloop {
     ) extends RebalanceEvent
   }
 
+  // Internal parameters, should not be necessary to tune
+  private final val commandQueueSize: Int = 1024
+
   def make(
     hasGroupId: Boolean,
     consumer: ConsumerAccess,
@@ -521,35 +573,29 @@ private[consumer] object Runloop {
     offsetRetrieval: OffsetRetrieval,
     userRebalanceListener: RebalanceListener,
     restartStreamsOnRebalancing: Boolean,
-    runloopTimeout: Duration,
-    maxPartitionQueueSize: Int
-  ): ZIO[Scope, Throwable, Runloop] =
+    partitionsHub: Hub[Take[Throwable, PartitionAssignment]],
+    consumerSettings: ConsumerSettings
+  ): URIO[Scope, Runloop] =
     for {
+      _                  <- ZIO.addFinalizer(diagnostics.emit(Finalization.RunloopFinalized))
       commandQueue       <- ZIO.acquireRelease(Queue.bounded[RunloopCommand](commandQueueSize))(_.shutdown)
       lastRebalanceEvent <- Ref.Synchronized.make[Option[Runloop.RebalanceEvent]](None)
-      partitionsQueue <- ZIO.acquireRelease(
-                           Queue
-                             .unbounded[
-                               Take[Throwable, (TopicPartition, Stream[Throwable, ByteArrayCommittableRecord])]
-                             ]
-                         )(_.shutdown)
-      currentStateRef <- Ref.make(State.initial)
-      runtime         <- ZIO.runtime[Any]
+      currentStateRef    <- Ref.make(State.initial)
+      runtime            <- ZIO.runtime[Any]
       runloop = new Runloop(
                   runtime = runtime,
                   hasGroupId = hasGroupId,
                   consumer = consumer,
                   pollTimeout = pollTimeout,
-                  runloopTimeout = runloopTimeout,
                   commandQueue = commandQueue,
                   lastRebalanceEvent = lastRebalanceEvent,
-                  partitionsQueue = partitionsQueue,
+                  partitionsHub = partitionsHub,
                   diagnostics = diagnostics,
                   offsetRetrieval = offsetRetrieval,
                   userRebalanceListener = userRebalanceListener,
                   restartStreamsOnRebalancing = restartStreamsOnRebalancing,
                   currentStateRef = currentStateRef,
-                  maxPartitionQueueSize = maxPartitionQueueSize
+                  consumerSettings = consumerSettings
                 )
       _ <- ZIO.logDebug("Starting Runloop")
 
@@ -559,9 +605,8 @@ private[consumer] object Runloop {
       waitForRunloopStop = fiber.join.orDie
 
       _ <- ZIO.addFinalizer(
-             ZIO.logTrace("Shutting down Runloop") *>
-               commandQueue.offer(RunloopCommand.StopAllStreams) *>
-               commandQueue.offer(RunloopCommand.StopRunloop) *>
+             ZIO.logDebug("Shutting down Runloop") *>
+               runloop.shutdown *>
                waitForRunloopStop <*
                ZIO.logDebug("Shut down Runloop")
            )
@@ -572,15 +617,13 @@ private[internal] final case class State(
   pendingRequests: Chunk[RunloopCommand.Request],
   pendingCommits: Chunk[RunloopCommand.Commit],
   assignedStreams: Chunk[PartitionStreamControl],
-  subscription: Option[Subscription]
+  subscriptionState: SubscriptionState
 ) {
   def addCommit(c: RunloopCommand.Commit): State   = copy(pendingCommits = pendingCommits :+ c)
   def addRequest(r: RunloopCommand.Request): State = copy(pendingRequests = pendingRequests :+ r)
 
-  def isSubscribed: Boolean = subscription.isDefined
-
   def shouldPoll: Boolean =
-    isSubscribed && (pendingRequests.nonEmpty || pendingCommits.nonEmpty || assignedStreams.isEmpty)
+    subscriptionState.isSubscribed && (pendingRequests.nonEmpty || pendingCommits.nonEmpty || assignedStreams.isEmpty)
 }
 
 object State {
@@ -588,6 +631,6 @@ object State {
     pendingRequests = Chunk.empty,
     pendingCommits = Chunk.empty,
     assignedStreams = Chunk.empty,
-    subscription = None
+    subscriptionState = SubscriptionState.NotSubscribed
   )
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -71,9 +71,8 @@ private[consumer] object RunloopAccess {
 
   def make(
     settings: ConsumerSettings,
-    diagnostics: Diagnostics = Diagnostics.NoOp,
     consumerAccess: ConsumerAccess,
-    consumerSettings: ConsumerSettings
+    diagnostics: Diagnostics = Diagnostics.NoOp
   ): ZIO[Scope, Throwable, RunloopAccess] =
     for {
       // This scope allows us to link the lifecycle of the Runloop and of the Hub to the lifecycle of the Consumer
@@ -93,7 +92,8 @@ private[consumer] object RunloopAccess {
                         userRebalanceListener = settings.rebalanceListener,
                         restartStreamsOnRebalancing = settings.restartStreamOnRebalancing,
                         partitionsHub = partitionsHub,
-                        consumerSettings = consumerSettings
+                        runloopTimeout = settings.runloopTimeout,
+                        maxPartitionQueueSize = settings.maxPartitionQueueSize
                       )
                       .withFinalizer(_ => runloopStateRef.set(RunloopState.Stopped))
                       .provide(ZLayer.succeed(consumerScope))

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -1,0 +1,119 @@
+package zio.kafka.consumer.internal
+
+import org.apache.kafka.common.TopicPartition
+import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization
+import zio.kafka.consumer.diagnostics.Diagnostics
+import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
+import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
+import zio.kafka.consumer.{ ConsumerSettings, InvalidSubscriptionUnion, Subscription }
+import zio.stream.{ Stream, Take, UStream, ZStream }
+import zio.{ durationInt, Hub, IO, Ref, Scope, UIO, ZIO, ZLayer }
+
+private[internal] sealed trait RunloopState
+private[internal] object RunloopState {
+  case object NotStarted                     extends RunloopState
+  final case class Started(runloop: Runloop) extends RunloopState
+  case object Stopped                        extends RunloopState
+}
+
+/**
+ * This [[RunloopAccess]] is here to make the [[Runloop]] instantiation/boot lazy: we only starts it when the user is
+ * starting a consuming session.
+ *
+ * This is needed because a Consumer can be used to do something else than consuming (e.g. fetching Kafka topics
+ * metadata)
+ */
+private[consumer] final class RunloopAccess private (
+  runloopStateRef: Ref.Synchronized[RunloopState],
+  partitionHub: Hub[Take[Throwable, PartitionAssignment]],
+  makeRunloop: UIO[Runloop],
+  diagnostics: Diagnostics
+) {
+  private def runloop(shouldStartIfNot: Boolean): UIO[RunloopState] =
+    runloopStateRef.updateSomeAndGetZIO {
+      case RunloopState.NotStarted if shouldStartIfNot => makeRunloop.map(RunloopState.Started.apply)
+    }
+  private def withRunloopZIO[E, A](shouldStartIfNot: Boolean)(f: Runloop => IO[E, A]): IO[E, A] =
+    runloop(shouldStartIfNot).flatMap {
+      case RunloopState.Stopped          => ZIO.unit.asInstanceOf[IO[E, A]]
+      case RunloopState.NotStarted       => ZIO.unit.asInstanceOf[IO[E, A]]
+      case RunloopState.Started(runloop) => f(runloop)
+    }
+
+  /**
+   * No need to call `Runloop::stopConsumption` if the Runloop has not been started or has been stopped.
+   *
+   * Note:
+   *   1. We do a 100 retries waiting 10ms between each to roughly take max 1s before to stop to retry. We want to avoid
+   *      an infinite loop. We need this recursion because if the user calls `stopConsumption` before the Runloop is
+   *      started, we need to wait for it to be started. Can happen if the user starts a consuming session in a forked
+   *      fiber and immediately after forking, stops it. The Runloop will potentially not be started yet.
+   */
+  // noinspection SimplifyUnlessInspection
+  def stopConsumption(retry: Int = 100, initialCall: Boolean = true): UIO[Unit] = {
+    @inline def next: UIO[Unit] = stopConsumption(retry - 1, initialCall = false)
+
+    runloop(shouldStartIfNot = false).flatMap {
+      case RunloopState.Stopped          => ZIO.unit
+      case RunloopState.Started(runloop) => runloop.stopConsumption
+      case RunloopState.NotStarted =>
+        if (retry <= 0) ZIO.unit
+        else if (initialCall) next
+        else next.delay(10.millis)
+    }
+  }
+
+  /**
+   * We're doing all of these things in this method so that the interface of this class is as simple as possible and
+   * there's no mistake possible for the caller.
+   *
+   * The external world (Consumer) doesn't need to know how we "subscribe", "unsubscribe", etc. internally.
+   */
+  def subscribe(
+    subscription: Subscription
+  ): ZIO[Scope, InvalidSubscriptionUnion, UStream[Take[Throwable, PartitionAssignment]]] =
+    for {
+      stream <- ZStream.fromHubScoped(partitionHub)
+      // starts the Runloop if not already started
+      _ <- withRunloopZIO(shouldStartIfNot = true)(_.addSubscription(subscription))
+      _ <- ZIO.addFinalizer {
+             withRunloopZIO(shouldStartIfNot = false)(_.removeSubscription(subscription)) <*
+               diagnostics.emit(Finalization.SubscriptionFinalized)
+           }
+    } yield stream
+
+}
+
+private[consumer] object RunloopAccess {
+  type PartitionAssignment = (TopicPartition, Stream[Throwable, ByteArrayCommittableRecord])
+
+  def make(
+    settings: ConsumerSettings,
+    diagnostics: Diagnostics = Diagnostics.NoOp,
+    consumerAccess: ConsumerAccess,
+    consumerSettings: ConsumerSettings
+  ): ZIO[Scope, Throwable, RunloopAccess] =
+    for {
+      // This scope allows us to link the lifecycle of the Runloop and of the Hub to the lifecycle of the Consumer
+      // When the Consumer is shutdown, the Runloop and the Hub will be shutdown too (before the consumer)
+      consumerScope <- ZIO.scope
+      partitionsHub <- ZIO
+                         .acquireRelease(Hub.unbounded[Take[Throwable, PartitionAssignment]])(_.shutdown)
+                         .provide(ZLayer.succeed(consumerScope))
+      runloopStateRef <- Ref.Synchronized.make[RunloopState](RunloopState.NotStarted)
+      makeRunloop = Runloop
+                      .make(
+                        hasGroupId = settings.hasGroupId,
+                        consumer = consumerAccess,
+                        pollTimeout = settings.pollTimeout,
+                        diagnostics = diagnostics,
+                        offsetRetrieval = settings.offsetRetrieval,
+                        userRebalanceListener = settings.rebalanceListener,
+                        restartStreamsOnRebalancing = settings.restartStreamOnRebalancing,
+                        partitionsHub = partitionsHub,
+                        consumerSettings = consumerSettings
+                      )
+                      .withFinalizer(_ => runloopStateRef.set(RunloopState.Stopped))
+                      .provide(ZLayer.succeed(consumerScope))
+    } yield new RunloopAccess(runloopStateRef, partitionsHub, makeRunloop, diagnostics)
+}

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
@@ -2,7 +2,7 @@ package zio.kafka.consumer.internal
 
 import org.apache.kafka.common.TopicPartition
 import zio._
-import zio.kafka.consumer.Subscription
+import zio.kafka.consumer.{ InvalidSubscriptionUnion, Subscription }
 
 sealed trait RunloopCommand
 object RunloopCommand {
@@ -20,20 +20,18 @@ object RunloopCommand {
   case object StopAllStreams extends StreamCommand
 
   final case class Commit(offsets: Map[TopicPartition, Long], cont: Promise[Throwable, Unit]) extends StreamCommand {
-    @inline def isDone: UIO[Boolean] = cont.isDone
-
+    @inline def isDone: UIO[Boolean]    = cont.isDone
     @inline def isPending: UIO[Boolean] = isDone.negate
   }
 
   /** Used by a stream to request more records. */
   final case class Request(tp: TopicPartition) extends StreamCommand
 
-  final case class ChangeSubscription(
-    subscription: Option[Subscription],
-    cont: Promise[Throwable, Unit]
-  ) extends StreamCommand {
-    @inline def succeed: UIO[Boolean] = cont.succeed(())
-
-    @inline def fail(throwable: Throwable): UIO[Boolean] = cont.fail(throwable)
+  final case class AddSubscription(subscription: Subscription, cont: Promise[InvalidSubscriptionUnion, Unit])
+      extends StreamCommand {
+    @inline def succeed: UIO[Unit]                           = cont.succeed(()).unit
+    @inline def fail(e: InvalidSubscriptionUnion): UIO[Unit] = cont.fail(e).unit
   }
+  final case class RemoveSubscription(subscription: Subscription) extends StreamCommand
+  case object RemoveAllSubscriptions                              extends StreamCommand
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopExecutor.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopExecutor.scala
@@ -1,6 +1,6 @@
 package zio.kafka.consumer.internal
 
-import zio.{ Executor, Scope, ZIO }
+import zio.{ Executor, Scope, URIO, ZIO }
 
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
@@ -9,9 +9,9 @@ private[consumer] object RunloopExecutor {
 
   private val counter: AtomicLong = new AtomicLong(0)
 
-  private val newSingleThreadedExecutor: ZIO[Scope, Throwable, Executor] =
+  private val newSingleThreadedExecutor: URIO[Scope, Executor] =
     ZIO.acquireRelease {
-      ZIO.attempt {
+      ZIO.succeed {
         val javaExecutor =
           Executors.newSingleThreadExecutor { runnable =>
             new Thread(runnable, s"zio-kafka-runloop-thread-${counter.getAndIncrement()}")
@@ -21,6 +21,6 @@ private[consumer] object RunloopExecutor {
       }
     } { case (_, executor) => ZIO.attempt(executor.shutdown()).orDie }.map(_._1)
 
-  val newInstance: ZIO[Scope, Throwable, Executor] = newSingleThreadedExecutor
+  val newInstance: URIO[Scope, Executor] = newSingleThreadedExecutor
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/SubscriptionState.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/SubscriptionState.scala
@@ -1,0 +1,15 @@
+package zio.kafka.consumer.internal
+
+import zio.kafka.consumer.Subscription
+
+private[internal] sealed trait SubscriptionState {
+  def isSubscribed: Boolean =
+    this match {
+      case _: SubscriptionState.Subscribed => true
+      case SubscriptionState.NotSubscribed => false
+    }
+}
+private[internal] object SubscriptionState {
+  case object NotSubscribed                                                          extends SubscriptionState
+  final case class Subscribed(subscriptions: Set[Subscription], union: Subscription) extends SubscriptionState
+}


### PR DESCRIPTION
Fixes #856 

We need this PR https://github.com/zio/zio-sbt/pull/220 to merged and a new release of zio-sbt to be made to fix the CI.

The solution implemented is to boot the Runloop lazily: we only start it when the user start a consuming session

## Benchmarks
### Before:
```scala
[info] Benchmark                                        Mode  Cnt     Score    Error  Units
[info] ConsumerBenchmark.throughput                     avgt   30   205.017 ±  6.977  ms/op
[info] ConsumerBenchmark.throughputWithCommits          avgt   30   284.384 ±  8.733  ms/op
[info] ConsumersComparisonBenchmark.kafkaClients        avgt   30   647.721 ±  2.320  ms/op
[info] ConsumersComparisonBenchmark.manualKafkaClients  avgt   30   641.767 ±  2.508  ms/op
[info] ConsumersComparisonBenchmark.manualZioKafka      avgt   30  2673.759 ± 89.569  ms/op
[info] ConsumersComparisonBenchmark.zioKafka            avgt   30   737.250 ± 22.264  ms/op
```

### After:
```scala
[info] Benchmark                                        Mode  Cnt     Score     Error  Units
[info] ConsumerBenchmark.throughput                     avgt   30   209.078 ±   9.219  ms/op
[info] ConsumerBenchmark.throughputWithCommits          avgt   30   284.131 ±   9.911  ms/op
[info] ConsumersComparisonBenchmark.kafkaClients        avgt   30   645.890 ±   3.103  ms/op
[info] ConsumersComparisonBenchmark.manualKafkaClients  avgt   30   642.727 ±   2.079  ms/op
[info] ConsumersComparisonBenchmark.manualZioKafka      avgt   30  1686.490 ± 219.173  ms/op
[info] ConsumersComparisonBenchmark.zioKafka            avgt   30   722.776 ±  38.728  ms/op
```
### Conclusions

Interestingly and unexpectedly it's making the manual consumption with zio-kafka kind of way faster 🤔

Here are the details about these changes in `manualZioKafka`:
Before:
```scala
sbt:zio-kafka> zioKafkaBench/Jmh/run -wi 10 -i 10 -r 1 -w 1 -t 1 -f 5 -foe true .*ConsumersComparisonBenchmark.manualZioKafka*
...
[info] Result "zio.kafka.bench.ConsumersComparisonBenchmark.manualZioKafka":
[info]   2655.102 ±(99.9%) 99.652 ms/op [Average]
[info]   (min, avg, max) = (1634.785, 2655.102, 2810.666), stdev = 201.302
[info]   CI (99.9%): [2555.450, 2754.754] (assumes normal distribution)
[info] # Run complete. Total time: 00:08:12
```

After:
```scala
sbt:zio-kafka> zioKafkaBench/Jmh/run -wi 10 -i 10 -r 1 -w 1 -t 1 -f 5 -foe true .*ConsumersComparisonBenchmark.manualZioKafka*
...
[info] Result "zio.kafka.bench.ConsumersComparisonBenchmark.manualZioKafka":
[info]   1706.941 ±(99.9%) 214.879 ms/op [Average]
[info]   (min, avg, max) = (1084.221, 1706.941, 2791.118), stdev = 434.067
[info]   CI (99.9%): [1492.062, 1921.820] (assumes normal distribution)
[info] # Run complete. Total time: 00:07:00
```

## Benchmarks after #889
### Before
(Results copied from #889)
```scala
zioKafkaBench/Jmh/run -wi 10 -i 10 -r 1 -w 1 -t 1 -f 3 -foe true .*comparison.*
...
[info] Result "zio.kafka.bench.comparison.KafkaClientBenchmarks.kafkaClients":
[info]   641.438 ±(99.9%) 3.349 ms/op [Average]
[info]   (min, avg, max) = (624.941, 641.438, 650.032), stdev = 5.012
[info]   CI (99.9%): [638.090, 644.787] (assumes normal distribution)
...
[info] Result "zio.kafka.bench.comparison.KafkaClientBenchmarks.manualKafkaClients":
[info]   642.514 ±(99.9%) 3.090 ms/op [Average]
[info]   (min, avg, max) = (632.069, 642.514, 656.932), stdev = 4.625
[info]   CI (99.9%): [639.424, 645.605] (assumes normal distribution)
...
[info] Result "zio.kafka.bench.comparison.ZioKafkaBenchmarks.manualZioKafka":
[info]   2605.392 ±(99.9%) 229.199 ms/op [Average]
[info]   (min, avg, max) = (1584.064, 2605.392, 2818.016), stdev = 343.055
[info]   CI (99.9%): [2376.193, 2834.592] (assumes normal distribution)
...
[info] Result "zio.kafka.bench.comparison.ZioKafkaBenchmarks.zioKafka":
[info]   734.987 ±(99.9%) 22.830 ms/op [Average]
[info]   (min, avg, max) = (683.740, 734.987, 826.528), stdev = 34.170
[info]   CI (99.9%): [712.158, 757.817] (assumes normal distribution)
...
[info] Result "zio.kafka.bench.comparison.ZioKafkaNoOptimisticResumeBenchmarks.manualZioKafka":
[info]   819.937 ±(99.9%) 120.082 ms/op [Average]
[info]   (min, avg, max) = (683.373, 819.937, 1243.105), stdev = 179.733
[info]   CI (99.9%): [699.855, 940.019] (assumes normal distribution)
...
[info] Result "zio.kafka.bench.comparison.ZioKafkaNoOptimisticResumeBenchmarks.zioKafka":
[info]   1311.588 ±(99.9%) 212.646 ms/op [Average]
[info]   (min, avg, max) = (755.915, 1311.588, 2329.325), stdev = 318.279
[info]   CI (99.9%): [1098.942, 1524.234] (assumes normal distribution)
...
[info] Benchmark                                            Mode  Cnt     Score     Error  Units
[info] KafkaClientBenchmarks.kafkaClients                   avgt   30   641.438 ±   3.349  ms/op
[info] KafkaClientBenchmarks.manualKafkaClients             avgt   30   642.514 ±   3.090  ms/op
[info] ZioKafkaBenchmarks.manualZioKafka                    avgt   30  2605.392 ± 229.199  ms/op
[info] ZioKafkaBenchmarks.zioKafka                          avgt   30   734.987 ±  22.830  ms/op
[info] ZioKafkaNoOptimisticResumeBenchmarks.manualZioKafka  avgt   30   819.937 ± 120.082  ms/op
[info] ZioKafkaNoOptimisticResumeBenchmarks.zioKafka        avgt   30  1311.588 ± 212.646  ms/op
```

### After
```scala
zioKafkaBench/Jmh/run -wi 10 -i 10 -r 1 -w 1 -t 1 -f 3 -foe true .*comparison.*
...
[info] Result "zio.kafka.bench.comparison.KafkaClientBenchmarks.kafkaClients":
[info]   645.296 ±(99.9%) 3.731 ms/op [Average]
[info]   (min, avg, max) = (629.622, 645.296, 657.384), stdev = 5.585
[info]   CI (99.9%): [641.564, 649.027] (assumes normal distribution)
...
[info] Result "zio.kafka.bench.comparison.KafkaClientBenchmarks.manualKafkaClients":
[info]   644.850 ±(99.9%) 3.046 ms/op [Average]
[info]   (min, avg, max) = (634.433, 644.850, 652.421), stdev = 4.559
[info]   CI (99.9%): [641.804, 647.896] (assumes normal distribution)
...
[info] Result "zio.kafka.bench.comparison.ZioKafkaBenchmarks.manualZioKafka":
[info]   1725.509 ±(99.9%) 283.478 ms/op [Average]
[info]   (min, avg, max) = (1083.098, 1725.509, 2688.894), stdev = 424.296
[info]   CI (99.9%): [1442.031, 2008.986] (assumes normal distribution)
...
[info] Result "zio.kafka.bench.comparison.ZioKafkaBenchmarks.zioKafka":
[info]   706.280 ±(99.9%) 23.099 ms/op [Average]
[info]   (min, avg, max) = (651.442, 706.280, 765.971), stdev = 34.573
[info]   CI (99.9%): [683.181, 729.379] (assumes normal distribution)
...
[info] Result "zio.kafka.bench.comparison.ZioKafkaNoOptimisticResumeBenchmarks.manualZioKafka":
[info]   891.336 ±(99.9%) 163.192 ms/op [Average]
[info]   (min, avg, max) = (556.650, 891.336, 1611.211), stdev = 244.258
[info]   CI (99.9%): [728.144, 1054.528] (assumes normal distribution)
...
[info] Result "zio.kafka.bench.comparison.ZioKafkaNoOptimisticResumeBenchmarks.zioKafka":
[info]   1351.880 ±(99.9%) 459.663 ms/op [Average]
[info]   (min, avg, max) = (807.197, 1351.880, 4276.599), stdev = 688.002
[info]   CI (99.9%): [892.217, 1811.544] (assumes normal distribution)
...
[info] Benchmark                                            Mode  Cnt     Score     Error  Units
[info] KafkaClientBenchmarks.kafkaClients                   avgt   30   645.296 ±   3.731  ms/op
[info] KafkaClientBenchmarks.manualKafkaClients             avgt   30   644.850 ±   3.046  ms/op
[info] ZioKafkaBenchmarks.manualZioKafka                    avgt   30  1725.509 ± 283.478  ms/op
[info] ZioKafkaBenchmarks.zioKafka                          avgt   30   706.280 ±  23.099  ms/op
[info] ZioKafkaNoOptimisticResumeBenchmarks.manualZioKafka  avgt   30   891.336 ± 163.192  ms/op
[info] ZioKafkaNoOptimisticResumeBenchmarks.zioKafka        avgt   30  1351.880 ± 459.663  ms/op
```

### Conclusions

We still see this important improvement in the  `ZioKafkaBenchmarks.manualZioKafka` benchmark. The other ones are stable.