### PR TITLE
Use less heap by calling offer directly

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -188,9 +188,8 @@ private[consumer] final class Runloop private (
         _ <- ZIO.foreachDiscard(streams) { streamControl =>
                val tp      = streamControl.tp
                val records = polledRecords.records(tp)
-               if (records.isEmpty) {
-                 ZIO.unit
-               } else {
+               if (records.isEmpty) ZIO.unit
+               else {
                  val builder  = ChunkBuilder.make[Record](records.size())
                  val iterator = records.iterator()
                  while (iterator.hasNext) {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -15,6 +15,7 @@ import java.util
 import scala.jdk.CollectionConverters._
 
 //noinspection SimplifyWhenInspection
+//noinspection SimplifyUnlessInspection
 private[consumer] final class Runloop private (
   runtime: Runtime[Any],
   hasGroupId: Boolean,
@@ -184,34 +185,26 @@ private[consumer] final class Runloop private (
     else {
       for {
         consumerGroupMetadata <- getConsumerGroupMetadataIfAny
-        committableRecords = {
-          val acc             = ChunkBuilder.make[(PartitionStreamControl, Chunk[Record])](streams.size)
-          val streamsIterator = streams.iterator
-          while (streamsIterator.hasNext) {
-            val streamControl = streamsIterator.next()
-            val tp            = streamControl.tp
-            val records       = polledRecords.records(tp)
-            if (!records.isEmpty) {
-              val builder  = ChunkBuilder.make[Record](records.size())
-              val iterator = records.iterator()
-              while (iterator.hasNext) {
-                val consumerRecord = iterator.next()
-                builder +=
-                  CommittableRecord[Array[Byte], Array[Byte]](
-                    record = consumerRecord,
-                    commitHandle = commit,
-                    consumerGroupMetadata = consumerGroupMetadata
-                  )
-              }
-              acc += (streamControl -> builder.result())
-            }
-          }
-          acc.result()
-        }
-        _ <- ZIO
-               .foreachDiscard(committableRecords) { case (streamControl, records) =>
-                 streamControl.offerRecords(records)
+        _ <- ZIO.foreachDiscard(streams) { streamControl =>
+               val tp      = streamControl.tp
+               val records = polledRecords.records(tp)
+               if (records.isEmpty) {
+                 ZIO.unit
+               } else {
+                 val builder  = ChunkBuilder.make[Record](records.size())
+                 val iterator = records.iterator()
+                 while (iterator.hasNext) {
+                   val consumerRecord = iterator.next()
+                   builder +=
+                     CommittableRecord[Array[Byte], Array[Byte]](
+                       record = consumerRecord,
+                       commitHandle = commit,
+                       consumerGroupMetadata = consumerGroupMetadata
+                     )
+                 }
+                 streamControl.offerRecords(builder.result())
                }
+             }
       } yield fulfillResult
     }
   }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -185,7 +185,7 @@ private[consumer] final class Runloop private (
     else {
       for {
         consumerGroupMetadata <- getConsumerGroupMetadataIfAny
-        _ <- ZIO.foreachDiscard(streams) { streamControl =>
+        _ <- ZIO.foreachParDiscard(streams) { streamControl =>
                val tp      = streamControl.tp
                val records = polledRecords.records(tp)
                if (records.isEmpty) ZIO.unit


### PR DESCRIPTION
Instead of first building a sequence of committable records and then offering those to the streams, we now offer the records directly after they are built. This saves an intermediate data structure while keeping the same number of ZIOs.