### PR TITLE
Try to use `zio-profiling` with our benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,11 @@ def stdSettings(prjName: String) = Seq(
       case Some((2, _)) => Seq(compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"))
       case _            => List.empty
     }
-  }
+  },
+  libraryDependencies ++= Seq(
+    compilerPlugin("dev.zio" %% "zio-profiling-tagging-plugin" % "0.2.0"),
+    "dev.zio" %% "zio-profiling" % "0.2.0"
+  )
 ) ++ scalafixSettings
 
 lazy val zioKafka =
@@ -153,7 +157,12 @@ lazy val zioKafkaBench =
     .enablePlugins(JmhPlugin)
     .settings(stdSettings("zio-kafka-bench"))
     .settings(publish / skip := true)
-    .settings(libraryDependencies += logback)
+    .settings(
+      libraryDependencies ++= Seq(
+        logback,
+        "dev.zio" %% "zio-profiling-jmh" % "0.2.0"
+      )
+    )
     .dependsOn(zioKafka, zioKafkaTestkit)
 
 lazy val zioKafkaExample =

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ComparisonBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ComparisonBenchmark.scala
@@ -11,7 +11,7 @@ import zio.kafka.consumer.{ Consumer, ConsumerSettings }
 import zio.kafka.producer.Producer
 import zio.kafka.testkit.Kafka
 import zio.kafka.testkit.KafkaTestUtils.{ consumerSettings, minimalConsumer, produceMany, producer }
-import zio.{ durationInt, ULayer, ZIO, ZLayer }
+import zio.{ ULayer, ZIO, ZLayer }
 
 import scala.jdk.CollectionConverters._
 
@@ -44,9 +44,7 @@ trait ComparisonBenchmark extends ZioBenchmark[Env] {
       consumerSettings(
         clientId = randomThing("client"),
         groupId = Some(randomThing("client")),
-        `max.poll.records` = 1000, // A more production worthy value
-        runloopTimeout =
-          1.hour // Absurdly high timeout to avoid the runloop from being interrupted while we're benchmarking other stuff
+        `max.poll.records` = 1000 // A more production worthy value
       )
     )
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -1,20 +1,29 @@
 package zio.kafka.consumer
 
 import io.github.embeddedkafka.EmbeddedKafka
-import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerPartitionAssignor, CooperativeStickyAssignor, RangeAssignor}
+import org.apache.kafka.clients.consumer.{
+  ConsumerConfig,
+  ConsumerPartitionAssignor,
+  CooperativeStickyAssignor,
+  RangeAssignor
+}
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import zio._
 import zio.kafka.ZIOSpecDefaultSlf4j
-import zio.kafka.consumer.Consumer.{AutoOffsetStrategy, OffsetRetrieval}
+import zio.kafka.consumer.Consumer.{ AutoOffsetStrategy, OffsetRetrieval }
 import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization
-import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization.{ConsumerFinalized, RunloopFinalized, SubscriptionFinalized}
-import zio.kafka.consumer.diagnostics.{DiagnosticEvent, Diagnostics}
-import zio.kafka.producer.{Producer, TransactionalProducer}
+import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization.{
+  ConsumerFinalized,
+  RunloopFinalized,
+  SubscriptionFinalized
+}
+import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
+import zio.kafka.producer.{ Producer, TransactionalProducer }
 import zio.kafka.serde.Serde
 import zio.kafka.testkit.KafkaTestUtils._
-import zio.kafka.testkit.{Kafka, KafkaRandom}
-import zio.stream.{ZSink, ZStream}
+import zio.kafka.testkit.{ Kafka, KafkaRandom }
+import zio.stream.{ ZSink, ZStream }
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
@@ -1267,7 +1276,59 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                 )
               )
             )
-          } @@ nonFlaky(5)
+          } @@ nonFlaky(5),
+          test(
+            "it's possible to start a new consumption session from a Consumer that had a consumption session stopped previously"
+          ) {
+            val numberOfMessages: Int           = 100000
+            val kvs: Iterable[(String, String)] = Iterable.tabulate(numberOfMessages)(i => (s"key-$i", s"msg-$i"))
+
+            def test(diagnostics: Diagnostics): ZIO[Producer & Scope & Kafka, Throwable, TestResult] =
+              for {
+                clientId <- randomClient
+                topic    <- randomTopic
+                settings <- consumerSettings(clientId = clientId)
+                consumer <- Consumer.make(settings, diagnostics = diagnostics)
+                _        <- produceMany(topic, kvs)
+                // Starting a consumption session to start the Runloop.
+                fiber <- consumer
+                           .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
+                           .take(numberOfMessages.toLong)
+                           .runCount
+                           .forkScoped
+                _          <- ZIO.sleep(200.millis)
+                _          <- consumer.stopConsumption
+                consumed_0 <- fiber.join
+                _          <- ZIO.logDebug(s"consumed_0: $consumed_0")
+
+                _ <- ZIO.logDebug("About to sleep 5 seconds")
+                _ <- ZIO.sleep(5.seconds)
+                _ <- ZIO.logDebug("Slept 5 seconds")
+                consumed_1 <- consumer
+                                .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
+                                .take(numberOfMessages.toLong)
+                                .runCount
+              } yield assert(consumed_0)(isGreaterThan(0L) && isLessThan(numberOfMessages.toLong)) &&
+                assert(consumed_1)(equalTo(numberOfMessages.toLong))
+
+            for {
+              diagnostics <- Diagnostics.SlidingQueue.make(1000)
+              testResult <- ZIO.scoped {
+                              test(diagnostics)
+                            }
+              finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isInstanceOf[Finalization]))
+            } yield testResult && assert(finalizationEvents)(
+              // The order is very important.
+              // The subscription must be finalized before the runloop, otherwise it creates a deadlock.
+              equalTo(
+                Chunk(
+                  SubscriptionFinalized,
+                  RunloopFinalized,
+                  ConsumerFinalized
+                )
+              )
+            )
+          }
         )
       )
     )

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -28,6 +28,7 @@ import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
 
+import java.util.concurrent.atomic.AtomicInteger
 import scala.reflect.ClassTag
 
 //noinspection SimplifyAssertInspection
@@ -1152,12 +1153,15 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                 settings <- consumerSettings(clientId = clientId)
                 consumer <- Consumer.make(settings, diagnostics = diagnostics)
                 _        <- produceMany(topic, kvs)
+                ref = new AtomicInteger(0)
                 // Starting a consumption session to start the Runloop.
-                fiber <- consumer
-                           .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
-                           .take(numberOfMessages.toLong)
-                           .runCount
-                           .forkScoped
+                fiber <-
+                  consumer
+                    .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
+                    .mapChunksZIO(chunks => ZIO.logDebug(s"Consumed ${ref.getAndAdd(chunks.size)} messages").as(chunks))
+                    .take(numberOfMessages.toLong)
+                    .runCount
+                    .fork
                 _          <- consumer.stopConsumption
                 consumed_0 <- fiber.join
               } yield assert(consumed_0)(isLessThan(numberOfMessages.toLong))

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -103,7 +103,6 @@ object KafkaTestUtils {
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
     `max.poll.records`: Int = 100, // settings this higher can cause concurrency bugs to go unnoticed
-    runloopTimeout: Duration = ConsumerSettings.defaultRunloopTimeout,
     properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =
     ZIO.serviceWith[Kafka] { (kafka: Kafka) =>
@@ -111,7 +110,6 @@ object KafkaTestUtils {
         .withClientId(clientId)
         .withCloseTimeout(5.seconds)
         .withPollTimeout(100.millis)
-        .withRunloopTimeout(runloopTimeout)
         .withProperties(
           ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "earliest",
           ConsumerConfig.METADATA_MAX_AGE_CONFIG         -> "100",

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -3,15 +3,14 @@ package zio.kafka.consumer
 import org.apache.kafka.clients.consumer.{ ConsumerRecord, OffsetAndMetadata, OffsetAndTimestamp }
 import org.apache.kafka.common._
 import zio._
+import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization
 import zio.kafka.consumer.diagnostics.Diagnostics
-import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
-import zio.kafka.consumer.internal.{ ConsumerAccess, Runloop }
+import zio.kafka.consumer.internal.{ ConsumerAccess, RunloopAccess }
 import zio.kafka.serde.{ Deserializer, Serde }
 import zio.kafka.utils.SslHelper
 import zio.stream._
 
 import scala.jdk.CollectionConverters._
-import scala.util.control.NoStackTrace
 
 trait Consumer {
 
@@ -156,15 +155,9 @@ trait Consumer {
 
 object Consumer {
 
-  case object RunloopTimeout extends RuntimeException("Timeout in Runloop") with NoStackTrace
-
   private final class Live private[Consumer] (
-    private val consumer: ConsumerAccess,
-    private val runloop: Runloop,
-    private val subscriptions: Ref.Synchronized[Set[Subscription]],
-    private val partitionAssignments: Hub[
-      Take[Throwable, Chunk[(TopicPartition, ZStream[Any, Throwable, ByteArrayCommittableRecord])]]
-    ]
+    consumer: ConsumerAccess,
+    runloopAccess: RunloopAccess
   ) extends Consumer {
 
     override def assignment: Task[Set[TopicPartition]] =
@@ -201,7 +194,9 @@ object Consumer {
      * Stops consumption of data, drains buffered records, and ends the attached streams while still serving commit
      * requests.
      */
-    override def stopConsumption: UIO[Unit] = runloop.stopConsumption
+    override def stopConsumption: UIO[Unit] =
+      ZIO.logDebug("stopConsumption called") *>
+        runloopAccess.stopConsumption()
 
     override def listTopics(timeout: Duration = Duration.Infinity): Task[Map[String, List[PartitionInfo]]] =
       consumer.withConsumer(_.listTopics(timeout.asJava).asScala.map { case (k, v) => k -> v.asScala.toList }.toMap)
@@ -222,43 +217,20 @@ object Consumer {
       keyDeserializer: Deserializer[R, K],
       valueDeserializer: Deserializer[R, V]
     ): Stream[Throwable, Chunk[(TopicPartition, ZStream[R, Throwable, CommittableRecord[K, V]])]] = {
-      def extendSubscriptions = subscriptions.updateZIO { existingSubscriptions =>
-        val newSubscriptions = NonEmptyChunk.fromIterable(subscription, existingSubscriptions)
-        Subscription.unionAll(newSubscriptions) match {
-          case None => ZIO.fail(InvalidSubscriptionUnion(newSubscriptions))
-          case Some(union) =>
-            ZIO.logDebug(s"Changing kafka subscription to $union") *>
-              subscribe(union).as(newSubscriptions.toSet)
-        }
-      }.uninterruptible
-
-      def reduceSubscriptions = subscriptions.updateZIO { existingSubscriptions =>
-        val newSubscriptions = NonEmptyChunk.fromIterableOption(existingSubscriptions - subscription)
-        val newUnion         = newSubscriptions.flatMap(Subscription.unionAll)
-
-        (newUnion match {
-          case Some(union) =>
-            ZIO.logDebug(s"Reducing kafka subscription to $union") *> subscribe(union)
-          case None =>
-            ZIO.logDebug(s"Unsubscribing kafka consumer") *> unsubscribe
-        }).as(newSubscriptions.fold(Set.empty[Subscription])(_.toSet))
-      }.uninterruptible
-
       val onlyByteArraySerdes: Boolean = (keyDeserializer eq Serde.byteArray) && (valueDeserializer eq Serde.byteArray)
 
       ZStream.unwrapScoped {
         for {
-          stream <- ZStream.fromHubScoped(partitionAssignments)
-          _      <- extendSubscriptions.withFinalizer(_ => reduceSubscriptions.orDie)
+          stream <- runloopAccess.subscribe(subscription)
         } yield stream
           .map(_.exit)
           .flattenExitOption
-          .flattenChunks
           .map {
             _.collect {
               case (tp, partitionStream) if Subscription.subscriptionMatches(subscription, tp) =>
                 val stream: ZStream[R, Throwable, CommittableRecord[K, V]] =
-                  if (onlyByteArraySerdes) partitionStream.asInstanceOf[ZStream[R, Throwable, CommittableRecord[K, V]]]
+                  if (onlyByteArraySerdes)
+                    partitionStream.asInstanceOf[ZStream[R, Throwable, CommittableRecord[K, V]]]
                   else partitionStream.mapChunksZIO(_.mapZIO(_.deserializeWith(keyDeserializer, valueDeserializer)))
 
                 tp -> stream
@@ -320,12 +292,6 @@ object Consumer {
                .runDrain
       } yield ()
 
-    private def subscribe(subscription: Subscription): Task[Unit] =
-      runloop.changeSubscription(Some(subscription))
-
-    private def unsubscribe: Task[Unit] =
-      runloop.changeSubscription(None)
-
     override def metrics: Task[Map[MetricName, Metric]] =
       consumer.withConsumer(_.metrics().asScala.toMap)
   }
@@ -345,40 +311,13 @@ object Consumer {
   def make(
     settings: ConsumerSettings,
     diagnostics: Diagnostics = Diagnostics.NoOp
-  ): ZIO[Scope, Throwable, Consumer] = {
-    /*
-    We must supply a queue size for the partitionAssignments hub below. Under most circumstances,
-    a value of 1 should be sufficient, as runloop.partitions is already an unbounded queue. But if
-    there is a large skew in speed of consuming partition assignments (not the speed of consuming kafka messages)
-    between the subscriptions, there may arise a situation where the faster stream is 'blocked' from
-    getting new partition assignments by the faster stream. A value of 32 should be more than sufficient to cover
-    this situation.
-     */
-    val hubCapacity = 32
-
+  ): ZIO[Scope, Throwable, Consumer] =
     for {
-      _       <- SslHelper.validateEndpoint(settings.bootstrapServers, settings.properties)
-      wrapper <- ConsumerAccess.make(settings)
-      runloop <- Runloop.make(
-                   hasGroupId = settings.hasGroupId,
-                   consumer = wrapper,
-                   pollTimeout = settings.pollTimeout,
-                   diagnostics = diagnostics,
-                   offsetRetrieval = settings.offsetRetrieval,
-                   userRebalanceListener = settings.rebalanceListener,
-                   restartStreamsOnRebalancing = settings.restartStreamOnRebalancing,
-                   runloopTimeout = settings.runloopTimeout,
-                   consumerSettings = settings
-                 )
-      subscriptions <- Ref.Synchronized.make(Set.empty[Subscription])
-
-      partitionAssignments <- ZStream
-                                .fromQueue(runloop.partitionsQueue)
-                                .map(_.exit)
-                                .flattenExitOption
-                                .toHub(hubCapacity)
-    } yield new Live(wrapper, runloop, subscriptions, partitionAssignments)
-  }
+      _              <- ZIO.addFinalizer(diagnostics.emit(Finalization.ConsumerFinalized))
+      _              <- SslHelper.validateEndpoint(settings.bootstrapServers, settings.properties)
+      consumerAccess <- ConsumerAccess.make(settings)
+      runloopAccess  <- RunloopAccess.make(settings, diagnostics, consumerAccess, settings)
+    } yield new Live(consumerAccess, runloopAccess)
 
   /**
    * Accessor method for [[Consumer.assignment]]

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -15,11 +15,6 @@ import zio.kafka.security.KafkaCredentialStore
  * @param restartStreamOnRebalancing
  *   When `true` _all_ streams are restarted during a rebalance, including those streams that are not revoked. The
  *   default is `false`.
- * @param runloopTimeout
- *   Internal timeout for each iteration of the command processing and polling loop, use to detect stalling. This should
- *   be much larger than the pollTimeout and the time it takes to process chunks of records. If your consumer is not
- *   subscribed for long periods during its lifetime, this timeout should take that into account as well. When the
- *   timeout expires, the plainStream/partitionedStream/etc will fail with a [[Consumer.RunloopTimeout]].
  * @param enableOptimisticResume
  *   When `true` (the default) zio-kafka predicts whether a stream needs more data, slightly ahead of time. Zio-kafka
  *   pauses partitions for which the associated stream is processing previously fetched data. When the stream needs more
@@ -34,7 +29,6 @@ final case class ConsumerSettings(
   offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
   rebalanceListener: RebalanceListener = RebalanceListener.noop,
   restartStreamOnRebalancing: Boolean = false,
-  runloopTimeout: Duration = ConsumerSettings.defaultRunloopTimeout,
   enableOptimisticResume: Boolean = true
 ) {
   private[this] def autoOffsetResetConfig: Map[String, String] = offsetRetrieval match {
@@ -90,8 +84,6 @@ final case class ConsumerSettings(
   def withCredentials(credentialsStore: KafkaCredentialStore): ConsumerSettings =
     withProperties(credentialsStore.properties)
 
-  def withRunloopTimeout(timeout: Duration): ConsumerSettings =
-    copy(runloopTimeout = timeout)
 }
 
 object ConsumerSettings {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
@@ -27,4 +27,11 @@ object DiagnosticEvent {
     final case class Lost(partitions: Set[TopicPartition])     extends Rebalance
   }
 
+  sealed trait Finalization extends DiagnosticEvent
+  object Finalization {
+    case object SubscriptionFinalized extends Finalization
+    case object RunloopFinalized      extends Finalization
+    case object ConsumerFinalized     extends Finalization
+  }
+
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -44,7 +44,7 @@ private[consumer] final class Runloop private (
       commandQueue
         .offerAll(
           Chunk(
-            RunloopCommand.StopSubscription,
+            RunloopCommand.RemoveAllSubscriptions,
             RunloopCommand.StopAllStreams,
             RunloopCommand.StopRunloop
           )
@@ -440,7 +440,7 @@ private[consumer] final class Runloop private (
                   doChangeSubscription(SubscriptionState.NotSubscribed)
             }
         }
-      case RunloopCommand.StopSubscription => doChangeSubscription(SubscriptionState.NotSubscribed)
+      case RunloopCommand.RemoveAllSubscriptions => doChangeSubscription(SubscriptionState.NotSubscribed)
       case RunloopCommand.StopAllStreams =>
         for {
           _ <- ZIO.logDebug("Stop all streams initiated")

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -493,7 +493,7 @@ private[consumer] final class Runloop private (
    *   - Poll periodically when we are subscribed but do not have assigned streams yet. This happens after
    *     initialization and rebalancing
    */
-  val run: ZIO[Scope, Throwable, Any] = {
+  def run: ZIO[Scope, Throwable, Any] = {
     import Runloop.StreamOps
 
     ZStream

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -493,7 +493,7 @@ private[consumer] final class Runloop private (
    *   - Poll periodically when we are subscribed but do not have assigned streams yet. This happens after
    *     initialization and rebalancing
    */
-  def run: ZIO[Scope, Throwable, Any] = {
+  val run: ZIO[Scope, Throwable, Any] = {
     import Runloop.StreamOps
 
     ZStream
@@ -607,7 +607,8 @@ private[consumer] object Runloop {
       waitForRunloopStop = fiber.join.orDie
 
       _ <- ZIO.addFinalizer(
-             runloop.shutdown *>
+             ZIO.logDebug("Shutting down Runloop") *>
+               runloop.shutdown *>
                waitForRunloopStop <*
                ZIO.logDebug("Shut down Runloop")
            )

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -4,11 +4,12 @@ import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.RebalanceInProgressException
 import zio._
-import zio.kafka.consumer.Consumer.{ OffsetRetrieval, RunloopTimeout }
+import zio.kafka.consumer.Consumer.OffsetRetrieval
 import zio.kafka.consumer._
+import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization
 import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
 import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
-import zio.kafka.consumer.internal.Runloop._
+import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
 import zio.stream._
 
 import java.util
@@ -20,10 +21,9 @@ private[consumer] final class Runloop private (
   hasGroupId: Boolean,
   consumer: ConsumerAccess,
   pollTimeout: Duration,
-  runloopTimeout: Duration,
   commandQueue: Queue[RunloopCommand],
   lastRebalanceEvent: Ref.Synchronized[Option[Runloop.RebalanceEvent]],
-  val partitionsQueue: Queue[Take[Throwable, (TopicPartition, Stream[Throwable, ByteArrayCommittableRecord])]],
+  partitionsHub: Hub[Take[Throwable, PartitionAssignment]],
   diagnostics: Diagnostics,
   offsetRetrieval: OffsetRetrieval,
   userRebalanceListener: RebalanceListener,
@@ -36,19 +36,26 @@ private[consumer] final class Runloop private (
     PartitionStreamControl.newPartitionStream(tp, commandQueue, diagnostics)
 
   def stopConsumption: UIO[Unit] =
-    commandQueue.offer(RunloopCommand.StopAllStreams).unit
+    ZIO.logDebug("stopConsumption called") *>
+      commandQueue.offer(RunloopCommand.StopAllStreams).unit
 
-  def changeSubscription(
-    subscription: Option[Subscription]
-  ): Task[Unit] =
-    Promise
-      .make[Throwable, Unit]
-      .flatMap { cont =>
-        commandQueue.offer(RunloopCommand.ChangeSubscription(subscription, cont)) *>
-          cont.await
-      }
-      .unit
-      .uninterruptible
+  private[consumer] def shutdown: UIO[Unit] =
+    ZIO.logDebug(s"Shutting down runloop initiated") *>
+      commandQueue
+        .offerAll(
+          Chunk(
+            RunloopCommand.StopSubscription,
+            RunloopCommand.StopAllStreams,
+            RunloopCommand.StopRunloop
+          )
+        )
+        .unit
+
+  private[internal] def addSubscription(subscription: Subscription): UIO[Unit] =
+    commandQueue.offer(RunloopCommand.AddSubscription(subscription)).unit
+
+  private[internal] def removeSubscription(subscription: Subscription): UIO[Unit] =
+    commandQueue.offer(RunloopCommand.RemoveSubscription(subscription)).unit
 
   private val rebalanceListener: RebalanceListener = {
     val emitDiagnostics = RebalanceListener(
@@ -351,7 +358,7 @@ private[consumer] final class Runloop private (
             .foreach(Chunk.fromIterable(pollResult.startingTps))(newPartitionStream)
             .tap { newStreams =>
               ZIO.logDebug(s"Offering partition assignment ${pollResult.startingTps}") *>
-                partitionsQueue.offer(Take.chunk(Chunk.fromIterable(newStreams.map(_.tpStream))))
+                partitionsHub.publish(Take.chunk(Chunk.fromIterable(newStreams.map(_.tpStream))))
             }
         }
       runningStreams <- ZIO.filter(pollResult.assignedStreams)(_.isRunning)
@@ -369,68 +376,107 @@ private[consumer] final class Runloop private (
       assignedStreams = updatedStreams
     )
 
-  private def handleCommand(state: State, cmd: RunloopCommand.StreamCommand): Task[State] =
+  private def handleCommand(state: State, cmd: RunloopCommand.StreamCommand): Task[State] = {
+    def doChangeSubscription(newSubscriptionState: SubscriptionState): Task[State] =
+      applyNewSubscriptionState(newSubscriptionState).flatMap { newAssignedStreams =>
+        val newState = state.copy(
+          assignedStreams = state.assignedStreams ++ newAssignedStreams,
+          subscriptionState = newSubscriptionState
+        )
+        if (newSubscriptionState.isSubscribed) ZIO.succeed(newState)
+        else
+          // End all streams and pending requests
+          endRevokedPartitions(
+            newState.pendingRequests,
+            newState.assignedStreams,
+            isRevoked = _ => true
+          ).map { revokeResult =>
+            newState.copy(
+              pendingRequests = revokeResult.pendingRequests,
+              assignedStreams = revokeResult.assignedStreams
+            )
+          }
+      }
+
     cmd match {
       case req: RunloopCommand.Request => ZIO.succeed(state.addRequest(req))
       case cmd: RunloopCommand.Commit  => doCommit(cmd).as(state.addCommit(cmd))
-      case cmd @ RunloopCommand.ChangeSubscription(subscription, _) =>
-        handleChangeSubscription(subscription).flatMap { newAssignedStreams =>
-          val newState = state.copy(
-            assignedStreams = state.assignedStreams ++ newAssignedStreams,
-            subscription = subscription
-          )
-          if (subscription.isDefined) ZIO.succeed(newState)
-          else {
-            // End all streams and pending requests
-            endRevokedPartitions(
-              newState.pendingRequests,
-              newState.assignedStreams,
-              isRevoked = _ => true
-            ).map { revokeResult =>
-              newState.copy(
-                pendingRequests = revokeResult.pendingRequests,
-                assignedStreams = revokeResult.assignedStreams
-              )
+      case RunloopCommand.AddSubscription(newSubscription) =>
+        state.subscriptionState match {
+          case SubscriptionState.NotSubscribed =>
+            val newSubState =
+              SubscriptionState.Subscribed(subscriptions = Set(newSubscription), union = newSubscription)
+            doChangeSubscription(newSubState)
+          case SubscriptionState.Subscribed(existingSubscriptions, _) =>
+            val subs = NonEmptyChunk.fromIterable(newSubscription, existingSubscriptions)
+
+            Subscription.unionAll(subs) match {
+              case None => ZIO.fail(InvalidSubscriptionUnion(subs))
+              case Some(union) =>
+                val newSubState =
+                  SubscriptionState.Subscribed(
+                    subscriptions = existingSubscriptions + newSubscription,
+                    union = union
+                  )
+                doChangeSubscription(newSubState)
             }
-          }
         }
-          .tapBoth(e => cmd.fail(e), _ => cmd.succeed)
-          .uninterruptible
+      case RunloopCommand.RemoveSubscription(subscription) =>
+        state.subscriptionState match {
+          case SubscriptionState.NotSubscribed => ZIO.succeed(state)
+          case SubscriptionState.Subscribed(existingSubscriptions, _) =>
+            val newUnion: Option[(Subscription, NonEmptyChunk[Subscription])] =
+              NonEmptyChunk
+                .fromIterableOption(existingSubscriptions - subscription)
+                .flatMap(subs => Subscription.unionAll(subs).map(_ -> subs))
+
+            newUnion match {
+              case Some((union, newSubscriptions)) =>
+                val newSubState =
+                  SubscriptionState.Subscribed(subscriptions = newSubscriptions.toSet, union = union)
+                doChangeSubscription(newSubState)
+              case None =>
+                ZIO.logDebug(s"Unsubscribing kafka consumer") *>
+                  doChangeSubscription(SubscriptionState.NotSubscribed)
+            }
+        }
+      case RunloopCommand.StopSubscription => doChangeSubscription(SubscriptionState.NotSubscribed)
       case RunloopCommand.StopAllStreams =>
         for {
           _ <- ZIO.logDebug("Stop all streams initiated")
           _ <- ZIO.foreachDiscard(state.assignedStreams)(_.end())
-          _ <- partitionsQueue.offer(Take.end)
+          _ <- partitionsHub.publish(Take.end)
           _ <- ZIO.logDebug("Stop all streams done")
         } yield state.copy(pendingRequests = Chunk.empty)
     }
+  }
 
-  private def handleChangeSubscription(
-    newSubscription: Option[Subscription]
+  private def applyNewSubscriptionState(
+    newSubscriptionState: SubscriptionState
   ): Task[Chunk[PartitionStreamControl]] =
     consumer.runloopAccess { c =>
-      newSubscription match {
-        case None =>
+      newSubscriptionState match {
+        case SubscriptionState.NotSubscribed =>
           ZIO
             .attempt(c.unsubscribe())
             .as(Chunk.empty)
-        case Some(Subscription.Pattern(pattern)) =>
+        case SubscriptionState.Subscribed(_, Subscription.Pattern(pattern)) =>
           val rc = RebalanceConsumer.Live(c)
           ZIO
             .attempt(c.subscribe(pattern.pattern, rebalanceListener.toKafka(runtime, rc)))
             .as(Chunk.empty)
-        case Some(Subscription.Topics(topics)) =>
+        case SubscriptionState.Subscribed(_, Subscription.Topics(topics)) =>
           val rc = RebalanceConsumer.Live(c)
           ZIO
             .attempt(c.subscribe(topics.asJava, rebalanceListener.toKafka(runtime, rc)))
             .as(Chunk.empty)
-        case Some(Subscription.Manual(topicPartitions)) =>
+        case SubscriptionState.Subscribed(_, Subscription.Manual(topicPartitions)) =>
           // For manual subscriptions we have to do some manual work before starting the run loop
           for {
             _                <- ZIO.attempt(c.assign(topicPartitions.asJava))
             _                <- doSeekForNewPartitions(c, topicPartitions)
             partitionStreams <- ZIO.foreach(Chunk.fromIterable(topicPartitions))(newPartitionStream)
-            _                <- partitionsQueue.offer(Take.chunk(partitionStreams.map(_.tpStream)))
+            _                <- partitionsHub.publish(Take.chunk(partitionStreams.map(_.tpStream)))
           } yield partitionStreams
       }
     }
@@ -452,7 +498,6 @@ private[consumer] final class Runloop private (
 
     ZStream
       .fromQueue(commandQueue)
-      .timeoutFail[Throwable](RunloopTimeout)(runloopTimeout)
       .takeWhile(_ != RunloopCommand.StopRunloop)
       .runFoldChunksDiscardZIO(State.initial) { (state, commands) =>
         for {
@@ -467,7 +512,7 @@ private[consumer] final class Runloop private (
         } yield updatedStateAfterPoll
       }
       .tapErrorCause(cause => ZIO.logErrorCause("Error in Runloop", cause))
-      .onError(cause => partitionsQueue.offer(Take.failCause(cause)))
+      .onError(cause => partitionsHub.offer(Take.failCause(cause)))
   }
 }
 
@@ -494,9 +539,6 @@ private[consumer] object Runloop {
 
   type ByteArrayCommittableRecord = CommittableRecord[Array[Byte], Array[Byte]]
 
-  // Internal parameters, should not be necessary to tune
-  private val commandQueueSize = 1024
-
   private final case class PollResult(
     startingTps: Set[TopicPartition],
     pendingRequests: Chunk[RunloopCommand.Request],
@@ -522,6 +564,9 @@ private[consumer] object Runloop {
     ) extends RebalanceEvent
   }
 
+  // Internal parameters, should not be necessary to tune
+  private final val commandQueueSize: Int = 1024
+
   def make(
     hasGroupId: Boolean,
     consumer: ConsumerAccess,
@@ -530,29 +575,23 @@ private[consumer] object Runloop {
     offsetRetrieval: OffsetRetrieval,
     userRebalanceListener: RebalanceListener,
     restartStreamsOnRebalancing: Boolean,
-    runloopTimeout: Duration,
+    partitionsHub: Hub[Take[Throwable, PartitionAssignment]],
     consumerSettings: ConsumerSettings
   ): ZIO[Scope, Throwable, Runloop] =
     for {
+      _                  <- ZIO.addFinalizer(diagnostics.emit(Finalization.RunloopFinalized))
       commandQueue       <- ZIO.acquireRelease(Queue.bounded[RunloopCommand](commandQueueSize))(_.shutdown)
       lastRebalanceEvent <- Ref.Synchronized.make[Option[Runloop.RebalanceEvent]](None)
-      partitionsQueue <- ZIO.acquireRelease(
-                           Queue
-                             .unbounded[
-                               Take[Throwable, (TopicPartition, Stream[Throwable, ByteArrayCommittableRecord])]
-                             ]
-                         )(_.shutdown)
-      currentStateRef <- Ref.make(State.initial)
-      runtime         <- ZIO.runtime[Any]
+      currentStateRef    <- Ref.make(State.initial)
+      runtime            <- ZIO.runtime[Any]
       runloop = new Runloop(
                   runtime = runtime,
                   hasGroupId = hasGroupId,
                   consumer = consumer,
                   pollTimeout = pollTimeout,
-                  runloopTimeout = runloopTimeout,
                   commandQueue = commandQueue,
                   lastRebalanceEvent = lastRebalanceEvent,
-                  partitionsQueue = partitionsQueue,
+                  partitionsHub = partitionsHub,
                   diagnostics = diagnostics,
                   offsetRetrieval = offsetRetrieval,
                   userRebalanceListener = userRebalanceListener,
@@ -568,9 +607,7 @@ private[consumer] object Runloop {
       waitForRunloopStop = fiber.join.orDie
 
       _ <- ZIO.addFinalizer(
-             ZIO.logTrace("Shutting down Runloop") *>
-               commandQueue.offer(RunloopCommand.StopAllStreams) *>
-               commandQueue.offer(RunloopCommand.StopRunloop) *>
+             runloop.shutdown *>
                waitForRunloopStop <*
                ZIO.logDebug("Shut down Runloop")
            )
@@ -581,15 +618,13 @@ private[internal] final case class State(
   pendingRequests: Chunk[RunloopCommand.Request],
   pendingCommits: Chunk[RunloopCommand.Commit],
   assignedStreams: Chunk[PartitionStreamControl],
-  subscription: Option[Subscription]
+  subscriptionState: SubscriptionState
 ) {
   def addCommit(c: RunloopCommand.Commit): State   = copy(pendingCommits = pendingCommits :+ c)
   def addRequest(r: RunloopCommand.Request): State = copy(pendingRequests = pendingRequests :+ r)
 
-  def isSubscribed: Boolean = subscription.isDefined
-
   def shouldPoll: Boolean =
-    isSubscribed && (pendingRequests.nonEmpty || pendingCommits.nonEmpty || assignedStreams.isEmpty)
+    subscriptionState.isSubscribed && (pendingRequests.nonEmpty || pendingCommits.nonEmpty || assignedStreams.isEmpty)
 }
 
 object State {
@@ -597,6 +632,6 @@ object State {
     pendingRequests = Chunk.empty,
     pendingCommits = Chunk.empty,
     assignedStreams = Chunk.empty,
-    subscription = None
+    subscriptionState = SubscriptionState.NotSubscribed
   )
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -577,7 +577,7 @@ private[consumer] object Runloop {
     restartStreamsOnRebalancing: Boolean,
     partitionsHub: Hub[Take[Throwable, PartitionAssignment]],
     consumerSettings: ConsumerSettings
-  ): ZIO[Scope, Throwable, Runloop] =
+  ): URIO[Scope, Runloop] =
     for {
       _                  <- ZIO.addFinalizer(diagnostics.emit(Finalization.RunloopFinalized))
       commandQueue       <- ZIO.acquireRelease(Queue.bounded[RunloopCommand](commandQueueSize))(_.shutdown)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -20,8 +20,8 @@ private[internal] object RunloopState {
  * This [[RunloopAccess]] is here to make the [[Runloop]] instantiation/boot lazy: we only starts it when the user is
  * starting a consuming session.
  *
- * <<<<<<< HEAD This is needed because a Consumer can be used to do something else than consuming (e.g. fetching Kafka
- * topics metadata)
+ * This is needed because a Consumer can be used to do something else than consuming (e.g. fetching Kafka topics
+ * metadata)
  */
 private[consumer] final class RunloopAccess private (
   runloopStateRef: Ref.Synchronized[RunloopState],

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -7,7 +7,7 @@ import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
 import zio.kafka.consumer.{ ConsumerSettings, Subscription }
 import zio.stream.{ Stream, Take, UStream, ZStream }
-import zio.{ durationInt, Hub, RIO, Ref, Scope, Task, UIO, ZIO, ZLayer }
+import zio.{ durationInt, Hub, Ref, Scope, UIO, ZIO, ZLayer }
 
 private[internal] sealed trait RunloopState
 private[internal] object RunloopState {
@@ -37,23 +37,22 @@ private[internal] object RunloopState {
 private[consumer] final class RunloopAccess private (
   runloopStateRef: Ref.Synchronized[RunloopState],
   partitionHub: Hub[Take[Throwable, PartitionAssignment]],
-  makeRunloop: Task[RunloopState.Started],
+  makeRunloop: UIO[RunloopState.Started],
   diagnostics: Diagnostics
 ) {
-  private def runloop(shouldStartIfNot: Boolean): Task[RunloopState] =
+  private def runloop(shouldStartIfNot: Boolean): UIO[RunloopState] =
     runloopStateRef.updateSomeAndGetZIO { case RunloopState.NotStarted if shouldStartIfNot => makeRunloop }
-  private def withRunloopZIO[R, A](shouldStartIfNot: Boolean)(f: Runloop => RIO[R, A]): RIO[R, A] =
+  private def withRunloopZIO[A](shouldStartIfNot: Boolean)(f: Runloop => UIO[A]): UIO[A] =
     runloop(shouldStartIfNot).flatMap {
-      case RunloopState.NotStarted       => ZIO.unit.asInstanceOf[RIO[R, A]]
+      case RunloopState.Stopped          => ZIO.unit.asInstanceOf[UIO[A]]
+      case RunloopState.NotStarted       => ZIO.unit.asInstanceOf[UIO[A]]
       case RunloopState.Started(runloop) => f(runloop)
-      case RunloopState.Stopped          => ZIO.unit.asInstanceOf[RIO[R, A]]
     }
 
   /**
    * No need to call `Runloop::stopConsumption` if the Runloop has not been started or has been stopped.
    *
    * Note:
-   *   1. The `.orDie` is just here for compilation. It cannot happen.
    *   1. We do a 100 retries waiting 10ms between each to roughly take max 1s before to stop to retry. We want to avoid
    *      an infinite loop. We need this recursion because if the user calls `stopConsumption` before the Runloop is
    *      started, we need to wait for it to be started. Can happen if the user starts a consuming session in a forked
@@ -63,7 +62,7 @@ private[consumer] final class RunloopAccess private (
   def stopConsumption(retry: Int = 100, initialCall: Boolean = true): UIO[Unit] = {
     @inline def next: UIO[Unit] = stopConsumption(retry - 1, initialCall = false)
 
-    runloop(shouldStartIfNot = false).orDie.flatMap {
+    runloop(shouldStartIfNot = false).flatMap {
       case RunloopState.Stopped          => ZIO.unit
       case RunloopState.Started(runloop) => runloop.stopConsumption
       case RunloopState.NotStarted =>
@@ -87,7 +86,7 @@ private[consumer] final class RunloopAccess private (
       // starts the Runloop if not already started
       _ <- withRunloopZIO(shouldStartIfNot = true)(_.addSubscription(subscription))
       _ <- ZIO.addFinalizer {
-             withRunloopZIO(shouldStartIfNot = false)(_.removeSubscription(subscription)).orDie <*
+             withRunloopZIO(shouldStartIfNot = false)(_.removeSubscription(subscription)) <*
                diagnostics.emit(Finalization.SubscriptionFinalized)
            }
     } yield stream

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -20,19 +20,8 @@ private[internal] object RunloopState {
  * This [[RunloopAccess]] is here to make the [[Runloop]] instantiation/boot lazy: we only starts it when the user is
  * starting a consuming session.
  *
- * This is needed because of 2 things:
- *
- *   1. A Consumer can be used to do something else than consuming (e.g. fetching Kafka topics metadata)
- *   1. The [[Runloop]] has a timeout which is reached if no commands are processed for a certain amount of time. If the
- *      Runloop is started eagerly (when we instantiate a Consumer), then the timeout will be reached even if the user
- *      is still using the Consumer.
- *
- * Additional note for the future:
- *
- * This is less an issue now that we have removed the `RunloopTimeout` exception. It might be possible to remove this
- * `RunloopAccess` and start the `Runloop` eagerly. Reaching the timeout if the user does not consumer. Rebooting a new
- * `Runloop` if the user decides to finally consume with its `Consumer`. Tho, I don't know the
- * implication/complexity/feasibility of this change and it's not what I'm trying to achieve/fix here.
+ * This is needed because a Consumer can be used to do something else than consuming (e.g. fetching Kafka topics
+ * metadata)
  */
 private[consumer] final class RunloopAccess private (
   runloopStateRef: Ref.Synchronized[RunloopState],

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -1,0 +1,130 @@
+package zio.kafka.consumer.internal
+
+import org.apache.kafka.common.TopicPartition
+import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization
+import zio.kafka.consumer.diagnostics.Diagnostics
+import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
+import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
+import zio.kafka.consumer.{ ConsumerSettings, Subscription }
+import zio.stream.{ Stream, Take, UStream, ZStream }
+import zio.{ durationInt, Hub, RIO, Ref, Scope, Task, UIO, ZIO, ZLayer }
+
+private[internal] sealed trait RunloopState
+private[internal] object RunloopState {
+  case object NotStarted                     extends RunloopState
+  final case class Started(runloop: Runloop) extends RunloopState
+  case object Stopped                        extends RunloopState
+}
+
+/**
+ * This [[RunloopAccess]] is here to make the [[Runloop]] instantiation/boot lazy: we only starts it when the user is
+ * starting a consuming session.
+ *
+ * This is needed because of 2 things:
+ *
+ *   1. A Consumer can be used to do something else than consuming (e.g. fetching Kafka topics metadata)
+ *   1. The [[Runloop]] has a timeout which is reached if no commands are processed for a certain amount of time. If the
+ *      Runloop is started eagerly (when we instantiate a Consumer), then the timeout will be reached even if the user
+ *      is still using the Consumer.
+ *
+ * Additional note for the future:
+ *
+ * This is less an issue now that we have removed the `RunloopTimeout` exception. It might be possible to remove this
+ * `RunloopAccess` and start the `Runloop` eagerly. Reaching the timeout if the user does not consumer. Rebooting a new
+ * `Runloop` if the user decides to finally consume with its `Consumer`. Tho, I don't know the
+ * implication/complexity/feasibility of this change and it's not what I'm trying to achieve/fix here.
+ */
+private[consumer] final class RunloopAccess private (
+  runloopStateRef: Ref.Synchronized[RunloopState],
+  partitionHub: Hub[Take[Throwable, PartitionAssignment]],
+  makeRunloop: Task[RunloopState.Started],
+  diagnostics: Diagnostics
+) {
+  private def runloop(shouldStartIfNot: Boolean): Task[RunloopState] =
+    runloopStateRef.updateSomeAndGetZIO { case RunloopState.NotStarted if shouldStartIfNot => makeRunloop }
+  private def withRunloopZIO[R, A](shouldStartIfNot: Boolean)(f: Runloop => RIO[R, A]): RIO[R, A] =
+    runloop(shouldStartIfNot).flatMap {
+      case RunloopState.NotStarted       => ZIO.unit.asInstanceOf[RIO[R, A]]
+      case RunloopState.Started(runloop) => f(runloop)
+      case RunloopState.Stopped          => ZIO.unit.asInstanceOf[RIO[R, A]]
+    }
+
+  /**
+   * No need to call `Runloop::stopConsumption` if the Runloop has not been started or has been stopped.
+   *
+   * Note:
+   *   1. The `.orDie` is just here for compilation. It cannot happen.
+   *   1. We do a 100 retries waiting 10ms between each to roughly take max 1s before to stop to retry. We want to avoid
+   *      an infinite loop. We need this recursion because if the user calls `stopConsumption` before the Runloop is
+   *      started, we need to wait for it to be started. Can happen if the user starts a consuming session in a forked
+   *      fiber and immediately after forking, stops it. The Runloop will potentially not be started yet.
+   */
+  // noinspection SimplifyUnlessInspection
+  def stopConsumption(retry: Int = 100, initialCall: Boolean = true): UIO[Unit] = {
+    @inline def next: UIO[Unit] = stopConsumption(retry - 1, initialCall = false)
+
+    runloop(shouldStartIfNot = false).orDie.flatMap {
+      case RunloopState.Stopped          => ZIO.unit
+      case RunloopState.Started(runloop) => runloop.stopConsumption
+      case RunloopState.NotStarted =>
+        if (retry <= 0) ZIO.unit
+        else if (initialCall) next
+        else next.delay(10.millis)
+    }
+  }
+
+  /**
+   * We're doing all of these things in this method so that the interface of this class is as simple as possible and
+   * there's no mistake possible for the caller.
+   *
+   * The external world (Consumer) doesn't need to know how we "subscribe", "unsubscribe", etc. internally.
+   */
+  def subscribe(
+    subscription: Subscription
+  ): ZIO[Scope, Throwable, UStream[Take[Throwable, PartitionAssignment]]] =
+    for {
+      stream <- ZStream.fromHubScoped(partitionHub)
+      // starts the Runloop if not already started
+      _ <- withRunloopZIO(shouldStartIfNot = true)(_.addSubscription(subscription))
+      _ <- ZIO.addFinalizer {
+             withRunloopZIO(shouldStartIfNot = false)(_.removeSubscription(subscription)).orDie <*
+               diagnostics.emit(Finalization.SubscriptionFinalized)
+           }
+    } yield stream
+
+}
+
+private[consumer] object RunloopAccess {
+  type PartitionAssignment = (TopicPartition, Stream[Throwable, ByteArrayCommittableRecord])
+
+  def make(
+    settings: ConsumerSettings,
+    diagnostics: Diagnostics = Diagnostics.NoOp,
+    consumerAccess: ConsumerAccess,
+    consumerSettings: ConsumerSettings
+  ): ZIO[Scope, Throwable, RunloopAccess] =
+    for {
+      // This scope allows us to link the lifecycle of the Runloop and of the Hub to the lifecycle of the Consumer
+      // When the Consumer is shutdown, the Runloop and the Hub will be shutdown too (before the consumer)
+      consumerScope <- ZIO.scope
+      partitionsHub <- ZIO
+                         .acquireRelease(Hub.unbounded[Take[Throwable, PartitionAssignment]])(_.shutdown)
+                         .provide(ZLayer.succeed(consumerScope))
+      runloopStateRef <- Ref.Synchronized.make[RunloopState](RunloopState.NotStarted)
+      makeRunloop = Runloop
+                      .make(
+                        hasGroupId = settings.hasGroupId,
+                        consumer = consumerAccess,
+                        pollTimeout = settings.pollTimeout,
+                        diagnostics = diagnostics,
+                        offsetRetrieval = settings.offsetRetrieval,
+                        userRebalanceListener = settings.rebalanceListener,
+                        restartStreamsOnRebalancing = settings.restartStreamOnRebalancing,
+                        partitionsHub = partitionsHub,
+                        consumerSettings = consumerSettings
+                      )
+                      .withFinalizer(_ => runloopStateRef.set(RunloopState.Stopped))
+                      .map(RunloopState.Started.apply)
+                      .provide(ZLayer.succeed(consumerScope))
+    } yield new RunloopAccess(runloopStateRef, partitionsHub, makeRunloop, diagnostics)
+}

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -20,8 +20,8 @@ private[internal] object RunloopState {
  * This [[RunloopAccess]] is here to make the [[Runloop]] instantiation/boot lazy: we only starts it when the user is
  * starting a consuming session.
  *
- * This is needed because a Consumer can be used to do something else than consuming (e.g. fetching Kafka topics
- * metadata)
+ * <<<<<<< HEAD This is needed because a Consumer can be used to do something else than consuming (e.g. fetching Kafka
+ * topics metadata)
  */
 private[consumer] final class RunloopAccess private (
   runloopStateRef: Ref.Synchronized[RunloopState],

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
@@ -29,5 +29,5 @@ object RunloopCommand {
 
   final case class AddSubscription(subscription: Subscription)    extends StreamCommand
   final case class RemoveSubscription(subscription: Subscription) extends StreamCommand
-  case object StopSubscription                                    extends StreamCommand
+  case object RemoveAllSubscriptions                              extends StreamCommand
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
@@ -20,20 +20,14 @@ object RunloopCommand {
   case object StopAllStreams extends StreamCommand
 
   final case class Commit(offsets: Map[TopicPartition, Long], cont: Promise[Throwable, Unit]) extends StreamCommand {
-    @inline def isDone: UIO[Boolean] = cont.isDone
-
+    @inline def isDone: UIO[Boolean]    = cont.isDone
     @inline def isPending: UIO[Boolean] = isDone.negate
   }
 
   /** Used by a stream to request more records. */
   final case class Request(tp: TopicPartition) extends StreamCommand
 
-  final case class ChangeSubscription(
-    subscription: Option[Subscription],
-    cont: Promise[Throwable, Unit]
-  ) extends StreamCommand {
-    @inline def succeed: UIO[Boolean] = cont.succeed(())
-
-    @inline def fail(throwable: Throwable): UIO[Boolean] = cont.fail(throwable)
-  }
+  final case class AddSubscription(subscription: Subscription)    extends StreamCommand
+  final case class RemoveSubscription(subscription: Subscription) extends StreamCommand
+  case object StopSubscription                                    extends StreamCommand
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopExecutor.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopExecutor.scala
@@ -1,6 +1,6 @@
 package zio.kafka.consumer.internal
 
-import zio.{ Executor, Scope, ZIO }
+import zio.{ Executor, Scope, URIO, ZIO }
 
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
@@ -9,9 +9,9 @@ private[consumer] object RunloopExecutor {
 
   private val counter: AtomicLong = new AtomicLong(0)
 
-  private val newSingleThreadedExecutor: ZIO[Scope, Throwable, Executor] =
+  private val newSingleThreadedExecutor: URIO[Scope, Executor] =
     ZIO.acquireRelease {
-      ZIO.attempt {
+      ZIO.succeed {
         val javaExecutor =
           Executors.newSingleThreadExecutor { runnable =>
             new Thread(runnable, s"zio-kafka-runloop-thread-${counter.getAndIncrement()}")
@@ -21,6 +21,6 @@ private[consumer] object RunloopExecutor {
       }
     } { case (_, executor) => ZIO.attempt(executor.shutdown()).orDie }.map(_._1)
 
-  val newInstance: ZIO[Scope, Throwable, Executor] = newSingleThreadedExecutor
+  val newInstance: URIO[Scope, Executor] = newSingleThreadedExecutor
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/SubscriptionState.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/SubscriptionState.scala
@@ -1,0 +1,15 @@
+package zio.kafka.consumer.internal
+
+import zio.kafka.consumer.Subscription
+
+private[internal] sealed trait SubscriptionState {
+  def isSubscribed: Boolean =
+    this match {
+      case _: SubscriptionState.Subscribed => true
+      case SubscriptionState.NotSubscribed => false
+    }
+}
+private[internal] object SubscriptionState {
+  case object NotSubscribed                                                          extends SubscriptionState
+  final case class Subscribed(subscriptions: Set[Subscription], union: Subscription) extends SubscriptionState
+}


### PR DESCRIPTION
To try to run a benchmark, in an sbt console:
```bash
clean;Test/compile;zioKafkaBench/Jmh/run -wi 20 -i 10 -r 1 -w 1 -t 1 -f 1 -foe true -prof zio.profiling.jmh.JmhZioProfiler .*ConsumersComparisonBenchmark.manualZioKafka*
```

For now, it's failing with the following error:
```scala
[info] # Warmup Iteration   1: 19:05:35.308 [zio-default-blocking-1] WARN  k.server.BrokerMetadataCheckpoint - No meta.properties file under dir /var/folders/5r/0tttbjvx405d9c4pg69m6swh0000gn/T/kafka-logs4001693473086757478/meta.properties
[info] Error in benchmark run: Exception in thread "zio-fiber-19,18" java.lang.NullPointerException: Cannot invoke "zio.ZIO.ensuring(scala.Function0, Object)" because "zio$3" is null
[info] 	at zio.FiberRef$unsafe$$anon$2.$anonfun$locally$5(FiberRef.scala:472)
[info] 	at zio.kafka.consumer.internal.RunloopAccess.runloop(RunloopAccess.scala:44)
[info] 	at zio.kafka.consumer.internal.RunloopAccess.withRunloopZIO(RunloopAccess.scala:46)
[info] 	at zio.kafka.consumer.internal.RunloopAccess.subscribe(RunloopAccess.scala:88)
[info] 	at zio.kafka.consumer.Consumer.Live.partitionedAssignmentStream(Consumer.scala:224)
[info] 	at zio.kafka.consumer.Consumer.Live.partitionedAssignmentStream(Consumer.scala:222)
[info] 	at zio.kafka.consumer.Consumer.Live.plainStream(Consumer.scala:270)
[info] 	at zio.kafka.consumer.Consumer.Live.plainStream(Consumer.scala:270)
[info] 	at zio.kafka.bench.ConsumersComparisonBenchmark.manualZioKafka(ConsumersComparisonBenchmark.scala:147)
[info] <failure>
[info] java.lang.NullPointerException: Cannot invoke "zio.ZIO.ensuring(scala.Function0, Object)" because "zio$3" is null
[info] 	at zio.FiberRef$unsafe$$anon$2.$anonfun$locally$5(FiberRef.scala:472)
[info] 	at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
[info] 	at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:890)
[info] 	at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:890)
[info] 	at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1024)
...
```