### PR TITLE
add consumeVia method

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -547,7 +547,7 @@ private[consumer] final class ConsumerLive private[consumer] (
     f: ConsumerRecord[K, V] => URIO[R1, Unit]
   ): ZIO[R & R1, Throwable, Unit] =
     consumeVia(subscription, keyDeserializer, valueDeserializer, commitRetryPolicy)(
-      ZPipeline.mapZIO(r => f(r.record).as(r.offset))
+      ZPipeline.mapChunksZIO(_.mapZIO(r => f(r.record).as(r.offset)))
     )
 
   def consumeVia[R: EnvironmentTag, R1: EnvironmentTag, K, V](


### PR DESCRIPTION
`consumeWith` _almost_ does what I need it to, but is unfortunately too restrictive. I'd therefore like to add a slightly generalized variant that works with a `ZPipeline`.
Specifically, in my use case I need to do some amount of work sequentially, while other parts are required to run concurrently for performance, and this new method allows me to do this kind of processing.