### PR TITLE
Improve support and documentation for manual offsets

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/Benchmarks.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/Benchmarks.scala
@@ -1,14 +1,18 @@
 package zio.kafka
 
+import org.apache.kafka.clients.consumer.{ ConsumerConfig, KafkaConsumer }
 import org.apache.kafka.clients.producer.ProducerRecord
-import zio.{ System => _, _ }, zio.stream._
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import zio.{ System => _, _ }
+import zio.stream._
 import zio.kafka.producer._
 import zio.kafka.serde._
-import org.apache.kafka.clients.producer.ProducerConfig
-import org.apache.kafka.clients.consumer.{ ConsumerConfig, KafkaConsumer }
+import zio.kafka.consumer.Consumer.{ AutoOffsetStrategy, OffsetRetrieval }
+
 import scala.jdk.CollectionConverters._
 import java.time.Duration
-import org.apache.kafka.common.serialization.StringDeserializer
+
 import java.util.concurrent.TimeUnit
 
 object PopulateTopic extends ZIOAppDefault {
@@ -79,7 +83,7 @@ object ZIOKafka extends ZIOAppDefault {
     val expectedCount = 1000000
     val settings = ConsumerSettings(List("localhost:9092"))
       .withGroupId(s"zio-kafka-${scala.util.Random.nextInt()}")
-      .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+      .withOffsetRetrieval(OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest))
       .withProperty("fetch.min.bytes", "128000")
       .withPollTimeout(50.millis)
 

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -114,7 +114,7 @@ object KafkaTestUtils {
     groupId: Option[String] = None,
     clientInstanceId: Option[String] = None,
     allowAutoCreateTopics: Boolean = true,
-    offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
+    offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest),
     restartStreamOnRebalancing: Boolean = false,
     rebalanceSafeCommits: Boolean = false,
     maxRebalanceDuration: Duration = 3.minutes,
@@ -132,7 +132,6 @@ object KafkaTestUtils {
         .withMaxPollRecords(`max.poll.records`)
         .withCommitTimeout(commitTimeout)
         .withProperties(
-          ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "earliest",
           ConsumerConfig.METADATA_MAX_AGE_CONFIG         -> "100",
           ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG       -> "3000",
           ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG    -> "1000",
@@ -156,7 +155,7 @@ object KafkaTestUtils {
     clientId: String,
     clientInstanceId: Option[String] = None,
     allowAutoCreateTopics: Boolean = true,
-    offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
+    offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest),
     restartStreamOnRebalancing: Boolean = false,
     rebalanceSafeCommits: Boolean = false,
     properties: Map[String, String] = Map.empty

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -401,10 +401,14 @@ object Consumer {
   def metrics: RIO[Consumer, Map[MetricName, Metric]] =
     ZIO.serviceWithZIO(_.metrics)
 
+  /** See ConsumerSettings.withOffsetRetrieval. */
   sealed trait OffsetRetrieval
   object OffsetRetrieval {
-    final case class Auto(reset: AutoOffsetStrategy = AutoOffsetStrategy.Latest)                extends OffsetRetrieval
-    final case class Manual(getOffsets: Set[TopicPartition] => Task[Map[TopicPartition, Long]]) extends OffsetRetrieval
+    final case class Auto(reset: AutoOffsetStrategy = AutoOffsetStrategy.Latest) extends OffsetRetrieval
+    final case class Manual(
+      getOffsets: Set[TopicPartition] => Task[Map[TopicPartition, Long]],
+      defaultStrategy: AutoOffsetStrategy = AutoOffsetStrategy.Latest
+    ) extends OffsetRetrieval
   }
 
   sealed trait AutoOffsetStrategy { self =>
@@ -415,6 +419,7 @@ object Consumer {
     }
   }
 
+  /** See ConsumerSettings.withOffsetRetrieval. */
   object AutoOffsetStrategy {
     case object Earliest extends AutoOffsetStrategy
     case object Latest   extends AutoOffsetStrategy

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -124,7 +124,7 @@ final case class ConsumerSettings(
    * https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset for more information.
    */
   def withOffsetRetrieval(retrieval: OffsetRetrieval): ConsumerSettings = {
-    val resetStrategy = offsetRetrieval match {
+    val resetStrategy = retrieval match {
       case OffsetRetrieval.Auto(reset)                => reset
       case OffsetRetrieval.Manual(_, defaultStrategy) => defaultStrategy
     }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -118,7 +118,7 @@ final case class ConsumerSettings(
    * committed offset. When no committed offset is available, the `defaultStrategy` is used and consuming starts from
    * the `Latest` offset (the default), the `Earliest` offset, or results in an error for `None`.
    *
-   * This configuration applies for both subscribed and assigned partitions.
+   * This configuration applies to both subscribed and assigned partitions.
    *
    * This method sets the `auto.offset.reset` Kafka configuration. See
    * https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset for more information.

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -386,6 +386,7 @@ private[consumer] final class Runloop private (
     if (hasGroupId) consumer.runloopAccess(c => ZIO.attempt(c.groupMetadata())).fold(_ => None, Some(_))
     else ZIO.none
 
+  /** @return the topic-partitions for which received records should be ignored */
   private def doSeekForNewPartitions(c: ByteArrayKafkaConsumer, tps: Set[TopicPartition]): Task[Set[TopicPartition]] =
     offsetRetrieval match {
       case OffsetRetrieval.Auto(_) => ZIO.succeed(Set.empty)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -389,12 +389,14 @@ private[consumer] final class Runloop private (
   private def doSeekForNewPartitions(c: ByteArrayKafkaConsumer, tps: Set[TopicPartition]): Task[Set[TopicPartition]] =
     offsetRetrieval match {
       case OffsetRetrieval.Auto(_) => ZIO.succeed(Set.empty)
-      case OffsetRetrieval.Manual(getOffsets) =>
+      case OffsetRetrieval.Manual(getOffsets, _) =>
         if (tps.isEmpty) ZIO.succeed(Set.empty)
         else
-          getOffsets(tps)
-            .flatMap(offsets => ZIO.attempt(offsets.foreach { case (tp, offset) => c.seek(tp, offset) }))
-            .as(tps)
+          getOffsets(tps).flatMap { offsets =>
+            ZIO
+              .attempt(offsets.foreach { case (tp, offset) => c.seek(tp, offset) })
+              .as(offsets.keySet)
+          }
     }
 
   /**


### PR DESCRIPTION
According to the javadoc of `seek`, when a given offset is invalid, it falls back to the `auto.offset.reset` configuration. In this change we allow the user to set that configuration when `Manual` offset retrieval is used. Furthermore, testing showed that we fall back to 'Auto' behavior when no offset is given.

This PR also contains a behavior change. For Manual offsets, when no offset is given by the user, before we would skip the records from the first poll. After this change those are no longer skipped.

In addition, add documentation on how to configure offset retrieval.

Note: this change is source compatible, but not binary compatible.