### PR TITLE
Fix: Runloop might be suspended when assigned with many partitions

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -554,9 +554,6 @@ private[consumer] object Runloop {
     ) extends RebalanceEvent
   }
 
-  // Internal parameters, should not be necessary to tune
-  private final val commandQueueSize: Int = 1024
-
   def make(
     hasGroupId: Boolean,
     consumer: ConsumerAccess,
@@ -572,7 +569,7 @@ private[consumer] object Runloop {
   ): URIO[Scope, Runloop] =
     for {
       _                  <- ZIO.addFinalizer(diagnostics.emit(Finalization.RunloopFinalized))
-      commandQueue       <- ZIO.acquireRelease(Queue.bounded[RunloopCommand](commandQueueSize))(_.shutdown)
+      commandQueue       <- ZIO.acquireRelease(Queue.unbounded[RunloopCommand])(_.shutdown)
       lastRebalanceEvent <- Ref.Synchronized.make[Option[Runloop.RebalanceEvent]](None)
       initialState = State.initial
       currentStateRef <- Ref.make(initialState)


### PR DESCRIPTION
 - The Runloop command queue is a bounded queue, with a fixed size of 1024
 - The Runloop stream takes commands from the queue, process them and offer a new `Poll` command into the stream (when applicable).
 - The `.offer` can suspend the fiber when the command queue is already full. this, in turn, makes the entire stream freeze. the underlying kafka consumer will eventually (after `max.poll.interval.ms`) be dropped from the group without any notification to the zstream.
 - to fix this, we can change the command queue from bounded to unbounded which will not suspend the fiber that adds the `Poll` command