### PR TITLE
Delete `RunloopTimeout` and small improvements

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -161,8 +161,7 @@ trait Consumer {
 }
 
 object Consumer {
-  case object RunloopTimeout extends RuntimeException("Timeout in Runloop") with NoStackTrace
-  case object CommitTimeout  extends RuntimeException("Commit timeout") with NoStackTrace
+  case object CommitTimeout extends RuntimeException("Commit timeout") with NoStackTrace
 
   val offsetBatches: ZSink[Any, Nothing, Offset, Nothing, OffsetBatch] =
     ZSink.foldLeft[Offset, OffsetBatch](OffsetBatch.empty)(_ add _)

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -28,7 +28,7 @@ object TransactionalProducer {
 
     private def commitTransactionWithOffsets(offsetBatch: OffsetBatch): Task[Unit] = {
       val sendOffsetsToTransaction: Task[Unit] =
-        ZIO.suspendSucceed {
+        ZIO.suspend {
           @inline def invalidGroupIdException: IO[InvalidGroupIdException, Nothing] =
             ZIO.fail(
               new InvalidGroupIdException(


### PR DESCRIPTION
* Delete `RunloopTimeout` as it is no longer used.
* Do not suppress error in `commitTransactionWithOffsets` (even though the only invoker still dies upon any error).
* Better debug logging in `Runloop`.
* Shave tens of seconds of test by never taking more messages than can be sent.
* Run test less often, 3 times is enough (`nonFlaky(3)`` runs the test 4 times!).