### PR TITLE
Add instructions for pruning the benchmark history

### DIFF
--- a/docs/prune-benchmark-history.md
+++ b/docs/prune-benchmark-history.md
@@ -1,0 +1,16 @@
+# Pruning the benchmarks report page
+
+Benchmarks are run on every commit, even in pull requests. This causes the historic graphs on
+https://zio.github.io/zio-kafka/dev/bench/ to contain so many results that it becomes unreadable. Rather than limiting
+the number of items in the graph (which is supported by the github action that generates the page), we keep the
+benchmark results of _all_ master commits, but only keep 1 month of pull request commits.
+
+The process is currently manual. Here are the instructions:
+
+* Make sure `jq` is installed
+* Checkout the `gh-pages` branch
+* Execute the following command in the root of the project:
+  ```shell
+  scripts/prune-benchmark-history.sh
+  ```
+* Commit and push changes


### PR DESCRIPTION
Mentioned shell script was already pushed to the gh-pages branch in https://github.com/zio/zio-kafka/commit/576a196496aaa98a73d679813905628048fd212f