### PR TITLE
Fix `Consumer.fromJavaConsumer` and `Producer.fromJavaProducer` type signatures

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -3,7 +3,6 @@ package zio.kafka.consumer
 import org.apache.kafka.clients.consumer.{
   Consumer => JConsumer,
   ConsumerRecord,
-  KafkaConsumer,
   OffsetAndMetadata,
   OffsetAndTimestamp
 }
@@ -191,22 +190,6 @@ object Consumer {
    * Create a zio-kafka Consumer from an org.apache.kafka KafkaConsumer
    *
    * You are responsible for creating and closing the KafkaConsumer
-   */
-  def fromJavaConsumer(
-    javaConsumer: KafkaConsumer[Array[Byte], Array[Byte]],
-    settings: ConsumerSettings,
-    diagnostics: Diagnostics = Diagnostics.NoOp
-  ): ZIO[Scope, Throwable, Consumer] =
-    for {
-      _              <- ZIO.addFinalizer(diagnostics.emit(Finalization.ConsumerFinalized))
-      consumerAccess <- ConsumerAccess.make(javaConsumer)
-      runloopAccess  <- RunloopAccess.make(settings, consumerAccess, diagnostics)
-    } yield new ConsumerLive(consumerAccess, runloopAccess)
-
-  /**
-   * Create a zio-kafka Consumer from an org.apache.kafka Consumer
-   *
-   * You are responsible for creating and closing the Consumer
    */
   def fromJavaConsumer(
     javaConsumer: JConsumer[Array[Byte], Array[Byte]],

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -212,25 +212,6 @@ object Producer {
    * You are responsible for creating and closing the KafkaProducer
    */
   def fromJavaProducer(
-    javaProducer: KafkaProducer[Array[Byte], Array[Byte]],
-    settings: ProducerSettings
-  ): ZIO[Scope, Throwable, Producer] =
-    for {
-      runtime <- ZIO.runtime[Any]
-      sendQueue <-
-        Queue.bounded[(Chunk[ByteRecord], Promise[Nothing, Chunk[Either[Throwable, RecordMetadata]]])](
-          settings.sendBufferSize
-        )
-      producer = new ProducerLive(javaProducer, runtime, sendQueue)
-      _ <- ZIO.blocking(producer.sendFromQueue).forkScoped
-    } yield producer
-
-  /**
-   * Create a zio-kafka Producer from an existing org.apache.kafka Producer
-   *
-   * You are responsible for creating and closing the Producer
-   */
-  def fromJavaProducer(
     javaProducer: JProducer[Array[Byte], Array[Byte]],
     settings: ProducerSettings
   ): ZIO[Scope, Throwable, Producer] =


### PR DESCRIPTION
Found the issue while trying to wrap the kafka Consumer and Producer with KafkaTelemetry to integrat Open Telemetry for tracing.

Added a pair of convenient methods.