### PR TITLE
Add processing timeout at the stream level

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,8 +79,7 @@ def stdSettings(prjName: String) = Seq(
   name              := s"$prjName",
   scalafmtOnCompile := !insideCI.value,
   Compile / compile / scalacOptions ++=
-    optionsOn("2.12")("-Yimports", "java.lang,scala,scala.Predef,scala.collection.compat").value ++
-      optionsOn("2.13")("-Wconf:cat=unused-nowarn:s").value,
+    optionsOn("2.13")("-Wconf:cat=unused-nowarn:s").value,
   scalacOptions -= "-Xlint:infer-any",
   // workaround for bad constant pool issue
   (Compile / doc) := Def.taskDyn {

--- a/build.sbt
+++ b/build.sbt
@@ -79,14 +79,9 @@ def stdSettings(prjName: String) = Seq(
   name              := s"$prjName",
   scalafmtOnCompile := !insideCI.value,
   Compile / compile / scalacOptions ++=
-    optionsOn("2.13")("-Wconf:cat=unused-nowarn:s").value,
+    optionsOn("2.12")("-Yimports", "java.lang,scala,scala.Predef,scala.collection.compat").value ++
+      optionsOn("2.13")("-Wconf:cat=unused-nowarn:s").value,
   scalacOptions -= "-Xlint:infer-any",
-  scalacOptions ++= {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 12)) => List("-Yimports:java.lang,scala,scala.Predef,scala.collection.compat")
-      case _             => List.empty
-    }
-  },
   // workaround for bad constant pool issue
   (Compile / doc) := Def.taskDyn {
     val default = (Compile / doc).taskValue

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,12 @@ def stdSettings(prjName: String) = Seq(
   Compile / compile / scalacOptions ++=
     optionsOn("2.13")("-Wconf:cat=unused-nowarn:s").value,
   scalacOptions -= "-Xlint:infer-any",
-  scalacOptions += "-Wconf:origin=scala.collection.compat.*:s",
+  scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 12)) => List("-Yimports:java.lang,scala,scala.Predef,scala.collection.compat")
+      case _             => List.empty
+    }
+  },
   // workaround for bad constant pool issue
   (Compile / doc) := Def.taskDyn {
     val default = (Compile / doc).taskValue

--- a/build.sbt
+++ b/build.sbt
@@ -80,6 +80,7 @@ def stdSettings(prjName: String) = Seq(
   scalafmtOnCompile := !insideCI.value,
   Compile / compile / scalacOptions ++=
     optionsOn("2.13")("-Wconf:cat=unused-nowarn:s").value,
+  Compile / compile / scalacOptions += "-Wconf:origin=scala.collection.compat.*:s",
   scalacOptions -= "-Xlint:infer-any",
   // workaround for bad constant pool issue
   (Compile / doc) := Def.taskDyn {

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,6 @@ def stdSettings(prjName: String) = Seq(
   scalafmtOnCompile := !insideCI.value,
   Compile / compile / scalacOptions ++=
     optionsOn("2.13")("-Wconf:cat=unused-nowarn:s").value,
-  Compile / compile / scalacOptions += "-Wconf:origin=scala.collection.compat.*:s",
   scalacOptions -= "-Xlint:infer-any",
   // workaround for bad constant pool issue
   (Compile / doc) := Def.taskDyn {

--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,7 @@ def stdSettings(prjName: String) = Seq(
   Compile / compile / scalacOptions ++=
     optionsOn("2.13")("-Wconf:cat=unused-nowarn:s").value,
   scalacOptions -= "-Xlint:infer-any",
+  scalacOptions += "-Wconf:origin=scala.collection.compat.*:s",
   // workaround for bad constant pool issue
   (Compile / doc) := Def.taskDyn {
     val default = (Compile / doc).taskValue

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ComparisonBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ComparisonBenchmark.scala
@@ -11,7 +11,7 @@ import zio.kafka.consumer.{ Consumer, ConsumerSettings }
 import zio.kafka.producer.Producer
 import zio.kafka.testkit.Kafka
 import zio.kafka.testkit.KafkaTestUtils.{ consumerSettings, minimalConsumer, produceMany, producer }
-import zio.{ durationInt, ULayer, ZIO, ZLayer }
+import zio.{ ULayer, ZIO, ZLayer }
 
 import scala.jdk.CollectionConverters._
 
@@ -44,9 +44,7 @@ trait ComparisonBenchmark extends ZioBenchmark[Env] {
       consumerSettings(
         clientId = randomThing("client"),
         groupId = Some(randomThing("client")),
-        `max.poll.records` = 1000, // A more production worthy value
-        // Absurdly high timeout to avoid the runloop from being interrupted while we're benchmarking other stuff
-        runloopTimeout = 1.hour
+        `max.poll.records` = 1000 // A more production worthy value
       ).map(_.withMaxPartitionQueueSize(8192))
     )
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -352,7 +352,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                    .runDrain
                    .forkScoped
             c1Exit        <- c1.join
-            subscriptions <- consumer.subscription
+            subscriptions <- consumer.subscription.delay(10.millis)
           } yield assertTrue(
             c1Exit.isFailure,
             subscriptions.isEmpty

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -336,8 +336,8 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                           properties = Map(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG -> "100")
                         )
             consumer <- Consumer.make(settings.withPollTimeout(50.millis))
-            _        <- scheduledProducer(topic1, Schedule.fixed(10.millis).jittered).runDrain.forkScoped
-            _        <- scheduledProducer(topic2, Schedule.fixed(10.millis).jittered).runDrain.forkScoped
+            _        <- scheduledProduce(topic1, Schedule.fixed(10.millis).jittered).runDrain.forkScoped
+            _        <- scheduledProduce(topic2, Schedule.fixed(10.millis).jittered).runDrain.forkScoped
             // The slow consumer:
             c1 <- consumer
                     .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
@@ -373,7 +373,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                         )
             consumer <- Consumer.make(settings.withPollTimeout(50.millis))
             // A slow producer
-            _ <- scheduledProducer(topic, Schedule.fixed(1.second)).runDrain.forkScoped
+            _ <- scheduledProduce(topic, Schedule.fixed(1.second)).runDrain.forkScoped
             consumed <- consumer
                           .plainStream(Subscription.topics(topic), Serde.string, Serde.string)
                           .take(2)

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -1062,14 +1062,17 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
       },
       suite("issue #856")(
         test(
-          "Booting a Consumer to do something else than consuming should not fail with `RunloopTimeout` exception"
+          "Booting a Consumer to do something else than consuming should not fail with a timeout exception"
         ) {
           def test(diagnostics: Diagnostics) =
             for {
               clientId <- randomClient
-              settings <- consumerSettings(clientId = clientId, runloopTimeout = 500.millis)
-              _        <- Consumer.make(settings, diagnostics = diagnostics)
-              _        <- ZIO.sleep(1.second)
+              settings <- consumerSettings(
+                            clientId = clientId,
+                            properties = Map(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG -> "500")
+                          )
+              _ <- Consumer.make(settings, diagnostics = diagnostics)
+              _ <- ZIO.sleep(1.second)
             } yield assertCompletes
 
           for {

--- a/zio-kafka-test/src/test/scala/zio/kafka/utils/ExtraZStreamOpsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/utils/ExtraZStreamOpsSpec.scala
@@ -76,6 +76,27 @@ object ExtraZStreamOpsSpec extends ZIOSpecDefaultSlf4j {
           result <- pullExit.join
         } yield assert(result)(fails(isSome(equalTo(ConsumeTimeout))))
       },
+// A stream that is not read from is just a description, it cannot fail.
+// Therefore, the following test doesn't make sense:
+//      test("consumeTimeoutFail fail stream when pull doesn't come") {
+//        for {
+//          endP <- Promise.make[Nothing, ConsumeTimeout.type]
+//          timeoutStream = stream10
+//            .consumeTimeoutFail(ConsumeTimeout)(100.seconds)
+//            .tapError(e => endP.succeed(e))
+//          pull <- timeoutStream.toPull
+//          endF <- (for {
+//                        _ <- pull.delay(50.seconds)
+//                        _ <- pull.delay(50.seconds)
+//                        _ <- ZIO.sleep(100.seconds)
+//                        e <- endP.await
+//                      } yield e).fork
+//          _      <- TestClock.adjust(50.second).schedule(Schedule.recurs(4))
+//          result <- endF.join
+//        } yield assertTrue(result == ConsumeTimeout)
+//      },
+// Since the wrapped stream only starts when pulling starts, we never time out waiting for the first pull.
+// Therefore, the following test doesn't make sense.
 //      test("consumeTimeoutFail fails stream when first pull is slow") {
 //        for {
 //          pull <- stream10

--- a/zio-kafka-test/src/test/scala/zio/kafka/utils/ExtraZStreamOpsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/utils/ExtraZStreamOpsSpec.scala
@@ -5,6 +5,7 @@ import zio.kafka.ZIOSpecDefaultSlf4j
 import zio.stream.ZStream
 import zio.test._
 import zio.test.Assertion._
+import zio.test.TestAspect.timeout
 
 import scala.util.control.NoStackTrace
 
@@ -96,6 +97,6 @@ object ExtraZStreamOpsSpec extends ZIOSpecDefaultSlf4j {
                       .runHead
         } yield assertTrue(result.map(_.size).getOrElse(0) == 5)
       }
-    )
+    ) @@ timeout(5.seconds)
 
 }

--- a/zio-kafka-test/src/test/scala/zio/kafka/utils/ExtraZStreamOpsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/utils/ExtraZStreamOpsSpec.scala
@@ -16,86 +16,77 @@ object ExtraZStreamOpsSpec extends ZIOSpecDefaultSlf4j {
 
   private val stream10 = ZStream(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).rechunk(1)
 
-  override def spec: Spec[TestEnvironment, Any] =
+  override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("ExtraZStreamOps")(
-      test("consumeTimeoutFail does not fail stream for fast consumer") {
+      test("consumeTimeoutFail does not fail stream for fast producer") {
         for {
-          f <- stream10
-                 .consumeTimeoutFail(ConsumeTimeout)(3.seconds)
-                 .tap(_ => ZIO.sleep(1.second))
-                 .take(5)
-                 .runCollect
-                 .fork
-          _        <- TestClock.adjust(1.second).repeatN(5)
-          consumed <- f.join
-        } yield assertTrue(consumed.size == 5)
+          consumed <- stream10
+            .consumeTimeoutFail(ConsumeTimeout)(1.second)
+            .take(5)
+            .runCollect
+        } yield assertTrue(consumed == Chunk(1, 2, 3, 4, 5))
       },
       test("consumeTimeoutFail does not fail stream for slow producer") {
         for {
           f <- ZStream
-                 .fromSchedule(Schedule.fixed(5.seconds))
-                 .consumeTimeoutFail(ConsumeTimeout)(1.second)
-                 .take(5)
-                 .runCollect
-                 .fork
-          _        <- TestClock.adjust(1.seconds).repeatN(25)
+            .fromSchedule(Schedule.fixed(5.seconds))
+            .consumeTimeoutFail(ConsumeTimeout)(1.second)
+            .take(5)
+            .runCollect
+            .fork
+          _ <- TestClock.adjust(1.seconds).repeatN(25)
           consumed <- f.join
-        } yield assertTrue(consumed.size == 5)
-      },
-      test("consumeTimeoutFail fails stream for slow consumer") {
-        for {
-          consumedRef <- Ref.make(Seq.empty[Int])
-          f <- stream10
-                 .consumeTimeoutFail(ConsumeTimeout)(100.seconds)
-                 .tap(elem => ZIO.sleep(200.seconds).when(elem == 4))
-                 .tap(elem => consumedRef.update(_ :+ elem))
-                 .runDrain
-                 .exit
-                 .fork
-          _        <- TestClock.adjust(100.seconds).repeatN(2)
-          fResult  <- f.join
-          consumed <- consumedRef.get
-        } yield assert(fResult)(fails(equalTo(ConsumeTimeout))) && assertTrue(consumed == Seq(1, 2, 3, 4))
-      },
-      test("consumeTimeoutFail fails stream when not consumed") {
-        for {
-          consumedRef <- Ref.make(Seq.empty[Int])
-          f <- stream10
-                 .consumeTimeoutFail(ConsumeTimeout)(100.seconds)
-                 .tap(_ => ZIO.sleep(200.seconds))
-                 .tap(elem => consumedRef.update(_ :+ elem))
-                 .runDrain
-                 .exit
-                 .fork
-          _        <- TestClock.adjust(100.seconds).repeatN(2)
-          fResult  <- f.join
-          consumed <- consumedRef.get
-        } yield assert(fResult)(fails(equalTo(ConsumeTimeout))) && assertTrue(consumed.isEmpty)
-      },
-      test("consumeTimeoutFail fails stream when consumer stops pulling") {
-        for {
-          consumedRef <- Ref.make(Seq.empty[Int])
-          f <- stream10
-                 .consumeTimeoutFail(ConsumeTimeout)(100.seconds)
-                 .tap(_ => ZIO.sleep(200.seconds))
-                 .take(1)
-                 .tap(elem => consumedRef.update(_ :+ elem))
-                 .runDrain
-                 .exit
-                 .fork
-          _        <- TestClock.adjust(100.seconds).repeatN(2)
-          fResult  <- f.join
-          consumed <- consumedRef.get
-        } yield assert(fResult)(fails(equalTo(ConsumeTimeout))) && assertTrue(consumed.size == 1)
+        } yield assertTrue(consumed == Chunk[Long](0, 1, 2, 3, 4))
       },
       test("consumeTimeoutFail retains chunking structure") {
         for {
           result <- ZStream(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-                      .rechunk(5)
-                      .consumeTimeoutFail(ConsumeTimeout)(100.seconds)
-                      .chunks
-                      .runHead
+            .rechunk(5)
+            .consumeTimeoutFail(ConsumeTimeout)(100.seconds)
+            .chunks
+            .runHead
         } yield assertTrue(result.map(_.size).getOrElse(0) == 5)
+      },
+      test("consumeTimeoutFail does not fail stream for fast consumer") {
+        for {
+          consumedRef <- Ref.make(Seq.empty[Int])
+          pull     <- stream10
+                     .consumeTimeoutFail(ConsumeTimeout)(3.seconds)
+                     .toPull
+          f        <- pull
+                     .tap(chunk => consumedRef.update(_ ++ chunk))
+                     .schedule(Schedule.spaced(1.second) && Schedule.recurs(5))
+                     .fork
+          _        <- TestClock.adjust(1.second).schedule(Schedule.recurs(5))
+          _        <- f.join
+          consumed <- consumedRef.get
+        } yield assertTrue(consumed.size == 5)
+      },
+      test("consumeTimeoutFail fail stream for slow consumer") {
+        for {
+          pull     <- stream10
+                     .consumeTimeoutFail(ConsumeTimeout)(100.seconds)
+                     .toPull
+          pullExit <- (for {
+                         _ <- pull.delay(50.seconds)
+                         _ <- pull.delay(50.seconds)
+                         e <- pull.delay(200.second).exit
+                       } yield e
+                      )
+                       .fork
+          _        <- TestClock.adjust(50.second).schedule(Schedule.recurs(6))
+          result   <- pullExit.join
+        } yield assert(result)(fails(isSome(equalTo(ConsumeTimeout))))
+      },
+      test("consumeTimeoutFail fails stream when first pull is slow") {
+        for {
+          pull     <- stream10
+                     .consumeTimeoutFail(ConsumeTimeout)(100.seconds)
+                     .toPull
+          pullExit <- pull.delay(200.second).exit.fork
+          _        <- TestClock.adjust(50.second).schedule(Schedule.recurs(6))
+          result   <- pullExit.join
+        } yield assert(result)(fails(isSome(equalTo(ConsumeTimeout))))
       }
     ) @@ timeout(5.seconds)
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/utils/ExtraZStreamOpsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/utils/ExtraZStreamOpsSpec.scala
@@ -1,0 +1,62 @@
+package zio.kafka.utils
+
+import zio._
+import zio.kafka.ZIOSpecDefaultSlf4j
+import zio.stream.ZStream
+import zio.test._
+import zio.test.Assertion._
+import zio.test.TestAspect.withLiveClock
+
+import scala.util.control.NoStackTrace
+
+object ExtraZStreamOpsSpec extends ZIOSpecDefaultSlf4j {
+  import ExtraZStreamOps._
+
+  private object ConsumeTimeout extends RuntimeException with NoStackTrace
+
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("ExtraZStreamOps")(
+      test("consumeTimeoutFail does not fail stream for fast consumer") {
+        for {
+          f <- ZStream
+                 .fromIterator(Iterator.from(1), 1)
+                 .consumeTimeoutFail(ConsumeTimeout)(100.millis)
+                 .tap(_ => ZIO.sleep(1.millis))
+                 .take(10)
+                 .runDrain
+                 .fork
+          _ <- TestClock.adjust(1.millis).repeatN(10)
+          _ <- f.join
+        } yield assertCompletes
+      },
+      test("consumeTimeoutFail fails stream for slow consumer") {
+        for {
+          consumed <- Ref.make(Seq.empty[Int])
+          f <- ZStream
+                 .fromIterator(Iterator.from(1), 1)
+                 .consumeTimeoutFail(ConsumeTimeout)(100.millis)
+                 .tap(elem => ZIO.sleep(200.millis).when(elem == 4))
+                 .take(10)
+                 .tap(elem => consumed.update(_ :+ elem))
+                 .runDrain
+                 .exit
+                 .fork
+          _       <- TestClock.adjust(100.millis).repeatN(2)
+          fResult <- f.join
+          result  <- consumed.get
+        } yield assert(fResult)(fails(equalTo(ConsumeTimeout))) && assertTrue(result == Seq(1, 2, 3))
+      },
+      test("consumeTimeoutFail fails stream for slow consumer - oud") {
+        for {
+          result <- ZStream
+                      .fromIterator(Iterator.from(1), 1)
+                      .consumeTimeoutFail(ConsumeTimeout)(10.millis)
+                      .tap(elem => ZIO.sleep(200.millis).when(elem == 40))
+                      .take(1000)
+                      .runDrain // todo: test that we get items up till the slow consumer
+                      .exit
+        } yield assert(result)(fails(equalTo(ConsumeTimeout)))
+      } @@ withLiveClock
+    )
+
+}

--- a/zio-kafka-test/src/test/scala/zio/kafka/utils/ExtraZStreamOpsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/utils/ExtraZStreamOpsSpec.scala
@@ -13,12 +13,13 @@ object ExtraZStreamOpsSpec extends ZIOSpecDefaultSlf4j {
 
   private object ConsumeTimeout extends RuntimeException with NoStackTrace
 
+  private val stream10 = ZStream(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).rechunk(1)
+
   override def spec: Spec[TestEnvironment, Any] =
     suite("ExtraZStreamOps")(
       test("consumeTimeoutFail does not fail stream for fast consumer") {
         for {
-          f <- ZStream
-                 .fromIterator(Iterator.from(1), 1)
+          f <- stream10
                  .consumeTimeoutFail(ConsumeTimeout)(3.seconds)
                  .tap(_ => ZIO.sleep(1.second))
                  .take(5)
@@ -43,11 +44,9 @@ object ExtraZStreamOpsSpec extends ZIOSpecDefaultSlf4j {
       test("consumeTimeoutFail fails stream for slow consumer") {
         for {
           consumedRef <- Ref.make(Seq.empty[Int])
-          f <- ZStream
-                 .fromIterator(Iterator.from(1), 1)
+          f <- stream10
                  .consumeTimeoutFail(ConsumeTimeout)(100.seconds)
                  .tap(elem => ZIO.sleep(200.seconds).when(elem == 4))
-                 .take(10)
                  .tap(elem => consumedRef.update(_ :+ elem))
                  .runDrain
                  .exit
@@ -57,10 +56,41 @@ object ExtraZStreamOpsSpec extends ZIOSpecDefaultSlf4j {
           consumed <- consumedRef.get
         } yield assert(fResult)(fails(equalTo(ConsumeTimeout))) && assertTrue(consumed == Seq(1, 2, 3, 4))
       },
+      test("consumeTimeoutFail fails stream when not consumed") {
+        for {
+          consumedRef <- Ref.make(Seq.empty[Int])
+          f <- stream10
+                 .consumeTimeoutFail(ConsumeTimeout)(100.seconds)
+                 .tap(_ => ZIO.sleep(200.seconds))
+                 .tap(elem => consumedRef.update(_ :+ elem))
+                 .runDrain
+                 .exit
+                 .fork
+          _        <- TestClock.adjust(100.seconds).repeatN(2)
+          fResult  <- f.join
+          consumed <- consumedRef.get
+        } yield assert(fResult)(fails(equalTo(ConsumeTimeout))) && assertTrue(consumed.isEmpty)
+      },
+      test("consumeTimeoutFail fails stream when consumer stops pulling") {
+        for {
+          consumedRef <- Ref.make(Seq.empty[Int])
+          f <- stream10
+                 .consumeTimeoutFail(ConsumeTimeout)(100.seconds)
+                 .tap(_ => ZIO.sleep(200.seconds))
+                 .take(1)
+                 .tap(elem => consumedRef.update(_ :+ elem))
+                 .runDrain
+                 .exit
+                 .fork
+          _        <- TestClock.adjust(100.seconds).repeatN(2)
+          fResult  <- f.join
+          consumed <- consumedRef.get
+        } yield assert(fResult)(fails(equalTo(ConsumeTimeout))) && assertTrue(consumed.size == 1)
+      },
       test("consumeTimeoutFail retains chunking structure") {
         for {
-          result <- ZStream
-                      .fromChunks(Chunk(1, 2, 3, 4, 5), Chunk(1, 2, 3, 4, 5))
+          result <- ZStream(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+                      .rechunk(5)
                       .consumeTimeoutFail(ConsumeTimeout)(100.seconds)
                       .chunks
                       .runHead

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -103,7 +103,6 @@ object KafkaTestUtils {
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
     `max.poll.records`: Int = 100, // settings this higher can cause concurrency bugs to go unnoticed
-    runloopTimeout: Duration = ConsumerSettings.defaultRunloopTimeout,
     commitTimeout: Duration = ConsumerSettings.defaultCommitTimeout,
     properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =
@@ -113,7 +112,6 @@ object KafkaTestUtils {
         .withCloseTimeout(5.seconds)
         .withPollTimeout(100.millis)
         .withCommitTimeout(commitTimeout)
-        .withRunloopTimeout(runloopTimeout)
         .withProperties(
           ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "earliest",
           ConsumerConfig.METADATA_MAX_AGE_CONFIG         -> "100",

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -116,6 +116,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
+    maxPollInterval: Duration = 10.seconds,
     `max.poll.records`: Int = 100, // settings this higher can cause concurrency bugs to go unnoticed
     commitTimeout: Duration = ConsumerSettings.defaultCommitTimeout,
     properties: Map[String, String] = Map.empty
@@ -125,14 +126,14 @@ object KafkaTestUtils {
         .withClientId(clientId)
         .withCloseTimeout(5.seconds)
         .withPollTimeout(100.millis)
+        .withMaxPollInterval(maxPollInterval)
         .withCommitTimeout(commitTimeout)
         .withProperties(
           ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "earliest",
           ConsumerConfig.METADATA_MAX_AGE_CONFIG         -> "100",
           ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG       -> "3000",
-          ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG     -> "10000",
           ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG    -> "1000",
-          ConsumerConfig.MAX_POLL_RECORDS_CONFIG         -> s"${`max.poll.records`}",
+          ConsumerConfig.MAX_POLL_RECORDS_CONFIG         -> `max.poll.records`.toString,
           ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG -> allowAutoCreateTopics.toString
         )
         .withOffsetRetrieval(offsetRetrieval)

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -96,7 +96,7 @@ object KafkaTestUtils {
   /**
    * A stream that produces messages to a Topic on a schedule for as long as it is running.
    */
-  def scheduledProducer[R](
+  def scheduledProduce[R](
     topic: String,
     schedule: Schedule[R, Any, Long]
   ): ZStream[R with Producer, Throwable, RecordMetadata] =

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -9,6 +9,7 @@ import zio.kafka.consumer._
 import zio.kafka.consumer.diagnostics.Diagnostics
 import zio.kafka.producer._
 import zio.kafka.serde.{ Deserializer, Serde }
+import zio.stream.ZStream
 
 import java.io.File
 import java.nio.file.{ Files, StandardCopyOption }
@@ -91,6 +92,19 @@ object KafkaTestUtils {
         Serde.string,
         Serde.string
       )
+
+  /**
+   * A stream that produces messages to a Topic on a schedule for as long as it is running.
+   */
+  def scheduledProducer[R](
+    topic: String,
+    schedule: Schedule[R, Any, Long]
+  ): ZStream[R with Producer, Throwable, RecordMetadata] =
+    ZStream
+      .fromSchedule(schedule)
+      .mapZIO { i =>
+        produceOne(topic, s"key$i", s"msg$i")
+      }
 
   /**
    * Utility function to make a Consumer settings set.

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -119,5 +119,5 @@ final case class ConsumerSettings(
 }
 
 object ConsumerSettings {
-  val defaultCommitTimeout: Duration  = 15.seconds
+  val defaultCommitTimeout: Duration = 15.seconds
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -25,7 +25,6 @@ final case class ConsumerSettings(
   properties: Map[String, AnyRef] = Map.empty,
   closeTimeout: Duration = 30.seconds,
   pollTimeout: Duration = 50.millis,
-  maxPollInterval: Duration = 5.minutes,
   commitTimeout: Duration = ConsumerSettings.defaultCommitTimeout,
   offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
   rebalanceListener: RebalanceListener = RebalanceListener.noop,
@@ -39,9 +38,8 @@ final case class ConsumerSettings(
 
   def driverSettings: Map[String, AnyRef] =
     Map(
-      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG    -> bootstrapServers.mkString(","),
-      ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG   -> "false",
-      ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG -> maxPollInterval.toMillis.toString
+      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG  -> bootstrapServers.mkString(","),
+      ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG -> "false"
     ) ++ autoOffsetResetConfig ++ properties
 
   def withBootstrapServers(servers: List[String]): ConsumerSettings =
@@ -72,19 +70,18 @@ final case class ConsumerSettings(
     copy(pollTimeout = timeout)
 
   /**
-   * The maximum delay between pulling chunks from a partition stream. This places an upper bound on the amount of time
-   * that a stream can be processing records. If no chunks are pulled before this timeout, then the entire consumer is
-   * considered failed and it will shutdown. When a group is in use the group will then rebalance in order to reassign
-   * the partitions to other members of the group.
+   * Set Kafka's `max.poll.interval.ms` configuration. See
+   * https://kafka.apache.org/documentation/#consumerconfigs_max.poll.interval.ms for more information.
    *
-   * This configuration is copied into Kafka's `max.poll.interval.ms` configuration. For more information see
-   * https://kafka.apache.org/documentation/#consumerconfigs_max.poll.interval.ms.
+   * Zio-kafka uses this value also to determine whether a stream stopped processing. If no chunks are pulled from a
+   * stream for this interval we consider the stream to be halted. When this happens we shutdown the entire consumer. In
+   * future versions of zio-kafka we may stop only the affected subscription.
    *
    * The default is 5 minutes. Make sure that all records from a single poll (see
    * https://kafka.apache.org/documentation/#consumerconfigs_max.poll.records) can be processed in this interval.
    */
-  def withMaxPollInterval(interval: Duration): ConsumerSettings =
-    copy(maxPollInterval = interval)
+  def withMaxPollInterval(maxPollInterval: Duration): ConsumerSettings =
+    withProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval.toMillis.toString)
 
   def withProperty(key: String, value: AnyRef): ConsumerSettings =
     copy(properties = properties + (key -> value))

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -29,7 +29,6 @@ final case class ConsumerSettings(
   offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
   rebalanceListener: RebalanceListener = RebalanceListener.noop,
   restartStreamOnRebalancing: Boolean = false,
-  runloopTimeout: Duration = ConsumerSettings.defaultRunloopTimeout,
   fetchStrategy: FetchStrategy = QueueSizeBasedFetchStrategy()
 ) {
   private[this] def autoOffsetResetConfig: Map[String, String] = offsetRetrieval match {
@@ -94,16 +93,6 @@ final case class ConsumerSettings(
     withProperties(credentialsStore.properties)
 
   /**
-   * @param timeout
-   *   Internal timeout for each iteration of the command processing and polling loop, use to detect stalling. This
-   *   should be much larger than the pollTimeout and the time it takes to process chunks of records. If your consumer
-   *   is not subscribed for long periods during its lifetime, this timeout should take that into account as well. When
-   *   the timeout expires, the plainStream/partitionedStream/etc will fail with a [[Consumer.RunloopTimeout]].
-   */
-  def withRunloopTimeout(timeout: Duration): ConsumerSettings =
-    copy(runloopTimeout = timeout)
-
-  /**
    * @param maxPartitionQueueSize
    *   Maximum number of records to be buffered per partition. This buffer improves throughput and supports varying
    *   downstream message processing time, while maintaining some backpressure. Large values effectively disable
@@ -130,6 +119,5 @@ final case class ConsumerSettings(
 }
 
 object ConsumerSettings {
-  val defaultRunloopTimeout: Duration = 4.minutes
   val defaultCommitTimeout: Duration  = 15.seconds
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -62,11 +62,11 @@ object PartitionStreamControl {
     maxPollInterval: Duration,
     onConsumeTimeout: UIO[Unit]
   ): UIO[PartitionStreamControl] = {
-    val consumeTimeout = new TimeoutException(
-      s"No records were polled for more than $maxPollInterval for topic partition $tp. " +
-        "Set kafka configuration 'max.poll.interval.ms' to a higher value " +
-        "if processing a batch of records needs more time."
-    ) with NoStackTrace
+    val timeOutMessage = s"No records were polled for more than $maxPollInterval for topic partition $tp. " +
+      "Set kafka configuration 'max.poll.interval.ms' to a higher value " +
+      "if processing a batch of records needs more time."
+    val consumeTimeout = new TimeoutException(timeOutMessage) with NoStackTrace
+    val onTimeout = ZIO.logError(timeOutMessage) *> onConsumeTimeout
 
     for {
       _                   <- ZIO.logDebug(s"Creating partition stream ${tp.toString}")
@@ -96,7 +96,7 @@ object PartitionStreamControl {
                  }.flattenTake
                    .chunksWith(_.tap(records => queueSize.update(_ - records.size)))
                    .interruptWhen(interruptionPromise)
-                   .consumeTimeoutFail(consumeTimeout)(maxPollInterval)(onConsumeTimeout)
+                   .consumeTimeoutFail(consumeTimeout)(maxPollInterval)(onTimeout)
     } yield new PartitionStreamControl(tp, stream, dataQueue, interruptionPromise, completedPromise, queueSize)
   }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -96,8 +96,7 @@ object PartitionStreamControl {
                  }.flattenTake
                    .chunksWith(_.tap(records => queueSize.update(_ - records.size)))
                    .interruptWhen(interruptionPromise)
-                   .consumeTimeoutFail(consumeTimeout)(maxPollInterval)
-                   .tapError(error => onConsumeTimeout.when(error eq consumeTimeout))
+                   .consumeTimeoutFail(consumeTimeout)(maxPollInterval)(onConsumeTimeout)
     } yield new PartitionStreamControl(tp, stream, dataQueue, interruptionPromise, completedPromise, queueSize)
   }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -8,7 +8,6 @@ import zio.stream.{ Take, ZStream }
 import zio._
 
 import scala.concurrent.TimeoutException
-import scala.util.control.NoStackTrace
 
 final class PartitionStreamControl private (
   val tp: TopicPartition,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -95,6 +95,11 @@ object PartitionStreamControl {
     } yield new PartitionStreamControl(tp, stream, dataQueue, interruptionPromise, completedPromise, queueSize)
 
   implicit private class ZStreamOps[R, E, A](val stream: ZStream[R, E, A]) {
+    /**
+     * Fails the stream with given error if it is not polled for a value after d duration.
+     *
+     * See [[zio.stream.ZStream#timeoutFail]] for failing the stream doesn't produce a value.
+     */
     def pollTimeoutFail[E1 >: E](e: E1)(timeout: Duration): ZStream[R, E1, A] =
       ZStream.unwrap(
         for {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -61,11 +61,11 @@ object PartitionStreamControl {
     diagnostics: Diagnostics,
     maxPollInterval: Duration
   ): UIO[PartitionStreamControl] = {
-    val consumeTimeout = new TimeoutException(
+    def consumeTimeout = new TimeoutException(
       s"No records were polled for more than $maxPollInterval, aborting the stream. " +
         "Set kafka configuration 'max.poll.interval.ms' to a higher value " +
         "if processing a batch of records needs more time."
-    ) with NoStackTrace
+    )
 
     for {
       _                   <- ZIO.logDebug(s"Creating partition stream ${tp.toString}")

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -62,11 +62,11 @@ object PartitionStreamControl {
     maxPollInterval: Duration,
     onConsumeTimeout: UIO[Unit]
   ): UIO[PartitionStreamControl] = {
-    val timeOutMessage = s"No records were polled for more than $maxPollInterval for topic partition $tp. " +
+    def timeOutMessage = s"No records were polled for more than $maxPollInterval for topic partition $tp. " +
       "Use ConsumerSettings.withMaxPollInterval to set a longer interval if processing a batch of records " +
       "needs more time."
-    val consumeTimeout = new TimeoutException(timeOutMessage) with NoStackTrace
-    val onTimeout      = ZIO.logError(timeOutMessage) *> onConsumeTimeout
+    def consumeTimeout = new TimeoutException(timeOutMessage) with NoStackTrace
+    def onTimeout      = ZIO.logError(timeOutMessage) *> onConsumeTimeout
 
     for {
       _                   <- ZIO.logDebug(s"Creating partition stream ${tp.toString}")

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -66,7 +66,7 @@ object PartitionStreamControl {
       "Set kafka configuration 'max.poll.interval.ms' to a higher value " +
       "if processing a batch of records needs more time."
     val consumeTimeout = new TimeoutException(timeOutMessage) with NoStackTrace
-    val onTimeout = ZIO.logError(timeOutMessage) *> onConsumeTimeout
+    val onTimeout      = ZIO.logError(timeOutMessage) *> onConsumeTimeout
 
     for {
       _                   <- ZIO.logDebug(s"Creating partition stream ${tp.toString}")

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -63,8 +63,8 @@ object PartitionStreamControl {
     onConsumeTimeout: UIO[Unit]
   ): UIO[PartitionStreamControl] = {
     val timeOutMessage = s"No records were polled for more than $maxPollInterval for topic partition $tp. " +
-      "Set kafka configuration 'max.poll.interval.ms' to a higher value " +
-      "if processing a batch of records needs more time."
+      "Use ConsumerSettings.withMaxPollInterval to set a longer interval if processing a batch of records " +
+      "needs more time."
     val consumeTimeout = new TimeoutException(timeOutMessage) with NoStackTrace
     val onTimeout      = ZIO.logError(timeOutMessage) *> onConsumeTimeout
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -3,25 +3,10 @@ package zio.kafka.consumer.internal
 import org.apache.kafka.common.TopicPartition
 import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
 import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
-import zio.stream.{ Take, ZChannel, ZPipeline, ZStream }
-import zio.{
-  Cause,
-  Chunk,
-  Clock,
-  Duration,
-  Fiber,
-  LogAnnotation,
-  Promise,
-  Queue,
-  Ref,
-  Scope,
-  UIO,
-  ZEnvironment,
-  ZIO,
-  ZNothing
-}
+import zio.kafka.utils.ExtraZStreamOps._
+import zio.stream.{ Take, ZStream }
+import zio._
 
-import java.time.Instant
 import scala.concurrent.TimeoutException
 
 final class PartitionStreamControl private (
@@ -103,112 +88,11 @@ object PartitionStreamControl {
                  }.flattenTake
                    .chunksWith(_.tap(records => queueSize.update(_ - records.size)))
                    .interruptWhen(interruptionPromise)
-                   .pollTimeoutFail(
+                   .consumeTimeoutFail(
                      new TimeoutException(
                        s"No records were polled for more than $maxPollInterval, aborting the stream. Set kafka configuration 'max.poll.interval.ms' to a higher value if processing a batch of records needs more time."
                      )
                    )(maxPollInterval)
     } yield new PartitionStreamControl(tp, stream, dataQueue, interruptionPromise, completedPromise, queueSize)
-
-  implicit private class ZStreamOps[R, E, A](val stream: ZStream[R, E, A]) {
-
-    /**
-     * Fails the stream with given error if it is not polled for a value after d duration.
-     *
-     * See [[zio.stream.ZStream#timeoutFail]] for failing the stream doesn't produce a value.
-     */
-    def pullTimeoutFail[E1 >: E](e: E1)(timeout: Duration): ZStream[R, E1, A] =
-      ZStream.unwrap(
-        for {
-          timeoutReached <- Promise.make[E1, A]
-          queue          <- Queue.bounded[Unit](1)
-        } yield {
-          val timeoutStream = ZStream
-            .fromQueue(queue)
-            .timeoutFail(e)(timeout)
-            .tapError(timeoutReached.fail)
-          val pollStream = stream.chunks
-            .tap(_ => queue.offer(()).unit)
-            .flattenChunks
-            .interruptWhen(timeoutReached)
-          timeoutStream *> pollStream
-        }
-      )
-
-    /**
-     * Fails the stream with given error if it is not consumed (pulled) from for a value after d duration.
-     *
-     * See [[zio.stream.ZStream#timeoutFail]] for failing the stream doesn't produce a value.
-     */
-    def consumeTimeoutFail[E1 >: E](e: => E1)(timeout: Duration): ZStream[R, E1, A] = {
-      def notifyQueue(queue: Queue[Unit]): ZPipeline[R, E, A, A] = {
-        val read: ZChannel[R, E, Chunk[A], Any, E, Chunk[A], Any] = ZChannel.readWith(
-          (in: Chunk[A]) => ZChannel.fromZIO(queue.offer(())) *> ZChannel.write(in) *> read,
-          (error: E) => ZChannel.fail(error),
-          (done: Any) => ZChannel.succeed(done)
-        )
-        ZPipeline.fromChannel(read)
-      }
-
-      ZStream.unwrap(
-        for {
-          timeoutReached <- Promise.make[E1, A]
-          queue          <- Queue.bounded[Unit](1)
-        } yield {
-          val timeoutStream = ZStream
-            .fromQueue(queue)
-            .timeoutFail(e)(timeout)
-            .tapError(timeoutReached.fail)
-          timeoutStream *> stream.via(notifyQueue(queue)).interruptWhen(timeoutReached)
-        }
-      )
-    }
-
-    def consumeTimeoutFail[E1 >: E](e: => E1)(after: Duration): ZStream[R, E1, A] =
-      stream.via(
-        ZPipeline.unwrapScoped {
-          for {
-            p <- Promise.make[E1, Unit]
-            timer = (p.fail(e).delay(after) <* ZIO.debug("timing out")).forkScoped
-            initialTimer <- timer
-          } yield {
-            def loop(
-              runningTimer: Fiber[Nothing, Boolean]
-            ): ZChannel[Scope, ZNothing, Chunk[A], Any, E, Chunk[A], Unit] = {
-              val interrupter = ZChannel.fromZIO(ZIO.debug("pulling") *> runningTimer.interrupt)
-              ZChannel.readWithCause(
-                (in: Chunk[A]) => interrupter *> ZChannel.write(in) *> ZChannel.unwrap(timer.map(loop)),
-                (cause: Cause[ZNothing]) => ZChannel.refailCause(cause),
-                (_: Any) => ZChannel.unit
-              )
-            }
-            ZPipeline.fromChannel(loop(initialTimer).interruptWhen(p))
-          }
-        }
-      )
-
-//    def timeoutPull[E, In](after: Duration)(e: => E): ZPipeline[Any, E, In, In] =
-//      ZPipeline.unwrapScoped(for {
-//        scope <- ZIO.scope
-//        p <- Promise.make[E, Unit]
-//        timer =
-//          (p.fail(e).delay(after) <* ZIO.debug(
-//            "timing out"
-//          )).forkScoped.provideEnvironment(ZEnvironment[Scope](scope))
-//        initial <- timer
-//      } yield {
-//        def loop(in: Fiber[Nothing, Boolean]): ZChannel[Any, ZNothing, Chunk[In], Any, E, Chunk[In], Unit] = {
-//          val interrupter = ZChannel.fromZIO(ZIO.debug("pulling") *> in.interrupt)
-//          ZChannel.readWithCause(
-//            (in: Chunk[In]) => interrupter *> ZChannel.write(in) *> ZChannel.unwrap(timer.map(loop)),
-//            (cause: Cause[ZNothing]) => ZChannel.refailCause(cause),
-//            (_: Any) => ZChannel.unit
-//          )
-//        }
-//
-//        ZPipeline.fromChannel(loop(initial).interruptWhen(p))
-//      })
-
-  }
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -24,7 +24,6 @@ private[consumer] final class Runloop private (
   pollTimeout: Duration,
   maxPollInterval: Duration,
   commitTimeout: Duration,
-  runloopTimeout: Duration,
   commandQueue: Queue[RunloopCommand],
   lastRebalanceEvent: Ref.Synchronized[Option[Runloop.RebalanceEvent]],
   partitionsHub: Hub[Take[Throwable, PartitionAssignment]],
@@ -488,7 +487,6 @@ private[consumer] final class Runloop private (
 
     ZStream
       .fromQueue(commandQueue)
-      .timeoutFail[Throwable](RunloopTimeout)(runloopTimeout)
       .takeWhile(_ != RunloopCommand.StopRunloop)
       .runFoldChunksDiscardZIO(initialState) { (state, commands) =>
         for {
@@ -566,7 +564,6 @@ private[consumer] object Runloop {
     userRebalanceListener: RebalanceListener,
     restartStreamsOnRebalancing: Boolean,
     partitionsHub: Hub[Take[Throwable, PartitionAssignment]],
-    runloopTimeout: Duration,
     fetchStrategy: FetchStrategy
   ): URIO[Scope, Runloop] =
     for {
@@ -583,7 +580,6 @@ private[consumer] object Runloop {
                   pollTimeout = pollTimeout,
                   maxPollInterval = maxPollInterval,
                   commitTimeout = commitTimeout,
-                  runloopTimeout = runloopTimeout,
                   commandQueue = commandQueue,
                   lastRebalanceEvent = lastRebalanceEvent,
                   partitionsHub = partitionsHub,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -22,6 +22,7 @@ private[consumer] final class Runloop private (
   hasGroupId: Boolean,
   consumer: ConsumerAccess,
   pollTimeout: Duration,
+  maxPollInterval: Duration,
   commitTimeout: Duration,
   runloopTimeout: Duration,
   commandQueue: Queue[RunloopCommand],
@@ -36,7 +37,7 @@ private[consumer] final class Runloop private (
 ) {
 
   private def newPartitionStream(tp: TopicPartition): UIO[PartitionStreamControl] =
-    PartitionStreamControl.newPartitionStream(tp, commandQueue, diagnostics)
+    PartitionStreamControl.newPartitionStream(tp, commandQueue, diagnostics, maxPollInterval)
 
   def stopConsumption: UIO[Unit] =
     ZIO.logDebug("stopConsumption called") *>
@@ -558,6 +559,7 @@ private[consumer] object Runloop {
     hasGroupId: Boolean,
     consumer: ConsumerAccess,
     pollTimeout: Duration,
+    maxPollInterval: Duration,
     commitTimeout: Duration,
     diagnostics: Diagnostics,
     offsetRetrieval: OffsetRetrieval,
@@ -579,6 +581,7 @@ private[consumer] object Runloop {
                   hasGroupId = hasGroupId,
                   consumer = consumer,
                   pollTimeout = pollTimeout,
+                  maxPollInterval = maxPollInterval,
                   commitTimeout = commitTimeout,
                   runloopTimeout = runloopTimeout,
                   commandQueue = commandQueue,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -36,7 +36,7 @@ private[consumer] final class Runloop private (
 ) {
 
   private def newPartitionStream(tp: TopicPartition): UIO[PartitionStreamControl] =
-    PartitionStreamControl.newPartitionStream(tp, commandQueue, diagnostics, maxPollInterval)
+    PartitionStreamControl.newPartitionStream(tp, commandQueue, diagnostics, maxPollInterval, shutdown)
 
   def stopConsumption: UIO[Unit] =
     ZIO.logDebug("stopConsumption called") *>

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -4,7 +4,7 @@ import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.RebalanceInProgressException
 import zio._
-import zio.kafka.consumer.Consumer.{ CommitTimeout, OffsetRetrieval, RunloopTimeout }
+import zio.kafka.consumer.Consumer.{ CommitTimeout, OffsetRetrieval }
 import zio.kafka.consumer._
 import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization
 import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -1,5 +1,6 @@
 package zio.kafka.consumer.internal
 
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.TopicPartition
 import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization
 import zio.kafka.consumer.diagnostics.Diagnostics
@@ -8,6 +9,8 @@ import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
 import zio.kafka.consumer.{ ConsumerSettings, InvalidSubscriptionUnion, Subscription }
 import zio.stream.{ Stream, Take, UStream, ZStream }
 import zio._
+
+import scala.util.Try
 
 private[internal] sealed trait RunloopState
 private[internal] object RunloopState {
@@ -76,6 +79,7 @@ private[consumer] object RunloopAccess {
     diagnostics: Diagnostics = Diagnostics.NoOp
   ): ZIO[Scope, Throwable, RunloopAccess] =
     for {
+      maxPollInterval <- maxPollIntervalConfig(settings)
       // This scope allows us to link the lifecycle of the Runloop and of the Hub to the lifecycle of the Consumer
       // When the Consumer is shutdown, the Runloop and the Hub will be shutdown too (before the consumer)
       consumerScope <- ZIO.scope
@@ -88,7 +92,7 @@ private[consumer] object RunloopAccess {
                         hasGroupId = settings.hasGroupId,
                         consumer = consumerAccess,
                         pollTimeout = settings.pollTimeout,
-                        maxPollInterval = settings.maxPollInterval,
+                        maxPollInterval = maxPollInterval,
                         commitTimeout = settings.commitTimeout,
                         diagnostics = diagnostics,
                         offsetRetrieval = settings.offsetRetrieval,
@@ -101,4 +105,17 @@ private[consumer] object RunloopAccess {
                       .provide(ZLayer.succeed(consumerScope))
     } yield new RunloopAccess(runloopStateRef, partitionsHub, makeRunloop, diagnostics)
 
+  private def maxPollIntervalConfig(settings: ConsumerSettings): Task[Duration] = ZIO.attempt {
+    def defaultMaxPollInterval: Int = ConsumerConfig
+      .configDef()
+      .defaultValues()
+      .get(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)
+      .asInstanceOf[Integer]
+
+    settings.properties
+      .get(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)
+      .flatMap(v => Try(v.toString.toInt).toOption) // Ignore invalid
+      .getOrElse(defaultMaxPollInterval)
+      .millis
+  }
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -103,12 +103,18 @@ private[consumer] object RunloopAccess {
     } yield new RunloopAccess(runloopStateRef, partitionsHub, makeRunloop, diagnostics)
 
   private def maxPollIntervalConfig(settings: ConsumerSettings): Duration = {
-    def defaultMaxPollInterval: AnyRef = ConsumerConfig
+    // Fallback default taken from
+    // https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#max-poll-interval-ms
+    def fallbackDefault: Int = 5.minutes.toMillis.toInt
+    def defaultMaxPollInterval: Int = ConsumerConfig
       .configDef()
       .defaultValues()
-      .getOrDefault(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "300000")
-    val maxPollIntervalStr = settings.properties
-      .getOrElse(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, defaultMaxPollInterval)
-    maxPollIntervalStr.toString.toInt.millis
+      .getOrDefault(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, Int.box(fallbackDefault))
+      .asInstanceOf[Integer]
+    settings.properties
+      .get(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)
+      .flatMap(_.toString.toIntOption) // Ignore invalid
+      .getOrElse(defaultMaxPollInterval)
+      .millis
   }
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -10,6 +10,8 @@ import zio.kafka.consumer.{ ConsumerSettings, InvalidSubscriptionUnion, Subscrip
 import zio.stream.{ Stream, Take, UStream, ZStream }
 import zio.{ durationInt, Duration, Hub, IO, Ref, Scope, UIO, ZIO, ZLayer }
 
+import scala.collection.compat._
+
 private[internal] sealed trait RunloopState
 private[internal] object RunloopState {
   case object NotStarted                     extends RunloopState

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -96,7 +96,6 @@ private[consumer] object RunloopAccess {
                         userRebalanceListener = settings.rebalanceListener,
                         restartStreamsOnRebalancing = settings.restartStreamOnRebalancing,
                         partitionsHub = partitionsHub,
-                        runloopTimeout = settings.runloopTimeout,
                         fetchStrategy = settings.fetchStrategy
                       )
                       .withFinalizer(_ => runloopStateRef.set(RunloopState.Finalized))

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -10,7 +10,7 @@ import zio.kafka.consumer.{ ConsumerSettings, InvalidSubscriptionUnion, Subscrip
 import zio.stream.{ Stream, Take, UStream, ZStream }
 import zio._
 
-import scala.collection.compat._
+import scala.util.Try
 
 private[internal] sealed trait RunloopState
 private[internal] object RunloopState {
@@ -114,7 +114,7 @@ private[consumer] object RunloopAccess {
 
     settings.properties
       .get(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)
-      .flatMap(_.toString.toIntOption) // Ignore invalid
+      .flatMap(v => Try(v.toString.toInt).toOption) // Ignore invalid
       .getOrElse(defaultMaxPollInterval)
       .millis
   }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -8,7 +8,9 @@ import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
 import zio.kafka.consumer.{ ConsumerSettings, InvalidSubscriptionUnion, Subscription }
 import zio.stream.{ Stream, Take, UStream, ZStream }
-import zio.{ durationInt, Duration, Hub, IO, Ref, Scope, UIO, ZIO, ZLayer }
+import zio._
+
+import scala.jdk.CollectionConverters._
 
 private[internal] sealed trait RunloopState
 private[internal] object RunloopState {
@@ -77,6 +79,7 @@ private[consumer] object RunloopAccess {
     diagnostics: Diagnostics = Diagnostics.NoOp
   ): ZIO[Scope, Throwable, RunloopAccess] =
     for {
+      maxPollInterval <- maxPollIntervalConfig(settings)
       // This scope allows us to link the lifecycle of the Runloop and of the Hub to the lifecycle of the Consumer
       // When the Consumer is shutdown, the Runloop and the Hub will be shutdown too (before the consumer)
       consumerScope <- ZIO.scope

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -1,5 +1,6 @@
 package zio.kafka.consumer.internal
 
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.TopicPartition
 import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization
 import zio.kafka.consumer.diagnostics.Diagnostics
@@ -7,7 +8,7 @@ import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
 import zio.kafka.consumer.{ ConsumerSettings, InvalidSubscriptionUnion, Subscription }
 import zio.stream.{ Stream, Take, UStream, ZStream }
-import zio.{ Hub, IO, Ref, Scope, UIO, ZIO, ZLayer }
+import zio.{ durationInt, Duration, Hub, IO, Ref, Scope, UIO, ZIO, ZLayer }
 
 private[internal] sealed trait RunloopState
 private[internal] object RunloopState {
@@ -88,6 +89,7 @@ private[consumer] object RunloopAccess {
                         hasGroupId = settings.hasGroupId,
                         consumer = consumerAccess,
                         pollTimeout = settings.pollTimeout,
+                        maxPollInterval = maxPollIntervalConfig(settings),
                         commitTimeout = settings.commitTimeout,
                         diagnostics = diagnostics,
                         offsetRetrieval = settings.offsetRetrieval,
@@ -100,4 +102,14 @@ private[consumer] object RunloopAccess {
                       .withFinalizer(_ => runloopStateRef.set(RunloopState.Finalized))
                       .provide(ZLayer.succeed(consumerScope))
     } yield new RunloopAccess(runloopStateRef, partitionsHub, makeRunloop, diagnostics)
+
+  private def maxPollIntervalConfig(settings: ConsumerSettings): Duration = {
+    def defaultMaxPollInterval: AnyRef = ConsumerConfig
+      .configDef()
+      .defaultValues()
+      .getOrDefault(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "300000")
+    val maxPollIntervalStr = settings.properties
+      .getOrElse(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, defaultMaxPollInterval)
+    maxPollIntervalStr.toString.toInt.millis
+  }
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -10,8 +10,6 @@ import zio.kafka.consumer.{ ConsumerSettings, InvalidSubscriptionUnion, Subscrip
 import zio.stream.{ Stream, Take, UStream, ZStream }
 import zio.{ durationInt, Duration, Hub, IO, Ref, Scope, UIO, ZIO, ZLayer }
 
-import scala.collection.compat._
-
 private[internal] sealed trait RunloopState
 private[internal] object RunloopState {
   case object NotStarted                     extends RunloopState

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -151,23 +151,19 @@ object Producer {
       }
 
     /**
-     * Calls to send may block when updating metadata or when communication with the broker is (temporarily) lost,
-     * therefore this stream is run on a the blocking thread pool
+     * Calls to send may block when updating metadata or when communication with the broker is (temporarily) lost.
      */
     val sendFromQueue: ZIO[Any, Nothing, Any] =
       ZStream
         .fromQueueWithShutdown(sendQueue)
         .mapZIO { case (serializedRecords, done) =>
           ZIO.attempt {
-            val it: Iterator[(ByteRecord, Int)] = serializedRecords.iterator.zipWithIndex
-            val res: Array[RecordMetadata]      = new Array[RecordMetadata](serializedRecords.length)
-            val count: AtomicLong               = new AtomicLong
-            val length                          = serializedRecords.length
+            val res: Array[RecordMetadata] = new Array[RecordMetadata](serializedRecords.length)
+            val count: AtomicLong          = new AtomicLong
+            val length                     = serializedRecords.length
 
-            while (it.hasNext) {
-              val (rec, idx): (ByteRecord, Int) = it.next()
-
-              val _ = p.send(
+            serializedRecords.iterator.zipWithIndex.foreach { case (rec, idx) =>
+              p.send(
                 rec,
                 (metadata: RecordMetadata, err: Exception) =>
                   Unsafe.unsafe { implicit u =>

--- a/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
@@ -50,7 +50,7 @@ object ExtraZStreamOps {
           _            <- deadlineChecker(stateRef, p.fail(e) *> onTimeout).interruptible.forkScoped
         } yield {
           val timedOutState = (ZIO.fail(e), ConsumerTimedOut)
-          val illegalState  = (ZIO.die(new IllegalStateException()), ConsumerTimedOut)
+          val illegalState  = (ZIO.die(new AssertionError("not possible")), ConsumerTimedOut)
 
           val producerDone: ZIO[Any, E1, Unit] =
             Clock.instant.flatMap { now =>

--- a/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
@@ -5,12 +5,12 @@ import zio.stream._
 
 object ExtraZStreamOps {
 
-  implicit class ZStreamOps[R, E, A](val stream: ZStream[R, E, A]) extends AnyVal {
+  implicit final class ZStreamOps[R, E, A](private val stream: ZStream[R, E, A]) extends AnyVal {
 
     /**
      * Fails the stream with given error if it is not consumed (pulled) from, for some duration.
      *
-     * Also see [[zio.stream.ZStream#timeoutFail]] for failing the stream doesn't _produce_ a value.
+     * Also see [[zio.stream.ZStream.timeoutFail]] for failing the stream doesn't _produce_ a value.
      */
     def consumeTimeoutFail[E1 >: E](e: => E1)(after: Duration): ZStream[R, E1, A] =
       // For every incoming chunk a timer is started. When the chunk is consumed, the timer is stopped by interrupting

--- a/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
@@ -18,10 +18,10 @@ object ExtraZStreamOps {
       stream.via(
         ZPipeline.unwrapScoped(
           for {
-            scope <- ZIO.scope
+            scope <- ZIO.environment[Scope]
             p     <- Promise.make[E1, Unit]
           } yield {
-            val timer = p.fail(e).delay(after).forkScoped.provideEnvironment(ZEnvironment[Scope](scope))
+            val timer = p.fail(e).delay(after).forkScoped.provideEnvironment(scope)
             def loop: ZChannel[Any, ZNothing, Chunk[A], Any, E, Chunk[A], Unit] =
               ZChannel.readWithCause(
                 (in: Chunk[A]) =>

--- a/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
@@ -5,7 +5,7 @@ import zio.stream._
 
 object ExtraZStreamOps {
 
-  implicit class ZStreamOps[R, E, A](val stream: ZStream[R, E, A]) {
+  implicit class ZStreamOps[R, E, A](val stream: ZStream[R, E, A]) extends AnyVal {
 
     /**
      * Fails the stream with given error if it is not consumed (pulled) from, for some duration.

--- a/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
@@ -10,30 +10,27 @@ object ExtraZStreamOps {
     /**
      * Fails the stream with given error if it is not consumed (pulled) from, for some duration.
      *
+     * Note: since the wrapped stream only starts when pulling starts, we never time out waiting for the first pull
+     *
      * Also see [[zio.stream.ZStream.timeoutFail]] for failing the stream doesn't _produce_ a value.
      */
     def consumeTimeoutFail[E1 >: E](e: => E1)(after: Duration): ZStream[R, E1, A] =
-      // For every incoming chunk a timer is started. When the chunk is consumed, the timer is stopped by interrupting
-      // it. When the timer completes, the stream gets interrupted.
-      stream.via(
-        ZPipeline.unwrapScoped(
-          for {
-            scope <- ZIO.environment[Scope]
-            p     <- Promise.make[E1, Unit]
-          } yield {
-            val timer = p.fail(e).delay(after).forkScoped.provideEnvironment(scope)
-            def loop: ZChannel[Any, ZNothing, Chunk[A], Any, E, Chunk[A], Unit] =
-              ZChannel.readWithCause(
-                (in: Chunk[A]) =>
-                  ZChannel.fromZIO(timer).flatMap { t =>
-                    ZChannel.write(in) *> ZChannel.fromZIO(t.interrupt) *> loop
-                  },
-                (cause: Cause[ZNothing]) => ZChannel.refailCause(cause),
-                (_: Any) => ZChannel.unit
-              )
-            ZPipeline.fromChannel(loop.interruptWhen(p))
-          }
-        )
+      ZStream.unwrap(
+        for {
+          streamStart <- Clock.nanoTime
+          pullEndRef  <- Ref.make(streamStart)
+        } yield {
+          val pull: ZIO[Scope with R, Nothing, ZIO[R, Option[E1], Chunk[A]]] =
+            stream.toPull.map { pull =>
+              for {
+                pullEnd    <- pullEndRef.get
+                now        <- Clock.nanoTime
+                pullResult <- if ((now - pullEnd).nanos < after) pull else ZIO.fail(Some(e))
+                _          <- Clock.nanoTime.flatMap(now => pullEndRef.set(now).unit)
+              } yield pullResult
+            }
+          ZStream.fromPull[R, E1, A](pull)
+        }
       )
   }
 

--- a/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
@@ -8,11 +8,13 @@ object ExtraZStreamOps {
   implicit class ZStreamOps[R, E, A](val stream: ZStream[R, E, A]) {
 
     /**
-     * Fails the stream with given error if it is not consumed (pulled) from for a value after d duration.
+     * Fails the stream with given error if it is not consumed (pulled) from, for some duration.
      *
      * Also see [[zio.stream.ZStream#timeoutFail]] for failing the stream doesn't _produce_ a value.
      */
-    def consumeTimeoutFail[E1 >: E](e: => E1)(after: Duration): ZStream[R, E1, A] =
+    def consumeTimeoutFail[E1 >: E](e: => E1)(after: Duration): ZStream[R, E1, A] = {
+      // For every incoming chunk a timer is started. When the chunk is consumed, the timer is stopped by interrupting
+      // it. When the timer completes, the stream gets interrupted.
       stream.via(
         ZPipeline.unwrapScoped(
           for {
@@ -33,6 +35,7 @@ object ExtraZStreamOps {
           }
         )
       )
+    }
   }
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
@@ -1,0 +1,41 @@
+package zio.kafka.utils
+
+import zio._
+import zio.stream._
+
+object ExtraZStreamOps {
+
+  implicit class ZStreamOps[R, E, A](val stream: ZStream[R, E, A]) {
+
+    /**
+     * Fails the stream with given error if it is not consumed (pulled) from for a value after d duration.
+     *
+     * Also see [[zio.stream.ZStream#timeoutFail]] for failing the stream doesn't _produce_ a value.
+     */
+    def consumeTimeoutFail[E1 >: E](e: => E1)(after: Duration): ZStream[R, E1, A] =
+      stream.via(
+        ZPipeline.unwrapScoped {
+          for {
+            scope <- ZIO.scope
+            p     <- Promise.make[E1, Unit]
+            timer = p.fail(e).delay(after).forkScoped.provideEnvironment(ZEnvironment[Scope](scope))
+            initialTimer <- timer
+          } yield {
+            def loop(
+              runningTimer: Fiber[Nothing, Boolean]
+            ): ZChannel[Any, ZNothing, Chunk[A], Any, E, Chunk[A], Unit] = {
+              val interrupter = ZChannel.fromZIO(runningTimer.interrupt)
+              ZChannel.readWithCause(
+                (in: Chunk[A]) => interrupter *> ZChannel.write(in) *> ZChannel.unwrap(timer.map(loop)),
+                (cause: Cause[ZNothing]) => ZChannel.refailCause(cause),
+                (_: Any) => ZChannel.unit
+              )
+            }
+
+            ZPipeline.fromChannel(loop(initialTimer).interruptWhen(p))
+          }
+        }
+      )
+  }
+
+}

--- a/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
@@ -26,7 +26,7 @@ object ExtraZStreamOps {
     // noinspection SimplifySleepInspection
     def consumeTimeoutFail[E1 >: E](
       e: => E1
-    )(after: Duration)(onTimeout: ZIO[R, Nothing, Any])(implicit trace: Trace): ZStream[R, E1, A] =
+    )(after: Duration)(onTimeout: => ZIO[R, Nothing, Any])(implicit trace: Trace): ZStream[R, E1, A] =
       ZStream.unwrapScoped[R] {
         def deadlineChecker(
           stateRef: Ref[State],

--- a/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/ExtraZStreamOps.scala
@@ -12,7 +12,7 @@ object ExtraZStreamOps {
      *
      * Also see [[zio.stream.ZStream#timeoutFail]] for failing the stream doesn't _produce_ a value.
      */
-    def consumeTimeoutFail[E1 >: E](e: => E1)(after: Duration): ZStream[R, E1, A] = {
+    def consumeTimeoutFail[E1 >: E](e: => E1)(after: Duration): ZStream[R, E1, A] =
       // For every incoming chunk a timer is started. When the chunk is consumed, the timer is stopped by interrupting
       // it. When the timer completes, the stream gets interrupted.
       stream.via(
@@ -35,7 +35,6 @@ object ExtraZStreamOps {
           }
         )
       )
-    }
   }
 
 }


### PR DESCRIPTION
Kafka's process to detect halted consumers is crude. Because it is based on polls, it works per consumer. Here we make it more fine grained by doing slow consumer detection per stream.

For the Kafka client 'halting' means poll is not called for longer than `max.poll.interval.ms`. Translated to zio-kafka 'halting' means that a stream does not consume any records for `max.poll.interval.ms` or longer, while records are available.

The halted stream is interrupted so that it can fail properly. In addition, we shut down the entire consumer. This will help the broker to detect slow consumers. Ideally we would only stop the subscription that the stream belongs to. Unfortunately, we do not maintain a topic belongs-to subscription relation.

As discussed on [Discord](https://discord.com/channels/629491597070827530/629497941719121960/1114868628156858400).

ExtraZStreamOps is based on a code example from @adamgfraser. Earlier versions were based on code from @paulpdaniels.

Replaces https://github.com/zio/zio-kafka/issues/686.
Implements #902.

Co-authored-by: Adam Fraser <adam.fraser@gmail.com>
Co-authored-by: Paul Daniels <paulpdaniels@gmail.com>