### PR TITLE
Automatically add new flame graphs to gh_pages, prune old

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -61,25 +61,30 @@ jobs:
 
       - name: Store flame graphs
         run: |
+          echo "Collecting new flame graph"
           git config pull.rebase true
           read REV COMMIT_DATE COMMIT_TIME COMMIT_TZ COMMIT_MSG <<< \
             $(git log --pretty=format:'%h %ad %s' --date=iso8601 -n 1 ${{ github.event.pull_request.head.sha }})
           HTML_LINE="  <li>$COMMIT_DATE $COMMIT_TIME <a href=\"$REV\">Flame graphs for $REV</a> $COMMIT_MSG</li>"
+          echo "::group::Content of zio-kafka-bench directory"
           ls -al zio-kafka-bench/
+          echo "::endgroup::"
           mv zio-kafka-bench/zio.kafka.bench.* /tmp
+          echo "Checkout gh-pages branch"
           git clean -fdx
           git checkout gh-pages
           git pull
+          git config --global user.name "zio-kafka CI"
+          git config --global user.email "ziokafkaci@users.noreply.github.com"
+          echo "Remove old flame graphs"
           scala-cli scripts/prune-flame-graph.sc
+          echo "Adding new flame graph"
           mkdir -p dev/profile/$REV
           mv /tmp/zio.kafka.bench.* dev/profile/$REV
           cd dev/profile
           find . -maxdepth 1 -type d \( ! -name . \) -exec bash -c "cd '{}' && tree -H . -o index.html" \;
           sed -i'' -e '/NEW-FLAME-GRAPHS-GO-HERE/a\'$'\n'"$HTML_LINE"$'\n' index.html
           cd ../../
-          git config --global user.name "zio-kafka CI"
-          git config --global user.email "ziokafkaci@users.noreply.github.com"
-          git ls-files --deleted | xargs git rm
           git add .
           git commit -m "Flame graphs for $REV"
           git push

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Store flame graphs
         run: |
+          echo "Store flame graphs"
           echo "Collecting new flame graph"
           git config pull.rebase true
           read REV COMMIT_DATE COMMIT_TIME COMMIT_TZ COMMIT_MSG <<< \
@@ -70,15 +71,16 @@ jobs:
           ls -al zio-kafka-bench/
           echo "::endgroup::"
           mv zio-kafka-bench/zio.kafka.bench.* /tmp
-          echo "Checkout gh-pages branch"
+          echo "::group::Checkout gh-pages branch"
           git clean -fdx
           git checkout gh-pages
           git pull
           git config --global user.name "zio-kafka CI"
           git config --global user.email "ziokafkaci@users.noreply.github.com"
+          echo "::endgroup::"
           echo "Remove old flame graphs"
           scala-cli scripts/prune-flame-graph.sc
-          echo "Adding new flame graph"
+          echo "::group::Adding new flame graph"
           mkdir -p dev/profile/$REV
           mv /tmp/zio.kafka.bench.* dev/profile/$REV
           cd dev/profile
@@ -88,3 +90,4 @@ jobs:
           git add .
           git commit -m "Flame graphs for $REV"
           git push
+          echo "::endgroup::"

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.head.repo.fork }} # comes from https://github.com/orgs/community/discussions/25217#discussioncomment-3246904
     steps:
-      - uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Java
@@ -57,10 +57,12 @@ jobs:
           mv .jvmopts_old .jvmopts
           cat .jvmopts
 
-      - name: Store flamegraphs
+      - name: Store flame graphs
         run: |
-          git config pull.rebase true 
-          export REV=$(git rev-parse --short HEAD)
+          git config pull.rebase true
+          read REV COMMIT_DATE COMMIT_TIME COMMIT_TZ COMMIT_MSG <<< \
+            $(git log --pretty=format:'%h %ad %s' --date=iso8601 -n 1 ${{ github.event.pull_request.head.sha }})
+          HTML_LINE="  <li>$COMMIT_DATE $COMMIT_TIME <a href=\"$REV\">Flame graphs for $REV</a> $COMMIT_MSG</li>"
           ls -al zio-kafka-bench/
           mv zio-kafka-bench/zio.kafka.bench.* /tmp
           git clean -fdx
@@ -70,9 +72,10 @@ jobs:
           mv /tmp/zio.kafka.bench.* dev/profile/$REV
           cd dev/profile
           find . -maxdepth 1 -type d \( ! -name . \) -exec bash -c "cd '{}' && tree -H . -o index.html" \;
+          sed -i'' -e '/NEW-FLAME-GRAPHS-GO-HERE/a\'$'\n'"$HTML_LINE"$'\n' index.html
           cd ../../
           git config --global user.name "zio-kafka CI"
           git config --global user.email "ziokafkaci@users.noreply.github.com"
           git add .
-          git commit -m "flamegraphs for $REV"
+          git commit -m "Flame graphs for $REV"
           git push

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -26,6 +26,8 @@ jobs:
           distribution: temurin
           java-version: 17
           check-latest: true
+      - uses: coursier/cache-action@v6
+      - uses: VirtusLab/scala-cli-setup@main
       - name: Use CI sbt jvmopts
         shell: bash
         run: |
@@ -68,6 +70,7 @@ jobs:
           git clean -fdx
           git checkout gh-pages
           git pull
+          scala-cli scripts/prune-flame-graph.sc
           mkdir -p dev/profile/$REV
           mv /tmp/zio.kafka.bench.* dev/profile/$REV
           cd dev/profile
@@ -76,6 +79,7 @@ jobs:
           cd ../../
           git config --global user.name "zio-kafka CI"
           git config --global user.email "ziokafkaci@users.noreply.github.com"
+          git ls-files --deleted | xargs git rm
           git add .
           git commit -m "Flame graphs for $REV"
           git push

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ project/plugins/project/
 
 # MacOS
 .DS_Store
+
+#scala-cli
+.scala-build/


### PR DESCRIPTION
This change adapts the profile workflow to:
* add new flamegraphs to the index file that is available on https://zio.github.io/zio-kafka/dev/profile/
* remove all flamegraphs that are older than 1 month

For the removal this workflow makes use of a [scala script](https://github.com/zio/zio-kafka/blob/gh-pages/scripts/prune-flame-graph.sc) that is located in the `gh-pages` branch. The script already ran as part of this PR, see the [output here](https://github.com/zio/zio-kafka/actions/runs/6842521355/job/18604085705) (expand section 'Store flame graphs').
