### PR TITLE
updating kafka-clients to version 3.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.Def
 
-lazy val kafkaVersion         = "3.4.1"
-lazy val embeddedKafkaVersion = "3.4.1" // Should be the same as kafkaVersion, except for the patch part
+lazy val kafkaVersion         = "3.5.0"
+lazy val embeddedKafkaVersion = "3.5.0" // Should be the same as kafkaVersion, except for the patch part
 
 lazy val kafkaClients          = "org.apache.kafka"           % "kafka-clients"           % kafkaVersion
 lazy val scalaCollectionCompat = "org.scala-lang.modules"    %% "scala-collection-compat" % "2.11.0"


### PR DESCRIPTION
Kafka-clients version 3.5.0 was released a while ago with several fixes and dependency updates.