### PR TITLE
Replace pending requests by single boolean

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -351,7 +351,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
       },
       test("handle rebalancing by completing topic-partition streams") {
         val nrMessages   = 50
-        val nrPartitions = 6
+        val nrPartitions = 6 // Must be even and strictly positive
 
         for {
           // Produce messages on several partitions
@@ -1142,6 +1142,9 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           test(
             "it's possible to start a new consumption session from a Consumer that had a consumption session stopped previously"
           ) {
+            // NOTE:
+            // When this test fails with the message `100000 was not less than 100000`, it's because
+            // your computer is so fast that the first consumer already consumed all 100000 messages.
             val numberOfMessages: Int           = 100000
             val kvs: Iterable[(String, String)] = Iterable.tabulate(numberOfMessages)(i => (s"key-$i", s"msg-$i"))
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
@@ -7,10 +7,10 @@ sealed trait DiagnosticEvent
 object DiagnosticEvent {
 
   final case class Poll(
-    tpRequested: Set[TopicPartition],
     tpWithData: Set[TopicPartition],
     tpWithoutData: Set[TopicPartition]
   ) extends DiagnosticEvent
+
   final case class Request(partition: TopicPartition) extends DiagnosticEvent
 
   sealed trait Commit extends DiagnosticEvent

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -64,7 +64,7 @@ object PartitionStreamControl {
       queueSize           <- Ref.make(0)
       requestAndAwaitData =
         for {
-          _     <- commandQueue.offer(RunloopCommand.Request(tp))
+          _     <- commandQueue.offer(RunloopCommand.Poll)
           _     <- diagnostics.emit(DiagnosticEvent.Request(tp))
           taken <- dataQueue.takeBetween(1, Int.MaxValue)
         } yield taken

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -451,7 +451,7 @@ private[consumer] final class Runloop private (
    *   - Poll periodically when we are subscribed but do not have assigned streams yet. This happens after
    *     initialization and rebalancing
    */
-  def run(initialState: State): ZIO[Scope, Throwable, Any] = {
+  private def run(initialState: State): ZIO[Scope, Throwable, Any] = {
     import Runloop.StreamOps
 
     ZStream

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
@@ -13,19 +13,17 @@ object RunloopCommand {
   /** Used for internal control of the stream of data from Kafka. */
   sealed trait StreamCommand extends RunloopCommand
 
-  /** Used as a signal that another poll is needed. */
-  case object Poll extends Control
+  case object StopRunloop extends Control
 
-  case object StopRunloop    extends Control
   case object StopAllStreams extends StreamCommand
+
+  /** Used as a signal that another poll is needed. */
+  case object Poll extends StreamCommand
 
   final case class Commit(offsets: Map[TopicPartition, Long], cont: Promise[Throwable, Unit]) extends StreamCommand {
     @inline def isDone: UIO[Boolean]    = cont.isDone
     @inline def isPending: UIO[Boolean] = isDone.negate
   }
-
-  /** Used by a stream to request more records. */
-  final case class Request(tp: TopicPartition) extends StreamCommand
 
   final case class AddSubscription(subscription: Subscription, cont: Promise[InvalidSubscriptionUnion, Unit])
       extends StreamCommand {


### PR DESCRIPTION
Since streams now wait for data by listening to their own queue, we no longer need to keep track of pending requests inside runloop. Instead:
- streams initiate a poll when they need data,
- runloop initiates another poll when not all streams got data.

Runloop still needs to know which streams need data. For this `def awaitingData` was added to the stream.

The advantage of this approach is:
* Less likely to go wrong (calculating pendingRequests is not trivial).
* The 'awaiting data state' is less implicit because it moved from runloop to stream.
* Slightly less pressure on the garbage collector because results from partition calculations are kept for a very short time (they are no longer kept until the next run loop).

Also:
* Removed field `tpRequested` from `DiagnosticEvent.Poll`.
* Class/object `State` is moved into `object Runloop` to hide it for the rest of the package.
