### PR TITLE
[DX] Fix `ConsumerSettings` interface

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -28,9 +28,9 @@ import zio.kafka.security.KafkaCredentialStore
  */
 final case class ConsumerSettings(
   bootstrapServers: List[String],
-  properties: Map[String, AnyRef],
-  closeTimeout: Duration,
-  pollTimeout: Duration,
+  properties: Map[String, AnyRef] = Map.empty,
+  closeTimeout: Duration = 30.seconds,
+  pollTimeout: Duration = 50.millis,
   offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
   rebalanceListener: RebalanceListener = RebalanceListener.noop,
   restartStreamOnRebalancing: Boolean = false,
@@ -96,14 +96,4 @@ final case class ConsumerSettings(
 
 object ConsumerSettings {
   val defaultRunloopTimeout: Duration = 4.minutes
-
-  def apply(bootstrapServers: List[String]): ConsumerSettings =
-    new ConsumerSettings(
-      bootstrapServers = bootstrapServers,
-      properties = Map.empty,
-      closeTimeout = 30.seconds,
-      pollTimeout = 50.millis,
-      offsetRetrieval = OffsetRetrieval.Auto(),
-      runloopTimeout = defaultRunloopTimeout
-    )
 }


### PR DESCRIPTION
Today, if you want to set `enableOptimisticResume` and pass only the `bootstrapServers`, you can't. You have to write:
```scala
val settings = ConsumerSettings(
  bootstrapServers = ...,
  properties = Map.empty,
  closeTimeout = 30.seconds,
  pollTimeout = 50.millis,
  enableOptimisticResume = true
)
```

With this fix, you can just write:
```scala
val settings = ConsumerSettings(
  bootstrapServers = ...,
  enableOptimisticResume = true
)
```