### PR TITLE
Add `Consumer.commit` and `Consumer.commitOrRetry` methods

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
@@ -38,6 +38,8 @@ final case class CommittableRecord[K, V](
   def partition: Int  = record.partition()
   def timestamp: Long = record.timestamp()
 
+  lazy val topicPartition: TopicPartition = new TopicPartition(record.topic(), record.partition())
+
   def offset: Offset =
     OffsetImpl(
       topic = record.topic(),

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -37,6 +37,8 @@ trait Consumer {
     timeout: Duration = Duration.Infinity
   ): Task[Map[TopicPartition, Long]]
 
+  def commit(record: CommittableRecord[_, _]): Task[Unit]
+
   /**
    * Retrieve the last committed offset for the given topic-partitions
    */
@@ -440,6 +442,9 @@ private[consumer] final class ConsumerLive private[consumer] (
       val offs = eo.endOffsets(partitions.asJava, timeout.asJava)
       offs.asScala.map { case (k, v) => k -> v.longValue() }.toMap
     }
+
+  override def commit(record: CommittableRecord[_, _]): Task[Unit] =
+    runloopAccess.commit(record)
 
   override def committed(
     partitions: Set[TopicPartition],

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -115,6 +115,9 @@ private[consumer] final class Runloop private (
     }
   }
 
+  private[internal] def commit(record: CommittableRecord[_, _]): Task[Unit] =
+    commit.apply(Map(record.topicPartition -> record.record.offset()))
+
   private val commit: Map[TopicPartition, Long] => Task[Unit] =
     offsets =>
       for {


### PR DESCRIPTION
First step toward removing the `Offset` trait atrocity and the current OOP orientation of the commit interface proposed by zio-kafka (ie. `record.offset.commit`. This is non sense which pisses me off TBH)