### PR TITLE
Remove deprecated `zio-concurrent` dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,6 @@ lazy val zioKafka =
       libraryDependencies ++= Seq(
         kafkaClients,
         scalaCollectionCompat,
-        "dev.zio" %% "zio-concurrent" % zioVersion.value
       )
     )
 


### PR DESCRIPTION
See https://github.com/zio/zio-kafka/pull/1109#issuecomment-1827967866