### PR TITLE
Implement default commit timeout

### DIFF
--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -104,6 +104,7 @@ object KafkaTestUtils {
     restartStreamOnRebalancing: Boolean = false,
     `max.poll.records`: Int = 100, // settings this higher can cause concurrency bugs to go unnoticed
     runloopTimeout: Duration = ConsumerSettings.defaultRunloopTimeout,
+    commitTimeout: Duration = ConsumerSettings.defaultCommitTimeout,
     properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =
     ZIO.serviceWith[Kafka] { (kafka: Kafka) =>
@@ -111,6 +112,7 @@ object KafkaTestUtils {
         .withClientId(clientId)
         .withCloseTimeout(5.seconds)
         .withPollTimeout(100.millis)
+        .withCommitTimeout(commitTimeout)
         .withRunloopTimeout(runloopTimeout)
         .withProperties(
           ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "earliest",
@@ -187,6 +189,7 @@ object KafkaTestUtils {
     allowAutoCreateTopics: Boolean = true,
     diagnostics: Diagnostics = Diagnostics.NoOp,
     restartStreamOnRebalancing: Boolean = false,
+    commitTimeout: Duration = ConsumerSettings.defaultCommitTimeout,
     properties: Map[String, String] = Map.empty
   ): ZLayer[Kafka, Throwable, Consumer] =
     (ZLayer(
@@ -197,7 +200,8 @@ object KafkaTestUtils {
         allowAutoCreateTopics = allowAutoCreateTopics,
         offsetRetrieval = offsetRetrieval,
         restartStreamOnRebalancing = restartStreamOnRebalancing,
-        properties = properties
+        properties = properties,
+        commitTimeout = commitTimeout
       )
     ) ++ ZLayer.succeed(diagnostics)) >>> Consumer.live
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -157,6 +157,8 @@ trait Consumer {
 object Consumer {
   case object RunloopTimeout extends RuntimeException("Timeout in Runloop") with NoStackTrace
 
+  case object CommitTimeout extends RuntimeException("Commit timeout") with NoStackTrace
+
   private final class Live private[Consumer] (
     consumer: ConsumerAccess,
     runloopAccess: RunloopAccess

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -25,6 +25,7 @@ final case class ConsumerSettings(
   properties: Map[String, AnyRef] = Map.empty,
   closeTimeout: Duration = 30.seconds,
   pollTimeout: Duration = 50.millis,
+  commitTimeout: Duration = ConsumerSettings.defaultCommitTimeout,
   offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
   rebalanceListener: RebalanceListener = RebalanceListener.noop,
   restartStreamOnRebalancing: Boolean = false,
@@ -47,6 +48,9 @@ final case class ConsumerSettings(
 
   def withCloseTimeout(timeout: Duration): ConsumerSettings =
     copy(closeTimeout = timeout)
+
+  def withCommitTimeout(timeout: Duration): ConsumerSettings =
+    copy(commitTimeout = timeout)
 
   def withClientId(clientId: String): ConsumerSettings =
     withProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientId)
@@ -127,4 +131,5 @@ final case class ConsumerSettings(
 
 object ConsumerSettings {
   val defaultRunloopTimeout: Duration = 4.minutes
+  val defaultCommitTimeout: Duration  = 15.seconds
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -88,6 +88,7 @@ private[consumer] object RunloopAccess {
                         hasGroupId = settings.hasGroupId,
                         consumer = consumerAccess,
                         pollTimeout = settings.pollTimeout,
+                        commitTimeout = settings.commitTimeout,
                         diagnostics = diagnostics,
                         offsetRetrieval = settings.offsetRetrieval,
                         userRebalanceListener = settings.rebalanceListener,


### PR DESCRIPTION
This PR adds commit timeout to `ConsumerSettings` with default set to 15 seconds. Discussed in  #852