### PR TITLE
Producer.produceChunkAsyncWithFailures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev
     - name: Setup Scala
-      uses: actions/setup-java@v3.12.0
+      uses: actions/setup-java@v3.11.0
       with:
         distribution: temurin
         java-version: '8'
@@ -54,7 +54,7 @@ jobs:
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev
     - name: Setup Scala
-      uses: actions/setup-java@v3.12.0
+      uses: actions/setup-java@v3.11.0
       with:
         distribution: temurin
         java-version: '8'
@@ -80,7 +80,7 @@ jobs:
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev
     - name: Setup Scala
-      uses: actions/setup-java@v3.12.0
+      uses: actions/setup-java@v3.11.0
       with:
         distribution: temurin
         java-version: ${{ matrix.java }}
@@ -106,7 +106,7 @@ jobs:
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev
     - name: Setup Scala
-      uses: actions/setup-java@v3.12.0
+      uses: actions/setup-java@v3.11.0
       with:
         distribution: temurin
         java-version: '8'
@@ -180,7 +180,7 @@ jobs:
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev
     - name: Setup Scala
-      uses: actions/setup-java@v3.12.0
+      uses: actions/setup-java@v3.11.0
       with:
         distribution: temurin
         java-version: '8'
@@ -209,7 +209,7 @@ jobs:
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev
     - name: Setup Scala
-      uses: actions/setup-java@v3.12.0
+      uses: actions/setup-java@v3.11.0
       with:
         distribution: temurin
         java-version: '8'

--- a/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -2,7 +2,9 @@ package zio.kafka
 
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.config.TopicConfig
 import zio._
+import zio.kafka.admin.AdminClient.NewTopic
 import zio.kafka.consumer._
 import zio.kafka.producer.TransactionalProducer.{ TransactionLeaked, UserInitiatedAbort }
 import zio.kafka.producer.{ ByteRecord, Producer, Transaction, TransactionalProducer }
@@ -206,6 +208,51 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         } yield assertTrue(outcome.length == 2) &&
           assertTrue(record1.nonEmpty) &&
           assertTrue(record2.nonEmpty)
+      },
+      test("a non-empty chunk of records with partial failure") {
+        import Subscription._
+
+        def withConsumer(subscription: Subscription, settings: ConsumerSettings) =
+          Consumer.make(settings).flatMap { c =>
+            c.plainStream(subscription, Serde.string, Serde.string).toQueue()
+          }
+
+        def makeChunk(standardTopic: String, compactedTopic: String): Chunk[ByteRecord] = {
+          // Specifically a null key so publishing to compacted topic fails
+          val key2: Array[Byte] = null
+
+          Chunk.fromIterable(
+            List[ByteRecord](
+              new ProducerRecord(standardTopic, "boo".getBytes, "baa".getBytes),
+              new ProducerRecord(compactedTopic, key2, "boo".getBytes),
+              new ProducerRecord(standardTopic, "hello".getBytes, "world".getBytes)
+            )
+          )
+        }
+
+        for {
+          compactedTopic <- randomTopic
+          standardTopic  <- randomTopic
+          _ <- withAdmin(
+                 _.createTopic(NewTopic(compactedTopic, 1, 1, Map(TopicConfig.CLEANUP_POLICY_CONFIG -> "compact")))
+               )
+          group  <- randomGroup
+          client <- randomClient
+          chunk = makeChunk(standardTopic, compactedTopic)
+          outcome  <- Producer.produceChunkAsyncWithFailures(chunk).flatten
+          settings <- consumerSettings(client, Some(group))
+          recordsConsumed <- ZIO.scoped {
+                               withConsumer(Topics(Set(standardTopic)), settings).flatMap { consumer =>
+                                 consumer.take.flatMap(_.done).mapError(_.getOrElse(new NoSuchElementException))
+                               }
+                             }
+        } yield assertTrue(outcome.length == 3) &&
+          assertTrue(outcome(0).isRight) &&
+          assertTrue(
+            outcome(1).swap.exists(_.getMessage.contains("Compacted topic cannot accept message without key"))
+          ) &&
+          assertTrue(outcome(2).isRight) &&
+          assertTrue(recordsConsumed.length == 2)
       },
       test("an empty chunk of records") {
         val chunks = Chunk.fromIterable(List.empty)

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -99,7 +99,7 @@ object TransactionalProducer {
       semaphore <- Semaphore.make(1)
       runtime   <- ZIO.runtime[Any]
       sendQueue <-
-        Queue.bounded[(Chunk[ByteRecord], Promise[Throwable, Chunk[RecordMetadata]])](
+        Queue.bounded[(Chunk[ByteRecord], Promise[Nothing, Chunk[Either[Throwable, RecordMetadata]]])](
           settings.producerSettings.sendBufferSize
         )
       live = new ProducerLive(rawProducer, runtime, sendQueue)


### PR DESCRIPTION
Similar to produceChunkAsync, but preserves all the failures in the chunk.