### PR TITLE
Adds test for stopping consumption while doing async commits

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -283,13 +283,14 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           keepProducing <- Ref.make(true)
           _             <- produceOne(topic, "key", "value").repeatWhileZIO(_ => keepProducing.get).fork
           _ <- Consumer
-                 .plainStream(Subscription.topics(topic), Serde.string, Serde.string)
-                 .zipWithIndex
-                 .tap { case (record, idx) =>
-                   (Consumer.stopConsumption <* ZIO.logDebug("Stopped consumption")).when(idx == 3) *>
-                     record.offset.commit <* ZIO.logDebug(s"Committed $idx")
+                 .partitionedStream(Subscription.topics(topic), Serde.string, Serde.string)
+                 .flatMapPar(Int.MaxValue) { case (_, partitionStream) =>
+                   partitionStream.zipWithIndex.tap { case (record, idx) =>
+                     Consumer.stopConsumption *>
+                       (Consumer.stopConsumption <* ZIO.logDebug("Stopped consumption")).when(idx == 3) *>
+                       record.offset.commit <* ZIO.logDebug(s"Committed $idx")
+                   }.tap { case (_, idx) => ZIO.logDebug(s"Consumed $idx") }
                  }
-                 .tap { case (_, idx) => ZIO.logDebug(s"Consumed $idx") }
                  .runDrain
                  .tap(_ => ZIO.logDebug("Stream completed"))
                  .provideSomeLayer[Kafka](
@@ -321,6 +322,29 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                       .provideSomeLayer[Kafka](consumer(client, Some(group)))
         } yield assert(offset.map(_.offset))(isSome(equalTo(9L)))
       },
+      test("process outstanding commits after a graceful shutdown with aggregateAsync") {
+        val kvs   = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
+        val topic = "test-outstanding-commits"
+        for {
+          group            <- randomGroup
+          client           <- randomClient
+          _                <- produceMany(topic, kvs)
+          messagesReceived <- Ref.make[Int](0)
+          offset <- (Consumer
+                      .plainStream(Subscription.topics(topic), Serde.string, Serde.string)
+                      .mapConcatZIO { record =>
+                        for {
+                          nr <- messagesReceived.updateAndGet(_ + 1)
+                          _  <- Consumer.stopConsumption.when(nr == 10)
+                        } yield if (nr < 10) Seq(record.offset) else Seq.empty
+                      }
+                      .aggregateAsync(Consumer.offsetBatches)
+                      .mapZIO(_.commit)
+                      .runDrain *>
+                      Consumer.committed(Set(new TopicPartition(topic, 0))).map(_.values.head))
+                      .provideSomeLayer[Kafka](consumer(client, Some(group), commitTimeout = 5.seconds))
+        } yield assert(offset.map(_.offset))(isSome(equalTo(9L)))
+      } @@ TestAspect.nonFlaky(10),
       test("a consumer timeout interrupts the stream and shuts down the consumer") {
         // Setup of this test:
         // - Set the max poll interval very low: a couple of seconds.

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -117,6 +117,7 @@ object KafkaTestUtils {
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
     restartStreamOnRebalancing: Boolean = false,
     rebalanceSafeCommits: Boolean = false,
+    maxRebalanceDuration: Duration = 3.minutes,
     maxPollInterval: Duration = 5.minutes,
     `max.poll.records`: Int = 100, // settings this higher can cause concurrency bugs to go unnoticed
     commitTimeout: Duration = ConsumerSettings.defaultCommitTimeout,
@@ -140,6 +141,7 @@ object KafkaTestUtils {
         .withOffsetRetrieval(offsetRetrieval)
         .withRestartStreamOnRebalancing(restartStreamOnRebalancing)
         .withRebalanceSafeCommits(rebalanceSafeCommits)
+        .withMaxRebalanceDuration(maxRebalanceDuration)
         .withProperties(properties)
 
       val withClientInstanceId = clientInstanceId.fold(settings)(settings.withGroupInstanceId)
@@ -207,6 +209,7 @@ object KafkaTestUtils {
     diagnostics: Diagnostics = Diagnostics.NoOp,
     restartStreamOnRebalancing: Boolean = false,
     rebalanceSafeCommits: Boolean = false,
+    maxRebalanceDuration: Duration = 3.minutes,
     commitTimeout: Duration = ConsumerSettings.defaultCommitTimeout,
     properties: Map[String, String] = Map.empty
   ): ZLayer[Kafka, Throwable, Consumer] =
@@ -219,6 +222,7 @@ object KafkaTestUtils {
         offsetRetrieval = offsetRetrieval,
         restartStreamOnRebalancing = restartStreamOnRebalancing,
         rebalanceSafeCommits = rebalanceSafeCommits,
+        maxRebalanceDuration = maxRebalanceDuration,
         properties = properties,
         commitTimeout = commitTimeout
       )


### PR DESCRIPTION
As of zio-kafka 2.7.1 it is possible to enable `rebalance safe mode` with a short `maxRebalanceDuration` to fix this problem. The trick is in setting a good `maxRabalanceDuration`, but for most cases a few seconds should be enough.

This PR includes 2 commits:
* commit 1: the test from @vladimirkl (see #1028)
* commit 2: added configuration so that the test passes

This fixes #852.

🙏 Many thanks for the test @vladimirkl!