### PR TITLE
Prevent runaway feedback loop in optimistic resume

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -245,9 +245,10 @@ private[consumer] final class Runloop private (
     val resumeTps = new java.util.ArrayList[TopicPartition](streams.size)
     val pauseTps  = new java.util.ArrayList[TopicPartition](streams.size)
     streams.foreach { stream =>
-      val tp = stream.tp
-      val toResume =
-        requestedPartitions.contains(tp) || (consumerSettings.enableOptimisticResume && stream.optimisticResume)
+      val tp              = stream.tp
+      val requestedResume = requestedPartitions.contains(tp)
+      if (consumerSettings.enableOptimisticResume) stream.addPollHistory(requestedResume)
+      val toResume = requestedResume || (consumerSettings.enableOptimisticResume && stream.optimisticResume)
       if (toResume) resumeTps.add(tp) else pauseTps.add(tp)
       if (consumerSettings.enableOptimisticResume) {
         stream.addPollHistory(toResume)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -247,12 +247,11 @@ private[consumer] final class Runloop private (
     streams.foreach { stream =>
       val tp              = stream.tp
       val requestedResume = requestedPartitions.contains(tp)
-      if (consumerSettings.enableOptimisticResume) stream.addPollHistory(requestedResume)
+      if (consumerSettings.enableOptimisticResume) {
+        stream.addPollHistory(requestedResume)
+      }
       val toResume = requestedResume || (consumerSettings.enableOptimisticResume && stream.optimisticResume)
       if (toResume) resumeTps.add(tp) else pauseTps.add(tp)
-      if (consumerSettings.enableOptimisticResume) {
-        stream.addPollHistory(toResume)
-      }
     }
     if (!resumeTps.isEmpty) c.resume(resumeTps)
     if (!pauseTps.isEmpty) c.pause(pauseTps)


### PR DESCRIPTION
At the cost of some performance, we are no longer including the predicted resumes in the poll history. This prevents runaway feedback loops which prevent out of memory problems.
