### PR TITLE
Make `partitionPreFetchBufferLimit` value `0` disable prefetching

### DIFF
--- a/docs/consumer-tuning.md
+++ b/docs/consumer-tuning.md
@@ -29,8 +29,8 @@ The most important settings for tuning throughput and latency are:
 * kafka's [configuration `max.poll.records`](https://kafka.apache.org/documentation/#consumerconfigs_max.poll.records) — The maximum number of records a poll will return. Kafka defaults
   this to `500`. You can set this higher for more throughput, or lower for lower latency.
 * zio-kafka's fetch-strategy `partitionPreFetchBufferLimit` — when the number of records in a partition queue is
-  below this value, zio-kafka will start to pre-fetch and buffer more records from Kafka. The default value for this
-  parameter is `1024`; 2 * the default `max.poll.records` of 500, rounded to the nearest power of 2.
+  at or below this value, zio-kafka will start to pre-fetch and buffer more records from Kafka. The default value for
+  this parameter is `1024`; 2 * the default `max.poll.records` of 500, rounded to the nearest power of 2.
 
 Zio-kafka provides 2 methods that set these settings for 2 common use cases: `ConsumerSettings.tuneForHighThroughput`
 and `ConsumerSettings.tuneForLowLatency`.

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -351,11 +351,11 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             c1 <- consumer
                     .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
                     // consumer timeout detection is done per chunk, sleep for some seconds to simulate
-                    // a consumer that is stuck. Note: we only sleep for the very first chunk.
+                    // a consumer that is stuck.
                     .chunksWith(
                       _.tap { c =>
                         ZIO.logDebug(s"chunk of ${c.size} elements") *>
-                          ZIO.sleep(4.seconds).when(c.head.key == "key0")
+                          ZIO.sleep(4.seconds)
                       }
                     )
                     // Use `take` to ensure the test ends quickly, even when the interrupt fails to occur.

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -336,7 +336,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                           maxPollInterval = 1.second,
                           `max.poll.records` = 2
                         )
-                          .map(_.withPollTimeout(50.millis))
+                          .map(_.withPollTimeout(50.millis).withPartitionPreFetchBufferLimit(0))
             consumer <- Consumer.make(settings)
             _        <- scheduledProduce(topic1, Schedule.fixed(50.millis).jittered).runDrain.forkScoped
             _        <- scheduledProduce(topic2, Schedule.fixed(200.millis).jittered).runDrain.forkScoped

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -377,7 +377,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             subscriptions.isEmpty
           )
         }
-      } @@ flaky(3),
+      },
       test("a slow producer doesnot interrupt the stream") {
         ZIO.scoped {
           for {

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -377,7 +377,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             subscriptions.isEmpty
           )
         }
-      },
+      } @@ flaky(3),
       test("a slow producer doesnot interrupt the stream") {
         ZIO.scoped {
           for {

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/fetch/QueueSizeBasedFetchStrategySpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/fetch/QueueSizeBasedFetchStrategySpec.scala
@@ -18,19 +18,19 @@ object QueueSizeBasedFetchStrategySpec extends ZIOSpecDefaultSlf4j {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("QueueSizeBasedFetchStrategySpec")(
       test("stream with queue size above limit is paused") {
-        val streams = Chunk(newStream(tp10, currentQueueSize = 100))
+        val streams = Chunk(newStream(tp10, currentQueueSize = partitionPreFetchBufferLimit + 1))
         for {
           result <- fetchStrategy.selectPartitionsToFetch(streams)
         } yield assertTrue(result.isEmpty)
       },
-      test("stream with queue size equal to limit is paused") {
+      test("stream with queue size equal to limit may resume") {
         val streams = Chunk(newStream(tp10, currentQueueSize = partitionPreFetchBufferLimit))
         for {
           result <- fetchStrategy.selectPartitionsToFetch(streams)
-        } yield assertTrue(result.isEmpty)
+        } yield assertTrue(result == Set(tp10))
       },
       test("stream with queue size below limit may resume") {
-        val streams = Chunk(newStream(tp10, currentQueueSize = 10))
+        val streams = Chunk(newStream(tp10, currentQueueSize = partitionPreFetchBufferLimit - 1))
         for {
           result <- fetchStrategy.selectPartitionsToFetch(streams)
         } yield assertTrue(result == Set(tp10))

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -177,7 +177,7 @@ final case class ConsumerSettings(
   /**
    * Disables partition record pre-fetching.
    */
-  def withoutPartitionPreFetching(): ConsumerSettings =
+  def withoutPartitionPreFetching: ConsumerSettings =
     withPartitionPreFetchBufferLimit(0)
 
   @deprecated("Use withPartitionPreFetchBufferLimit instead", "2.6.0")

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -164,7 +164,7 @@ final case class ConsumerSettings(
    *   values effectively disable backpressure at the cost of high memory usage, low values will effectively disable
    *   prefetching in favor of low memory consumption. The number of records that is fetched on every poll is controlled
    *   by the `max.poll.records` setting, the number of records fetched for every partition is somewhere between 0 and
-   *   `max.poll.records`. A value that is a power of 2 offers somewhat better queueing performance.
+   *   `max.poll.records`.
    *
    * The default value for this parameter is 1024. It is calculated by taking 2 * the default `max.poll.records` of 500,
    * rounded to the nearest power of 2.

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -159,18 +159,26 @@ final case class ConsumerSettings(
 
   /**
    * @param partitionPreFetchBufferLimit
-   *   The queue size below which more records are fetched and buffered (per partition). This buffer improves throughput
-   *   and supports varying downstream message processing time, while maintaining some backpressure. Large values
-   *   effectively disable backpressure at the cost of high memory usage, low values will effectively disable
-   *   prefetching in favour of low memory consumption. The number of records that is fetched on every poll is
-   *   controlled by the `max.poll.records` setting, the number of records fetched for every partition is somewhere
-   *   between 0 and `max.poll.records`. A value that is a power of 2 offers somewhat better queueing performance.
+   *   The queue size at or below which more records are fetched and buffered (per partition). This buffer improves
+   *   throughput and supports varying downstream message processing time, while maintaining some backpressure. Large
+   *   values effectively disable backpressure at the cost of high memory usage, low values will effectively disable
+   *   prefetching in favor of low memory consumption. The number of records that is fetched on every poll is controlled
+   *   by the `max.poll.records` setting, the number of records fetched for every partition is somewhere between 0 and
+   *   `max.poll.records`. A value that is a power of 2 offers somewhat better queueing performance.
    *
    * The default value for this parameter is 1024. It is calculated by taking 2 * the default `max.poll.records` of 500,
    * rounded to the nearest power of 2.
+   *
+   * The value `0` disables pre-fetching.
    */
   def withPartitionPreFetchBufferLimit(partitionPreFetchBufferLimit: Int): ConsumerSettings =
     copy(fetchStrategy = QueueSizeBasedFetchStrategy(partitionPreFetchBufferLimit))
+
+  /**
+   * Disables partition record pre-fetching.
+   */
+  def withoutPartitionPreFetching(): ConsumerSettings =
+    withPartitionPreFetchBufferLimit(0)
 
   @deprecated("Use withPartitionPreFetchBufferLimit instead", "2.6.0")
   def withMaxPartitionQueueSize(partitionPreFetchBufferLimit: Int): ConsumerSettings =

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/fetch/FetchStrategy.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/fetch/FetchStrategy.scala
@@ -25,24 +25,32 @@ trait FetchStrategy {
 }
 
 /**
- * A fetch strategy that allows a stream to fetch data when its queue size is below `partitionPreFetchBufferLimit`.
+ * A fetch strategy that allows a stream to fetch data when its queue size is at or below
+ * `partitionPreFetchBufferLimit`.
  *
  * @param partitionPreFetchBufferLimit
- *   The queue size below which more records are fetched and buffered (per partition). This buffer improves throughput
- *   and supports varying downstream message processing time, while maintaining some backpressure. Large values
- *   effectively disable backpressure at the cost of high memory usage, low values will effectively disable prefetching
- *   in favour of low memory consumption. The number of records that is fetched on every poll is controlled by the
- *   `max.poll.records` setting, the number of records fetched for every partition is somewhere between 0 and
+ *   The queue size at or below which more records are fetched and buffered (per partition). This buffer improves
+ *   throughput and supports varying downstream message processing time, while maintaining some backpressure. Large
+ *   values effectively disable backpressure at the cost of high memory usage, low values will effectively disable
+ *   prefetching in favor of low memory consumption. The number of records that is fetched on every poll is controlled
+ *   by the `max.poll.records` setting, the number of records fetched for every partition is somewhere between 0 and
  *   `max.poll.records`. A value that is a power of 2 offers somewhat better queueing performance.
  *
  * The default value for this parameter is 2 * the default `max.poll.records` of 500, rounded to the nearest power of 2.
+ *
+ * The value `0` disables pre-fetching.
  */
 final case class QueueSizeBasedFetchStrategy(partitionPreFetchBufferLimit: Int = 1024) extends FetchStrategy {
+  require(
+    partitionPreFetchBufferLimit >= 0,
+    s"partitionPreFetchBufferLimit must be at least 0, got $partitionPreFetchBufferLimit"
+  )
+
   override def selectPartitionsToFetch(streams: Chunk[PartitionStream]): ZIO[Any, Nothing, Set[TopicPartition]] =
     ZIO
       .foldLeft(streams)(mutable.ArrayBuilder.make[TopicPartition]) { case (acc, stream) =>
         stream.queueSize.map { queueSize =>
-          if (queueSize < partitionPreFetchBufferLimit) acc += stream.tp else acc
+          if (queueSize <= partitionPreFetchBufferLimit) acc += stream.tp else acc
         }
       }
       .map(_.result().toSet)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/fetch/FetchStrategy.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/fetch/FetchStrategy.scala
@@ -34,7 +34,7 @@ trait FetchStrategy {
  *   values effectively disable backpressure at the cost of high memory usage, low values will effectively disable
  *   prefetching in favor of low memory consumption. The number of records that is fetched on every poll is controlled
  *   by the `max.poll.records` setting, the number of records fetched for every partition is somewhere between 0 and
- *   `max.poll.records`. A value that is a power of 2 offers somewhat better queueing performance.
+ *   `max.poll.records`.
  *
  * The default value for this parameter is 2 * the default `max.poll.records` of 500, rounded to the nearest power of 2.
  *

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -3,7 +3,7 @@ package zio.kafka.consumer.internal
 import org.apache.kafka.common.TopicPartition
 import zio.kafka.consumer.Offset
 import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
-import zio.kafka.consumer.internal.PartitionStreamControl.QueueInfo
+import zio.kafka.consumer.internal.PartitionStreamControl.{ NanoTime, QueueInfo }
 import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.stream.{ Take, ZStream }
 import zio.{ Chunk, Clock, Duration, LogAnnotation, Promise, Queue, Ref, UIO, ZIO }
@@ -62,15 +62,14 @@ final class PartitionStreamControl private (
   def queueSize: UIO[Int] = queueInfoRef.get.map(_.size)
 
   /**
+   * @param now
+   *   the time as given by `Clock.nanoTime`
    * @return
    *   `true` when the stream has data available, but none has been pulled for more than `maxPollInterval` (since data
    *   became available), `false` otherwise
    */
-  private[internal] def maxPollIntervalExceeded: UIO[Boolean] =
-    for {
-      now       <- Clock.nanoTime
-      queueInfo <- queueInfoRef.get
-    } yield queueInfo.deadlineExceeded(now)
+  private[internal] def maxPollIntervalExceeded(now: NanoTime): UIO[Boolean] =
+    queueInfoRef.get.map(_.deadlineExceeded(now))
 
   /** To be invoked when the partition was lost. */
   private[internal] def lost: UIO[Boolean] =
@@ -106,7 +105,7 @@ final class PartitionStreamControl private (
 
 object PartitionStreamControl {
 
-  private type NanoTime = Long
+  type NanoTime = Long
 
   private[internal] def newPartitionStream(
     tp: TopicPartition,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -405,8 +405,10 @@ private[consumer] final class Runloop private (
    */
   private def checkStreamPollInterval(streams: Chunk[PartitionStreamControl]): ZIO[Any, Nothing, Unit] =
     for {
+      now <- Clock.nanoTime
       anyExceeded <- ZIO.foldLeft(streams)(false) { case (acc, stream) =>
-                       stream.maxPollIntervalExceeded
+                       stream
+                         .maxPollIntervalExceeded(now)
                          .tap(exceeded => if (exceeded) stream.halt else ZIO.unit)
                          .map(acc || _)
                      }


### PR DESCRIPTION
Before you need to use `ConsumerSettings.partitionPreFetchBufferLimit(1)` to disable pre-fetching. I found that very confusing. After this change you can disable pre-fetching with `ConsumerSettings.partitionPreFetchBufferLimit(0)`, or simply with `ConsumerSettings.withoutPartitionPreFetching`.

Also: attempt to make test `a consumer timeout interrupts the stream and shuts down the consumer` stable by disabling prefetching