### PR TITLE
Micro-optimisation for manual consumption mode: Use only 1 IO to execute all the `c.seek` calls in `doSeekForNewPartitions`

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -235,7 +235,7 @@ private[consumer] final class Runloop private (
         if (tps.isEmpty) ZIO.succeed(Set.empty)
         else
           getOffsets(tps)
-            .tap(offsets => ZIO.foreachDiscard(offsets) { case (tp, offset) => ZIO.attempt(c.seek(tp, offset)) })
+            .flatMap(offsets => ZIO.attempt(offsets.foreach { case (tp, offset) => c.seek(tp, offset) }))
             .as(tps)
     }
 


### PR DESCRIPTION
Inspired by the `handlePoll` code