### PR TITLE
Fix signature of Producer#produceAll

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -41,7 +41,7 @@ trait Producer {
   def produceAll[R, K, V](
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V]
-  ): ZPipeline[R & Producer, Throwable, ProducerRecord[K, V], RecordMetadata] =
+  ): ZPipeline[R, Throwable, ProducerRecord[K, V], RecordMetadata] =
     ZPipeline.mapChunksZIO(records => produceChunk(records, keySerializer, valueSerializer))
 
   /**


### PR DESCRIPTION
This tiny PR removes `Producer` service from environment of `Producer#produceAll` - probably it was left there by accident. Without fix method cannot be used with Module 2.0 pattern 