### PR TITLE
Always end streams in rebalance listener, support lost partitions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import sbt.Def
 lazy val kafkaVersion         = "3.6.0"
 lazy val embeddedKafkaVersion = "3.6.0" // Should be the same as kafkaVersion, except for the patch part
 
-lazy val kafkaClients          = "org.apache.kafka"           % "kafka-clients"           % kafkaVersion
-lazy val scalaCollectionCompat = "org.scala-lang.modules"    %% "scala-collection-compat" % "2.11.0"
-lazy val logback               = "ch.qos.logback"             % "logback-classic"         % "1.3.11"
+lazy val kafkaClients          = "org.apache.kafka"        % "kafka-clients"           % kafkaVersion
+lazy val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0"
+lazy val logback               = "ch.qos.logback"          % "logback-classic"         % "1.3.11"
 
 enablePlugins(ZioSbtEcosystemPlugin, ZioSbtCiPlugin)
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -854,6 +854,8 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           _ <- ZIO.foreachDiscard((nrMessages + 1) to (2 * nrMessages)) { i =>
                  produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
                }
+          // Give the consumers some time
+          _ <- ZIO.sleep(500.millis)
           _ <- fib2.join
           _ <- ZIO.logDebug("Consumer 2 done")
           _ <- fib.join

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -854,10 +854,10 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           _ <- ZIO.foreachDiscard((nrMessages + 1) to (2 * nrMessages)) { i =>
                  produceMany(topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
                }
-          // Give the consumers some time
-          _ <- ZIO.sleep(500.millis)
           _ <- fib2.join
           _ <- ZIO.logDebug("Consumer 2 done")
+          // Give consumer 1 some time to consume the rest
+          _ <- ZIO.sleep(500.millis)
           _ <- fib.join
           _ <- ZIO.logDebug("Consumer 1 done")
           // fib2 terminates after 20 messages, fib terminates after fib2 because of the rebalancing (drainCount==2)

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -739,17 +739,19 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
       },
       test("restartStreamsOnRebalancing mode closes all partition streams") {
         // Test plan:
-        // - Throughout the test, continuously produce to all partitions of a topics.
-        // - Start consumer 1,
-        //   - track which partitions are assigned after each rebalance.
-        //   - track which streams stopped
+        // - Throughout the test, continuously produce to all partitions of a topic.
+        // - Start consumer 1:
+        //   - track which partitions are assigned after each rebalance,
+        //   - track which streams stopped.
         // - Start consumer 2 but finish after just a few records. This results in 2 rebalances for consumer 1.
         // - Verify that in the first rebalance, consumer 1 ends the streams for _all_ partitions,
-        //   and starts them again.
+        //   and then starts them again.
         //
         // NOTE: we need to use the cooperative sticky assignor. The default assignor `ConsumerPartitionAssignor`,
-        // revokes all partitions and re-assigns them on every rebalance, so the behavior for
-        // `restartStreamOnRebalancing` is already the default.
+        // revokes all partitions and re-assigns them on every rebalance. This means that all streams are restarted
+        // on every rebalance, exactly what `restartStreamOnRebalancing` would have caused. In other words, with the
+        // default assignor the externally visible behavior is the same, regardless of whether
+        // `restartStreamOnRebalancing` is `true` or `false`.
 
         val nrPartitions = 5
         val partitionIds = Chunk.fromIterable(0 until nrPartitions)

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -807,7 +807,6 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           _ <- ZIO
                  .foreach(messagesReceived.values)(_.get)
                  .map(_.sum)
-                 .debug("Messages received by Fib1: ")
                  .repeat(Schedule.recurUntil((n: Int) => n == nrMessages) && Schedule.fixed(100.millis))
 
           // Starting a new consumer that will stop after receiving 20 messages, causing two rebalancing events for fib1
@@ -833,8 +832,8 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                     .fork
 
           // Waiting until fib1's partition streams got restarted because of the rebalancing
-          // Note: on fast computers we may not never see `drainCount == 1` but `2` immediately, therefore we need to
-          // check for `drainCount >= 1`.
+          // Note: on fast computers we may never see `drainCount == 1` but `2` immediately, therefore we need to check
+          // for `drainCount >= 1`.
           _ <- drainCount.get.repeat(Schedule.recurUntil((_: Int) >= 1) && Schedule.fixed(100.millis))
           _ <- ZIO.logDebug("Consumer 1 finished rebalancing")
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -857,7 +857,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           _ <- fib2.join
           _ <- ZIO.logDebug("Consumer 2 done")
           // Give consumer 1 some time to consume the rest
-          _ <- ZIO.sleep(500.millis)
+          _ <- ZIO.sleep(1.second)
           _ <- fib.join
           _ <- ZIO.logDebug("Consumer 1 done")
           // fib2 terminates after 20 messages, fib terminates after fib2 because of the rebalancing (drainCount==2)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -72,8 +72,10 @@ final class PartitionStreamControl private (
     queueInfoRef.get.map(_.deadlineExceeded(now))
 
   /** To be invoked when the partition was lost. */
-  private[internal] def lost: UIO[Boolean] =
-    interruptionPromise.fail(new RuntimeException(s"Partition ${tp.toString} was lost"))
+  private[internal] def lost: UIO[Boolean] = {
+    val lostException = new RuntimeException(s"Partition ${tp.toString} was lost") with NoStackTrace
+    interruptionPromise.fail(lostException)
+  }
 
   /** To be invoked when the stream is no longer processing. */
   private[internal] def halt: UIO[Boolean] = {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -294,7 +294,6 @@ private[consumer] final class Runloop private (
                s" resuming ${partitionsToFetch} partitions"
            )
       _ <- currentStateRef.set(state)
-      _ <- lastRebalanceEvent.set(RebalanceEvent.None)
       pollResult <-
         consumer.runloopAccess { c =>
           ZIO.suspend {
@@ -317,7 +316,7 @@ private[consumer] final class Runloop private (
                 tpWithoutData = requestedPartitions -- providedTps
               )
             } *>
-              lastRebalanceEvent.get.flatMap {
+              lastRebalanceEvent.getAndSet(RebalanceEvent.None).flatMap {
                 case RebalanceEvent(false, _, _, _, _) =>
                   // The fast track, rebalance listener was not invoked:
                   //   no assignment changes, only new records.


### PR DESCRIPTION
Previously, streams would only be ended in the rebalance listener for revoked partitions. Now, they are ended there even when `restartStreamsOnRebalancing` is used.

Lost partitions are no longer treated as being revoked. With this change, streams of lost partitions are interrupted. Interrupting them prevents these streams from processing and committing more data.

A nice side effect is that Zio-kafka is now faster when the rebalance listener was _not_ called; the 'fast track'.

The main reason for this change is to prepare awaiting commits from within the rebalance listener which will prevent duplicate consuming of records (see #830).

Also: fix test `restartStreamsOnRebalancing mode closes all partition streams` so that it detects rebalances properly on fast computers.