### PR TITLE
One line change to break scala 3.3.0

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -46,10 +46,11 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           topic2 <- randomTopic
           group  <- randomGroup
           client <- randomClient
-          key1   = "boo"
-          value1 = "baa"
-          key2   = "baa"
-          value2 = "boo"
+          key1              = "boo"
+          value1            = "baa"
+          key2              = "baa"
+          value2            = "boo"
+          key3: Array[Byte] = null
           chunks = Chunk.fromIterable(
                      List(new ProducerRecord(topic1, key1, value1), new ProducerRecord(topic2, key2, value2))
                    )


### PR DESCRIPTION
This one line change (excluding the formatting changes) breaks the scala compiler with 
```
    Exception in thread "zio-fiber-160" scala.MatchError: (producerspec-client-2ba87fcc-4935-43e5-bbdd-229e48663d24,boo,baa,baa,boo,null,Chunk(ProducerRecord(topic=producerspec-topic-ba3fa3af-4b80-4810-b4c5-9af902046b5d, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=boo, value=baa, timestamp=null),ProducerRecord(topic=producerspec-topic-2b66b954-9f16-4ad1-b337-db37fcb58a30, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=baa, value=boo, timestamp=null))) (of class scala.Tuple7)
    	at zio.kafka.ProducerSpec$.$anonfun$2$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$2(ProducerSpec.scala:79)
    	at zio.kafka.ProducerSpec.spec(ProducerSpec.scala:79)
    	at zio.kafka.ProducerSpec.spec(ProducerSpec.scala:80)
```

Not intended to be merged, I just wanted to capture this bug. Initially discovered while trying to get #879 to compile for scala 3.3.0