### PR TITLE
Prevent double logging in tests

### DIFF
--- a/zio-kafka-test/src/test/resources/logback.xml
+++ b/zio-kafka-test/src/test/resources/logback.xml
@@ -14,6 +14,10 @@
     <logger name="com.yammer.metrics" level="ERROR"/>
     <logger name="kafka" level="ERROR" />
 
+    <!-- Some useful loggers to configure while debugging tests: -->
+    <logger name="zio.kafka" level="INFO" />
+    <logger name="zio.kafka.consumer.ConsumerSpec" level="INFO" />
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/zio-kafka-test/src/test/scala/zio/kafka/ZIOSpecDefaultSlf4j.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ZIOSpecDefaultSlf4j.scala
@@ -11,7 +11,9 @@ import zio.test.{ TestAspect, TestAspectAtLeastR, TestEnvironment, ZIOSpecDefaul
  */
 abstract class ZIOSpecDefaultSlf4j extends ZIOSpecDefault {
 
+  private val loggerLayer = SLF4J.slf4j
+
   override def aspects: Chunk[TestAspectAtLeastR[TestEnvironment]] =
-    super.aspects :+ TestAspect.fromLayer(zio.Runtime.removeDefaultLoggers >>> SLF4J.slf4j)
+    super.aspects :+ TestAspect.fromLayer(zio.Runtime.removeDefaultLoggers >>> loggerLayer)
 
 }


### PR DESCRIPTION
Also: add some useful loggers in the logback configuration.