### PR TITLE
Pre-fetch per consumer, not per stream

### DIFF
--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ZioKafkaNoPrefetchingBenchmarks.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ZioKafkaNoPrefetchingBenchmarks.scala
@@ -11,10 +11,10 @@ import java.util.concurrent.TimeUnit
 
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-class ZioKafkaNoOptimisticResumeBenchmarks extends ComparisonBenchmark {
+class ZioKafkaNoPrefetchingBenchmarks extends ComparisonBenchmark {
 
   override protected def settings: ZLayer[Kafka, Nothing, ConsumerSettings] =
-    super.settings.map(env => ZEnvironment(env.get.copy(enableOptimisticResume = false)))
+    super.settings.map(env => ZEnvironment(env.get.copy(maxPrefetchPolls = 0)))
 
   @Benchmark
   @BenchmarkMode(Array(Mode.AverageTime))

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/PollHistorySpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/PollHistorySpec.scala
@@ -12,12 +12,12 @@ object PollHistorySpec extends ZIOSpecDefaultSlf4j {
         (("001" * 22) + "").toPollHistory.estimatedPollCountToResume == 3,
         (("001" * 22) + "0").toPollHistory.estimatedPollCountToResume == 2,
         (("001" * 22) + "00").toPollHistory.estimatedPollCountToResume == 1,
-        (("00001" * 13) + "").toPollHistory.estimatedPollCountToResume == 5,
+        (("00001" * 13) + "").toPollHistory.estimatedPollCountToResume == 5
       )
     },
     test("estimates poll count for somewhat irregular pattern") {
       assertTrue(
-        "000101001001100001000011001001001".toPollHistory.estimatedPollCountToResume == 3,
+        "000101001001100001000011001001001".toPollHistory.estimatedPollCountToResume == 3
       )
     },
     test("estimates poll count only when paused for less than 16 polls") {
@@ -25,7 +25,7 @@ object PollHistorySpec extends ZIOSpecDefaultSlf4j {
         "0".toPollHistory.estimatedPollCountToResume == 64,
         "10000000000000000000000000000000".toPollHistory.estimatedPollCountToResume == 64,
         ("11" * 8 + "00" * 8).toPollHistory.estimatedPollCountToResume == 64,
-        ("11" * 9 + "00" * 7).toPollHistory.estimatedPollCountToResume == 0,
+        ("11" * 9 + "00" * 7).toPollHistory.estimatedPollCountToResume == 0
       )
     },
     test("estimates poll count for edge cases") {
@@ -34,7 +34,7 @@ object PollHistorySpec extends ZIOSpecDefaultSlf4j {
         "10000000000000001000000000000000".toPollHistory.estimatedPollCountToResume == 1,
         "01000000000000000100000000000000".toPollHistory.estimatedPollCountToResume == 2,
         "00100000000000000010000000000000".toPollHistory.estimatedPollCountToResume == 3,
-        "00010000000000000001000000000000".toPollHistory.estimatedPollCountToResume == 4,
+        "00010000000000000001000000000000".toPollHistory.estimatedPollCountToResume == 4
       )
     },
     test("add to history") {

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/PollHistorySpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/PollHistorySpec.scala
@@ -7,11 +7,35 @@ import zio.test._
 
 object PollHistorySpec extends ZIOSpecDefaultSlf4j {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("PollHistorySpec")(
-    test("optimisticResume for listed pattern") {
-      assertTrue("011111".toPollHistory.optimisticResume)
+    test("estimates poll count for very regular pattern") {
+      assertTrue(
+        (("001" * 22) + "").toPollHistory.estimatedPollCountToResume == 3,
+        (("001" * 22) + "0").toPollHistory.estimatedPollCountToResume == 2,
+        (("001" * 22) + "00").toPollHistory.estimatedPollCountToResume == 1,
+        (("00001" * 13) + "").toPollHistory.estimatedPollCountToResume == 5,
+      )
     },
-    test("optimisticResume for unknown pattern") {
-      assertTrue(!"0111111".toPollHistory.optimisticResume)
+    test("estimates poll count for somewhat irregular pattern") {
+      assertTrue(
+        "000101001001100001000011001001001".toPollHistory.estimatedPollCountToResume == 3,
+      )
+    },
+    test("estimates poll count only when paused for less than 16 polls") {
+      assertTrue(
+        "0".toPollHistory.estimatedPollCountToResume == 64,
+        "10000000000000000000000000000000".toPollHistory.estimatedPollCountToResume == 64,
+        ("11" * 8 + "00" * 8).toPollHistory.estimatedPollCountToResume == 64,
+        ("11" * 9 + "00" * 7).toPollHistory.estimatedPollCountToResume == 0,
+      )
+    },
+    test("estimates poll count for edge cases") {
+      assertTrue(
+        "11111111111111111111111111111111".toPollHistory.estimatedPollCountToResume == 1,
+        "10000000000000001000000000000000".toPollHistory.estimatedPollCountToResume == 1,
+        "01000000000000000100000000000000".toPollHistory.estimatedPollCountToResume == 2,
+        "00100000000000000010000000000000".toPollHistory.estimatedPollCountToResume == 3,
+        "00010000000000000001000000000000".toPollHistory.estimatedPollCountToResume == 4,
+      )
     },
     test("add to history") {
       assertTrue(

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -20,11 +20,11 @@ import zio.kafka.security.KafkaCredentialStore
  *   be much larger than the pollTimeout and the time it takes to process chunks of records. If your consumer is not
  *   subscribed for long periods during its lifetime, this timeout should take that into account as well. When the
  *   timeout expires, the plainStream/partitionedStream/etc will fail with a [[Consumer.RunloopTimeout]].
- * @param enableOptimisticResume
- *   When `true` (the default) zio-kafka predicts whether a stream needs more data, slightly ahead of time. Zio-kafka
- *   pauses partitions for which the associated stream is processing previously fetched data. When the stream needs more
- *   data, the partition is resumed. With this feature enabled, partitions are also resumed when it is likely that the
- *   stream needs more data in the next poll.
+ * @param maxPrefetchPolls
+ *   The consumer continually polls the broker as long as there is demand. There is some room to poll more data even
+ *   when there isn't demand. This allow prefetching of records. This prefetching is controlled by the
+ *   `maxPrefetchPolls` setting. Polls will only be done as long as processing is fast enough, so that less than
+ *   `maxPrefetchPolls` polls are prefetched. Defaults to `2`.
  */
 final case class ConsumerSettings(
   bootstrapServers: List[String],
@@ -35,7 +35,7 @@ final case class ConsumerSettings(
   rebalanceListener: RebalanceListener = RebalanceListener.noop,
   restartStreamOnRebalancing: Boolean = false,
   runloopTimeout: Duration = ConsumerSettings.defaultRunloopTimeout,
-  enableOptimisticResume: Boolean = true
+  maxPrefetchPolls: Int = 2
 ) {
   private[this] def autoOffsetResetConfig: Map[String, String] = offsetRetrieval match {
     case OffsetRetrieval.Auto(reset) => Map(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> reset.toConfig)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -47,7 +47,7 @@ private[internal] final class PartitionStreamControl private (
   val tpStream: (TopicPartition, ZStream[Any, Throwable, ByteArrayCommittableRecord]) =
     (tp, stream)
 
-  def optimisticResume: Boolean = pollResumedHistory.optimisticResume
+  def optimisticResume: Boolean = pollResumedHistory.estimatedPollCountToResume < 2
 
   /**
    * Add a poll event to the poll history.

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -47,7 +47,7 @@ private[internal] final class PartitionStreamControl private (
   val tpStream: (TopicPartition, ZStream[Any, Throwable, ByteArrayCommittableRecord]) =
     (tp, stream)
 
-  def optimisticResume: Boolean = pollResumedHistory.estimatedPollCountToResume < 2
+  def estimatedPollCountToResume: Int = pollResumedHistory.estimatedPollCountToResume
 
   /**
    * Add a poll event to the poll history.

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PollHistory.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PollHistory.scala
@@ -1,19 +1,21 @@
 package zio.kafka.consumer.internal
 
-import zio.Chunk
+import java.lang.{Long => JavaLong}
 
 /**
  * Keep track of a partition status ('resumed' or 'paused') history as it is just before a poll.
  *
- * The goal is to predict when the partition is likely to be resumed in the next poll.
+ * The goal is to predict in how many polls the partition will be resumed.
  */
 private[internal] sealed trait PollHistory {
 
   /**
    * @return
-   *   true when -based on the poll history- the partition is likely to be resumed in the next poll
+   *   the estimated number of polls before the partition is resumed (a positive number).
+   *   The result should not be interpreted as an absolute number of polls, but rather as an estimate
+   *   relative to other estimates.
    */
-  def optimisticResume: Boolean
+  def estimatedPollCountToResume: Int
 
   /**
    * Creates a new poll history by appending the given partition status as the latest poll. The history length might be
@@ -28,93 +30,45 @@ private[internal] sealed trait PollHistory {
 private[internal] object PollHistory {
 
   /**
-   * Patterns that, when they match the end of a poll history, indicate that the partition is likely to be resumed in
-   * the next poll.
-   *
-   * Each pattern is given as a bit string where each character is either a '1': the partition was resumed or '0': the
-   * partition was paused. The oldest poll comes first and the newest last.
-   *
-   * '''Run-away feedback loop'''
-   *
-   * If a pattern matches, the partition will be resumed (causing a `1` to be added to the poll history). If in the next
-   * poll, again a pattern matches, the partition will be resumed again, causing a run-away feedback loop of repeated
-   * resumes while the stream might not need more data at all. (We do not make a distinction between resumes because of
-   * a request for data, or because of an optimistic resume.)
-   *
-   * For example, the very short pattern `1` causes a run-away feedback loop immediately after the first resume. For the
-   * same reason, if pattern `p` is included, `p1` may _not_ be included. (For example, if pattern `101` is included,
-   * pattern `1011` may not be included.)
-   *
-   * '''How these patterns were found'''
-   *
-   * The patterns were found by iterating over all possible (short) patterns and selecting those that are likely to lead
-   * to a resume. Iteration is done by the number of recent resumes or pauses. So first we list all patterns that end
-   * with 5 resumes, then all patterns that end with 4 resumes, etc. Then we list all patterns that end with 1 pause,
-   * with 2 pauses, etc.
-   *
-   * For example, lets look at all patterns that end with 2 resumes, so patterns that end with `011`. Just 2 resumes is
-   * not a strong signal that the partition is likely to be resumed in the next poll. Therefore, we require that a least
-   * 2 more resumes happened shortly before. (Note that this is a choice based on intuition. More research is needed to
-   * select optimal requirements.) We do this by extending the pattern to the left. The patterns with at least 2 resumes
-   * in 3 polls are: `11`, `101` and `110` (note: `11` matches both `011` and `111`). Prepending this to `011` gives the
-   * patterns `11011`, `101011` and `110011`. An arbitrary choice was made to omit patterns with 2 consecutive pauses.
-   *
-   * Some patterns are not allowed because we want to prevent a run-away feedback loop. For example, because we list
-   * pattern `0111`, pattern `01111` is not allowed. So instead of `01111` we include `11101111`.
-   *
-   * '''Mask and bit pattern'''
-   *
-   * The patterns are converted into pairs containing a mask and a bit pattern. The mask selects the history bits that
-   * need to match the bit pattern.
-   */
-  private val OptimisticResumePollPatterns: Chunk[(Int, Int)] =
-    Chunk(
-      // Patterns ending with 5 resumes
-      "011111",
-      // Patterns ending with 4 resumes (require 3 preceding resumes to prevent run-away feedback loop)
-      "11101111",
-      // Patterns ending with 3 resumes
-      "0111",
-      // Patterns ending with 2 resumes (require 2 resumes in 3 polls preceding)
-      "11011",
-      "101011",
-      // Patterns ending with 1 resume (require 3 resumes in 4 polls preceding)
-      "11101",
-      "101101",
-      "110101",
-      // Patterns ending with 1 pause (require 2 resumes in 3 polls preceding)
-      "110",
-      "1010",
-      // Patterns ending with 2 pauses (require 3 resumes in 5 polls preceding)
-      "11100",
-      "101100",
-      "110100",
-      "1001100",
-      "1010100",
-      "1100100"
-    ).map { pattern =>
-      val bitPattern = Integer.parseUnsignedInt(pattern, 2)
-      val mask       = (1 << pattern.length) - 1
-      assert(
-        mask != bitPattern,
-        "A pattern of all 1s causes a runaway feedback loop, effectively disabling partition pausing"
-      )
-      (mask, bitPattern)
-    }
-
-  /**
-   * An implementation of [[PollHistory]] that stores the poll statuses as bits in an unsigned [[Int]].
+   * An implementation of [[PollHistory]] that stores the poll statuses as bits in an unsigned [[Long]].
    *
    * Bit value 1 indicates that the partition was resumed and value 0 indicates it was paused. The most recent poll is
    * in the least significant bit, the oldest poll is in the most significant bit.
    */
   private[internal] final class PollHistoryImpl private[PollHistory] (
-    /* exposed only for tests */ private[internal] val resumeBits: Int
+    /* exposed only for tests */ private[internal] val resumeBits: Long
   ) extends PollHistory {
-    override val optimisticResume: Boolean =
-      OptimisticResumePollPatterns.exists { case (mask, pattern) =>
-        (resumeBits & mask) == pattern
+    override def estimatedPollCountToResume: Int = {
+      // Let's assume 8 bit history.
+      // Full history is "00100100"
+      // We are currently paused for 2 polls (last "00")
+      // The 'before history' contains 2 polls (in "001001", 6 bits long)
+      // So the average resume cycle is 6 / 2 = 3 polls.
+      // Wait time before next resume is 3 - 2 = 1 poll.
+
+      // Now consider the pattern "0100010001000100" (16 bit history).
+      // It is very regular but the estimate will be off because the oldest cycle
+      // (at beginning of the bitstring) is not complete.
+      // We compensate by removing the first cycle from the 'before' history.
+      // This also helps predicting when the stream only just started.
+
+      // When no resumes have been observed yet in 'before history', we return the maximum estimate (32).
+
+      // When the 'before history' is too short, we can not make a prediction.
+      // We require that 'before history' is at least 16 polls long.
+
+      val currentPausedCount = JavaLong.numberOfTrailingZeros(resumeBits)
+      val firstPollCycleLength = JavaLong.numberOfLeadingZeros(resumeBits) + 1
+      val beforeHistory = resumeBits >>> currentPausedCount
+      val resumeCount = JavaLong.bitCount(beforeHistory) - 1
+      val beforeHistoryLength = JavaLong.SIZE - firstPollCycleLength - currentPausedCount
+      if (resumeCount == 0 || beforeHistoryLength < 16) {
+        JavaLong.SIZE
+      } else {
+        val averageResumeCycleLength = Math.round(beforeHistoryLength / resumeCount.toDouble).toInt
+        Math.max(0, averageResumeCycleLength - currentPausedCount)
       }
+    }
 
     override def addPollHistory(resumed: Boolean): PollHistory =
       new PollHistoryImpl(resumeBits << 1 | (if (resumed) 1 else 0))


### PR DESCRIPTION
Resume some partitions when there is no other demand, limited by the maxPrefetchPolls setting.

We select partitions based on the estimate number of polls to the next resume. This algorithm is much faster and more accurate than the previous bit-pattern based algorithm.

The advantages of pre-fetching per consumer are:
 - No more OOM; only a fixed number of polls are pre-fetched so additional memory pressure is very limited.
 - Read-starvation problem is back to pre-2.1 zio-kafka. This is because the pre-fetching only kicks in when no other streams have demand.

Todo before going out of draft:
 - [ ] Check performance.
 - [ ] Move magic values into a constant.
 - [ ] See if we need more unit tests.