### PR TITLE
[WIP] Fix race condition spotted thanks to the `ConsumerSpec` "running streams don't stall after a poll timeout" test and its logs in DEBUG mode

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -28,7 +28,8 @@ private[consumer] final class Runloop private (
   offsetRetrieval: OffsetRetrieval,
   userRebalanceListener: RebalanceListener,
   restartStreamsOnRebalancing: Boolean,
-  currentState: Ref[State]
+  currentState: Ref[State],
+  isShuttingDownRef: Ref[Boolean] // Do not use this Ref for anything else than its current usage.
 ) {
 
   private def newPartitionStream(tp: TopicPartition): UIO[PartitionStreamControl] =
@@ -38,17 +39,29 @@ private[consumer] final class Runloop private (
   def gracefulShutdown: UIO[Unit] =
     commandQueue.offer(Command.StopAllStreams).unit
 
+  /**
+   * You cannot change the subscription when the runloop is shutting down.
+   *
+   * That can lead to deadlock if the `Command.ChangeSubscription` if offered and we wait for its Promise while the
+   * runloop doesn't accept more commands. The Promise will never be terminated.
+   */
   def changeSubscription(
     subscription: Option[Subscription]
   ): Task[Unit] =
-    Promise
-      .make[Throwable, Unit]
-      .flatMap { cont =>
-        commandQueue.offer(Command.ChangeSubscription(subscription, cont)) *>
-          cont.await
-      }
-      .unit
-      .uninterruptible
+    isShuttingDownRef.get.flatMap { isDown =>
+      // noinspection SimplifyUnlessInspection
+      if (isDown)
+        ZIO.debug(s"Runloop::changeSubscription called with $subscription while the Runloop is already shutdown")
+      else
+        Promise
+          .make[Throwable, Unit]
+          .flatMap { cont =>
+            commandQueue.offer(Command.ChangeSubscription(subscription, cont)) *>
+              cont.await
+          }
+          .unit
+          .uninterruptible
+    }
 
   val rebalanceListener: RebalanceListener = {
     val emitDiagnostics = RebalanceListener(
@@ -588,8 +601,9 @@ private[consumer] object Runloop {
                           Take[Throwable, (TopicPartition, Stream[Throwable, ByteArrayCommittableRecord])]
                         ]
                     )(_.shutdown)
-      currentStateRef <- Ref.make(State.initial)
-      runtime         <- ZIO.runtime[Any]
+      currentStateRef   <- Ref.make(State.initial)
+      runtime           <- ZIO.runtime[Any]
+      isShuttingDownRef <- Ref.make(false)
       runloop = new Runloop(
                   runtime,
                   hasGroupId,
@@ -603,7 +617,8 @@ private[consumer] object Runloop {
                   offsetRetrieval,
                   userRebalanceListener,
                   restartStreamsOnRebalancing,
-                  currentStateRef
+                  currentStateRef,
+                  isShuttingDownRef
                 )
       _ <- ZIO.logDebug("Starting Runloop")
 
@@ -612,7 +627,8 @@ private[consumer] object Runloop {
       fib      <- ZIO.onExecutor(executor)(runloop.run).forkScoped
 
       _ <- ZIO.addFinalizer(
-             ZIO.logTrace("Shutting down Runloop") *>
+             ZIO.logDebug("Shutting down Runloop") *>
+               isShuttingDownRef.set(true) *>
                commandQueue.offer(StopAllStreams) *>
                commandQueue.offer(StopRunloop) *>
                fib.join.orDie <*


### PR DESCRIPTION
Here are the logs from this tests when in DEBUG mode:
```scala
23:30:26.564 [ZScheduler-Worker-7] DEBUG zio.kafka.consumer.internal.Runloop - Starting Runloop
23:30:26.564 [ZScheduler-Worker-7] DEBUG zio.kafka.consumer.internal.Runloop - Starting Runloop
23:30:26.565 [ZScheduler-Worker-7] DEBUG z.k.c.C.L.partitionedAssignmentStream - Changing kafka subscription to Manual(Set(consumespec-topic-278906c2-8e99-46a1-88c5-7ce47e2e34ec-0))
23:30:26.565 [ZScheduler-Worker-7] DEBUG z.k.c.C.L.partitionedAssignmentStream - Changing kafka subscription to Manual(Set(consumespec-topic-278906c2-8e99-46a1-88c5-7ce47e2e34ec-0))
23:30:26.572 [ZScheduler-2] DEBUG zio.kafka.consumer.ConsumerSpec - CommittableRecord(ConsumerRecord(topic = consumespec-topic-278906c2-8e99-46a1-88c5-7ce47e2e34ec, partition = 0, leaderEpoch = 0, offset = 0, CreateTime = 1684870226540, serialized key size = 4, serialized value size = 8, headers = RecordHeaders(headers = [], isReadOnly = false), key = key1, value = message1),zio.kafka.consumer.internal.Runloop$$Lambda$3065/0x00000008013f6220@ead0521,None)
23:30:26.572 [ZScheduler-2] DEBUG zio.kafka.consumer.ConsumerSpec - CommittableRecord(ConsumerRecord(topic = consumespec-topic-278906c2-8e99-46a1-88c5-7ce47e2e34ec, partition = 0, leaderEpoch = 0, offset = 0, CreateTime = 1684870226540, serialized key size = 4, serialized value size = 8, headers = RecordHeaders(headers = [], isReadOnly = false), key = key1, value = message1),zio.kafka.consumer.internal.Runloop$$Lambda$3065/0x00000008013f6220@ead0521,None)
23:30:26.800 [ZScheduler-8] DEBUG zio.kafka.consumer.ConsumerSpec - CommittableRecord(ConsumerRecord(topic = consumespec-topic-278906c2-8e99-46a1-88c5-7ce47e2e34ec, partition = 0, leaderEpoch = 0, offset = 1, CreateTime = 1684870226778, serialized key size = 4, serialized value size = 8, headers = RecordHeaders(headers = [], isReadOnly = false), key = key2, value = message2),zio.kafka.consumer.internal.Runloop$$Lambda$3065/0x00000008013f6220@ead0521,None)
23:30:26.800 [ZScheduler-8] DEBUG zio.kafka.consumer.ConsumerSpec - CommittableRecord(ConsumerRecord(topic = consumespec-topic-278906c2-8e99-46a1-88c5-7ce47e2e34ec, partition = 0, leaderEpoch = 0, offset = 1, CreateTime = 1684870226778, serialized key size = 4, serialized value size = 8, headers = RecordHeaders(headers = [], isReadOnly = false), key = key2, value = message2),zio.kafka.consumer.internal.Runloop$$Lambda$3065/0x00000008013f6220@ead0521,None)
23:30:26.805 [ZScheduler-Worker-14] DEBUG zio.kafka.consumer.internal.Runloop - Shutting down Runloop
23:30:26.852 [zio-kafka-runloop-thread-0] DEBUG zio.kafka.consumer.internal.Runloop - Graceful shutdown
23:30:26.852 [zio-kafka-runloop-thread-0] DEBUG zio.kafka.consumer.internal.Runloop - Graceful shutdown
23:30:26.852 [zio-kafka-runloop-thread-0] DEBUG zio.kafka.consumer.internal.Runloop - Graceful shutdown initiated
23:30:26.852 [zio-kafka-runloop-thread-0] DEBUG zio.kafka.consumer.internal.Runloop - Graceful shutdown initiated
23:30:26.853 [ZScheduler-9] DEBUG z.k.c.i.P.newPartitionStream - Partition stream consumespec-topic-278906c2-8e99-46a1-88c5-7ce47e2e34ec-0 has ended
23:30:26.853 [ZScheduler-9] DEBUG z.k.c.i.P.newPartitionStream - Partition stream consumespec-topic-278906c2-8e99-46a1-88c5-7ce47e2e34ec-0 has ended
23:30:26.853 [ZScheduler-8] DEBUG z.k.c.C.L.partitionedAssignmentStream - Unsubscribing kafka consumer
23:30:26.853 [ZScheduler-8] DEBUG z.k.c.C.L.partitionedAssignmentStream - Unsubscribing kafka consumer
23:30:26.854 [ZScheduler-3] DEBUG zio.kafka.consumer.internal.Runloop - Shut down Runloop
```

To reproduce the deadlock, on the `master` branch (before this fix) run: 
```bash
sbt testOnly zio.kafka.consumer.ConsumerSpec
```
I reproduce this deadlock almost each time I run all the tests of `ConsumerSpec` (with the previous command)

When I only run the `"running streams don't stall after a poll timeout"`, I weirdly never reproduce: 
```bash
testOnly zio.kafka.consumer.ConsumerSpec -- -t \"running streams don't stall after a poll timeout\"
```