### PR TITLE
Automatically merge commits

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
@@ -16,13 +16,11 @@ object RunloopCommand {
   /** Used as a signal that another poll is needed. */
   case object Poll extends Control
 
+  /** Used as a signal to the poll-loop that commits are available in the commit-queue. */
+  case object CommitAvailable extends Control
+
   case object StopRunloop    extends Control
   case object StopAllStreams extends StreamCommand
-
-  final case class Commit(offsets: Map[TopicPartition, Long], cont: Promise[Throwable, Unit]) extends StreamCommand {
-    @inline def isDone: UIO[Boolean]    = cont.isDone
-    @inline def isPending: UIO[Boolean] = isDone.negate
-  }
 
   /** Used by a stream to request more records. */
   final case class Request(tp: TopicPartition) extends StreamCommand

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
@@ -16,11 +16,13 @@ object RunloopCommand {
   /** Used as a signal that another poll is needed. */
   case object Poll extends Control
 
-  /** Used as a signal to the poll-loop that commits are available in the commit-queue. */
-  case object CommitAvailable extends Control
-
   case object StopRunloop    extends Control
   case object StopAllStreams extends StreamCommand
+
+  final case class Commit(offsets: Map[TopicPartition, Long], cont: Promise[Throwable, Unit]) extends RunloopCommand {
+    @inline def isDone: UIO[Boolean]    = cont.isDone
+    @inline def isPending: UIO[Boolean] = isDone.negate
+  }
 
   /** Used by a stream to request more records. */
   final case class Request(tp: TopicPartition) extends StreamCommand


### PR DESCRIPTION
The commit throughput that is supported by Kafka brokers is much lower than the consume throughput. Therefore, to retain a high consume throughput it is important that not every record's offset is committed. In this PR we automatically merge all commits that were generated in the course of a single run of the runloop. This frees users from having to merge streams and do the commit merging themselves.