### PR TITLE
retry Consumer.CommitTimeout exception

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
@@ -35,6 +35,7 @@ object Offset {
     commit.retry(
       Schedule.recurWhile[Throwable] {
         case _: RetriableCommitFailedException => true
+        case Consumer.CommitTimeout            => true
         case _                                 => false
       } && policy
     )


### PR DESCRIPTION
Though this is a debatable change, I think it's not obious that `Consumer.CommitTimeout` exception is not retrieable when using `Offset#commitOrRetry` or `OffsetBatch#commitOrRetry`.