### PR TITLE
Bootstrap servers is regular config

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -1513,9 +1513,9 @@ object AdminClient {
   def javaClientFromSettings(settings: AdminClientSettings): ZIO[Scope, Throwable, JAdmin] =
     ZIO.acquireRelease {
       val endpointCheck = SslHelper
-        .validateEndpoint(settings.bootstrapServers, settings.properties)
+        .validateEndpoint(settings.properties)
 
-      endpointCheck *> ZIO.attempt(JAdmin.create(settings.driverSettings.asJava))
+      endpointCheck *> ZIO.attempt(JAdmin.create(settings.properties.asJava))
     }(client => ZIO.attemptBlocking(client.close(settings.closeTimeout)).orDie)
 
   implicit final class MapOps[K1, V1](private val v: Map[K1, V1]) extends AnyVal {

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClientSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClientSettings.scala
@@ -5,13 +5,11 @@ import zio._
 import zio.kafka.security.KafkaCredentialStore
 
 final case class AdminClientSettings(
-  bootstrapServers: List[String],
   closeTimeout: Duration,
   properties: Map[String, AnyRef]
 ) {
-  def driverSettings: Map[String, AnyRef] =
-    Map(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServers.mkString(",")) ++
-      properties
+  def withBootstrapServers(servers: List[String]): AdminClientSettings =
+    withProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, servers.mkString(","))
 
   def withProperty(key: String, value: AnyRef): AdminClientSettings =
     copy(properties = properties + (key -> value))
@@ -29,8 +27,7 @@ final case class AdminClientSettings(
 object AdminClientSettings {
   def apply(bootstrapServers: List[String]): AdminClientSettings =
     AdminClientSettings(
-      bootstrapServers = bootstrapServers,
       closeTimeout = 30.seconds,
       properties = Map.empty
-    )
+    ).withBootstrapServers(bootstrapServers)
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -181,7 +181,7 @@ object Consumer {
   ): ZIO[Scope, Throwable, Consumer] =
     for {
       _              <- ZIO.addFinalizer(diagnostics.emit(Finalization.ConsumerFinalized))
-      _              <- SslHelper.validateEndpoint(settings.bootstrapServers, settings.properties)
+      _              <- SslHelper.validateEndpoint(settings.driverSettings)
       consumerAccess <- ConsumerAccess.make(settings)
       runloopAccess  <- RunloopAccess.make(settings, consumerAccess, diagnostics)
     } yield new ConsumerLive(consumerAccess, runloopAccess)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -21,7 +21,6 @@ import zio.kafka.security.KafkaCredentialStore
  *   the Kafka bootstrap servers
  */
 final case class ConsumerSettings(
-  bootstrapServers: List[String],
   properties: Map[String, AnyRef] = Map.empty,
   closeTimeout: Duration = 30.seconds,
   pollTimeout: Duration = 50.millis,
@@ -39,12 +38,11 @@ final case class ConsumerSettings(
 
   def driverSettings: Map[String, AnyRef] =
     Map(
-      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG  -> bootstrapServers.mkString(","),
       ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG -> "false"
     ) ++ autoOffsetResetConfig ++ properties
 
   def withBootstrapServers(servers: List[String]): ConsumerSettings =
-    copy(bootstrapServers = servers)
+    withProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, servers.mkString(","))
 
   def withCloseTimeout(timeout: Duration): ConsumerSettings =
     copy(closeTimeout = timeout)
@@ -140,4 +138,7 @@ final case class ConsumerSettings(
 object ConsumerSettings {
   val defaultRunloopTimeout: Duration = 4.minutes
   val defaultCommitTimeout: Duration  = 15.seconds
+
+  def apply(bootstrapServers: List[String]) =
+    new ConsumerSettings().withBootstrapServers(bootstrapServers)
 }

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -192,12 +192,11 @@ object Producer {
 
   def make(settings: ProducerSettings): ZIO[Scope, Throwable, Producer] =
     for {
-      props <- ZIO.attempt(settings.driverSettings)
-      _     <- SslHelper.validateEndpoint(settings.bootstrapServers, props)
+      _ <- SslHelper.validateEndpoint(settings.properties)
       rawProducer <- ZIO.acquireRelease(
                        ZIO.attempt(
                          new KafkaProducer[Array[Byte], Array[Byte]](
-                           props.asJava,
+                           settings.properties.asJava,
                            new ByteArraySerializer(),
                            new ByteArraySerializer()
                          )

--- a/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
@@ -5,17 +5,12 @@ import zio._
 import zio.kafka.security.KafkaCredentialStore
 
 final case class ProducerSettings(
-  bootstrapServers: List[String],
   closeTimeout: Duration = 30.seconds,
   sendBufferSize: Int = 4096,
   properties: Map[String, AnyRef] = Map.empty
 ) {
-  def driverSettings: Map[String, AnyRef] =
-    Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServers.mkString(",")) ++
-      properties
-
   def withBootstrapServers(servers: List[String]): ProducerSettings =
-    copy(bootstrapServers = servers)
+    withProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, servers.mkString(","))
 
   def withClientId(clientId: String): ProducerSettings =
     withProperty(ProducerConfig.CLIENT_ID_CONFIG, clientId)
@@ -36,4 +31,11 @@ final case class ProducerSettings(
     withProperties(credentialsStore.properties)
 
   def withSendBufferSize(sendBufferSize: Int) = copy(sendBufferSize = sendBufferSize)
+}
+
+object ProducerSettings {
+  def apply(
+    bootstrapServers: List[String]
+  ): ProducerSettings =
+    ProducerSettings().withBootstrapServers(bootstrapServers)
 }

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -85,11 +85,10 @@ object TransactionalProducer {
 
   def make(settings: TransactionalProducerSettings): ZIO[Scope, Throwable, TransactionalProducer] =
     for {
-      props <- ZIO.attempt(settings.producerSettings.driverSettings)
       rawProducer <- ZIO.acquireRelease(
                        ZIO.attempt(
                          new KafkaProducer[Array[Byte], Array[Byte]](
-                           props.asJava,
+                           settings.producerSettings.properties.asJava,
                            new ByteArraySerializer(),
                            new ByteArraySerializer()
                          )

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
@@ -14,11 +14,10 @@ object TransactionalProducerSettings {
   def apply(bootstrapServers: List[String], transactionalId: String): TransactionalProducerSettings =
     TransactionalProducerSettings(
       ProducerSettings(
-        bootstrapServers,
         30.seconds,
         4096,
         Map(ProducerConfig.TRANSACTIONAL_ID_CONFIG -> transactionalId)
-      )
+      ).withBootstrapServers(bootstrapServers)
     )
 
   def apply(
@@ -30,10 +29,9 @@ object TransactionalProducerSettings {
   ): TransactionalProducerSettings =
     TransactionalProducerSettings(
       ProducerSettings(
-        bootstrapServers,
         closeTimeout,
         sendBufferSize,
         properties.updated(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
-      )
+      ).withBootstrapServers(bootstrapServers)
     )
 }

--- a/zio-kafka/src/main/scala/zio/kafka/utils/SslHelper.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/SslHelper.scala
@@ -1,6 +1,6 @@
 package zio.kafka.utils
 
-import org.apache.kafka.clients.{ ClientDnsLookup, ClientUtils }
+import org.apache.kafka.clients.{ ClientDnsLookup, ClientUtils, CommonClientConfigs }
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.network.TransferableChannel
 import org.apache.kafka.common.protocol.ApiKeys
@@ -32,6 +32,15 @@ object SslHelper {
   private final case class ConnectionError(cause: Throwable) extends NoStackTrace
 
   // ⚠️ Must not do anything else than calling `doValidateEndpoint`. The algorithm of this function must be completely contained in `doValidateEndpoint`.
+  def validateEndpoint(props: Map[String, AnyRef]): IO[KafkaException, Unit] = {
+    val bootstrapServers = props.get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG) match {
+      case Some(config) => config.toString.split(",").toList
+      case None         => List.empty
+    }
+    validateEndpoint(bootstrapServers, props)
+  }
+
+  // ⚠️ Must not do anything else than calling `doValidateEndpoint`. The algorithm of this function must be completely contained in `doValidateEndpoint`.
   def validateEndpoint(bootstrapServers: List[String], props: Map[String, AnyRef]): IO[KafkaException, Unit] =
     doValidateEndpoint(SocketChannel.open)(bootstrapServers, props)
 
@@ -44,7 +53,7 @@ object SslHelper {
     @inline def `request.timeout.ms`: Duration = {
       val defaultValue = 30.seconds
 
-      props.get("request.timeout.ms") match {
+      props.get(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG) match {
         case None => defaultValue
         case Some(raw) =>
           try {
@@ -61,7 +70,7 @@ object SslHelper {
       ZIO
         .unless(
           props
-            .get("security.protocol")
+            .get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)
             .exists {
               case x: String if x.toUpperCase().contains("SSL") => true
               case _                                            => false


### PR DESCRIPTION
This change is because when updating to the latest version of zio-kafka I started getting errors about having no bootstrap servers. This is because in my config, the servers are already represented as a comma delimited String. I didn't want to have to do 

```
ProducerSettings(myConfig.get("bootstrap.servers").split(",")).withProperties(myConfig)
```

What I have is 
```
ProducerSettings(List.empty).withProperties(myConfig)
```

Now, the Producer respects this, because it works on the config. But the SSLHelper is using the explicitly provided bootstrap servers list and so fails. 

The current model is also a little broken because you can do:
```
producerSettings.withProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092")
```
and the producer and SSLHelper use different values for what the servers are.

If this seems reasonable, the same change needs to be made to Admin and Consumer wiring up as well.

side note: I do wonder if the SSLHelper should be another producer setting which is enabled by default, but we can turn it off.