### PR TITLE
Collect consumer metrics

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopCommitOffsetsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopCommitOffsetsSpec.scala
@@ -16,39 +16,57 @@ object RunloopCommitOffsetsSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("Runloop.CommitOffsets spec")(
       test("addCommits adds to empty CommitOffsets") {
-        val s1 = Runloop.CommitOffsets(Map.empty)
-        val s2 = s1.addCommits(Chunk(makeCommit(Map(tp10 -> 10))))
-        assertTrue(s2.offsets == Map(tp10 -> 10L))
+        val s1        = Runloop.CommitOffsets(Map.empty)
+        val (inc, s2) = s1.addCommits(Chunk(makeCommit(Map(tp10 -> 10))))
+        assertTrue(
+          inc == 0,
+          s2.offsets == Map(tp10 -> 10L)
+        )
       },
       test("addCommits updates offset when it is higher") {
-        val s1 = Runloop.CommitOffsets(Map(tp10 -> 5L))
-        val s2 = s1.addCommits(Chunk(makeCommit(Map(tp10 -> 10))))
-        assertTrue(s2.offsets == Map(tp10 -> 10L))
+        val s1        = Runloop.CommitOffsets(Map(tp10 -> 4L))
+        val (inc, s2) = s1.addCommits(Chunk(makeCommit(Map(tp10 -> 10))))
+        assertTrue(
+          inc == 10 - 4,
+          s2.offsets == Map(tp10 -> 10L)
+        )
       },
       test("addCommits ignores an offset when it is lower") {
-        val s1 = Runloop.CommitOffsets(Map(tp10 -> 10L))
-        val s2 = s1.addCommits(Chunk(makeCommit(Map(tp10 -> 5))))
-        assertTrue(s2.offsets == Map(tp10 -> 10L))
+        val s1        = Runloop.CommitOffsets(Map(tp10 -> 10L))
+        val (inc, s2) = s1.addCommits(Chunk(makeCommit(Map(tp10 -> 5))))
+        assertTrue(
+          inc == 0,
+          s2.offsets == Map(tp10 -> 10L)
+        )
       },
       test("addCommits keeps unrelated partitions") {
-        val s1 = Runloop.CommitOffsets(Map(tp10 -> 10L))
-        val s2 = s1.addCommits(Chunk(makeCommit(Map(tp11 -> 11))))
-        assertTrue(s2.offsets == Map(tp10 -> 10L, tp11 -> 11L))
+        val s1        = Runloop.CommitOffsets(Map(tp10 -> 10L))
+        val (inc, s2) = s1.addCommits(Chunk(makeCommit(Map(tp11 -> 11))))
+        assertTrue(
+          inc == 0,
+          s2.offsets == Map(tp10 -> 10L, tp11 -> 11L)
+        )
       },
       test("addCommits does it all at once") {
-        val s1 = Runloop.CommitOffsets(Map(tp10 -> 10L, tp20 -> 205L, tp21 -> 210L, tp22 -> 220L))
-        val s2 = s1.addCommits(Chunk(makeCommit(Map(tp11 -> 11, tp20 -> 206L, tp21 -> 209L, tp22 -> 220L))))
-        assertTrue(s2.offsets == Map(tp10 -> 10L, tp11 -> 11L, tp20 -> 206L, tp21 -> 210L, tp22 -> 220L))
+        val s1        = Runloop.CommitOffsets(Map(tp10 -> 10L, tp20 -> 205L, tp21 -> 210L, tp22 -> 220L))
+        val (inc, s2) = s1.addCommits(Chunk(makeCommit(Map(tp11 -> 11, tp20 -> 206L, tp21 -> 209L, tp22 -> 220L))))
+        assertTrue(
+          inc == /* tp10 */ 0 + /* tp11 */ 0 + /* tp20 */ 1 + /* tp21 */ 0 + /* tp22 */ 0,
+          s2.offsets == Map(tp10 -> 10L, tp11 -> 11L, tp20 -> 206L, tp21 -> 210L, tp22 -> 220L)
+        )
       },
       test("addCommits adds multiple commits") {
         val s1 = Runloop.CommitOffsets(Map(tp10 -> 10L, tp20 -> 200L, tp21 -> 210L, tp22 -> 220L))
-        val s2 = s1.addCommits(
+        val (inc, s2) = s1.addCommits(
           Chunk(
             makeCommit(Map(tp11 -> 11, tp20 -> 199L, tp21 -> 211L, tp22 -> 219L)),
             makeCommit(Map(tp20 -> 198L, tp21 -> 209L, tp22 -> 221L))
           )
         )
-        assertTrue(s2.offsets == Map(tp10 -> 10L, tp11 -> 11L, tp20 -> 200L, tp21 -> 211L, tp22 -> 221L))
+        assertTrue(
+          inc == /* tp10 */ 0 + /* tp11 */ 0 + /* tp20 */ 0 + /* tp21 */ 1 + /* tp22 */ 1,
+          s2.offsets == Map(tp10 -> 10L, tp11 -> 11L, tp20 -> 200L, tp21 -> 211L, tp22 -> 221L)
+        )
       },
       test("keepPartitions removes some partitions") {
         val s1 = Runloop.CommitOffsets(Map(tp10 -> 10L, tp20 -> 20L))
@@ -80,6 +98,6 @@ object RunloopCommitOffsetsSpec extends ZIOSpecDefault {
   private def makeCommit(offsets: Map[TopicPartition, Long]): Runloop.Commit = {
     val o = offsets.map { case (tp, offset) => tp -> new OffsetAndMetadata(offset) }
     val p = Unsafe.unsafe(implicit unsafe => Promise.unsafe.make[Throwable, Unit](FiberId.None))
-    Runloop.Commit(o, p)
+    Runloop.Commit(0L, o, p)
   }
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -30,7 +30,8 @@ final case class ConsumerSettings(
   restartStreamOnRebalancing: Boolean = false,
   rebalanceSafeCommits: Boolean = false,
   maxRebalanceDuration: Option[Duration] = None,
-  fetchStrategy: FetchStrategy = QueueSizeBasedFetchStrategy()
+  fetchStrategy: FetchStrategy = QueueSizeBasedFetchStrategy(),
+  metricsConsumerId: Option[String] = None
 ) {
 
   /**
@@ -278,6 +279,21 @@ final case class ConsumerSettings(
    */
   def withFetchStrategy(fetchStrategy: FetchStrategy): ConsumerSettings =
     copy(fetchStrategy = fetchStrategy)
+
+  /**
+   * @param consumerId
+   *   The value given to the metrics label `consumer_id` for all metrics. When this value is not set, the consumer
+   *   group id is used, when no group id is set, it defaults to a random value that is generated when the consumer is
+   *   created.
+   */
+  def withMetricsConsumerId(consumerId: String): ConsumerSettings =
+    copy(metricsConsumerId = Some(consumerId))
+
+  def derivedMetricsConsumerId: String =
+    metricsConsumerId
+      .orElse(properties.get(ConsumerConfig.GROUP_ID_CONFIG).map(_.toString))
+      .getOrElse(Seq.fill(6)(scala.util.Random.nextInt(16).toHexString).mkString)
+
 }
 
 object ConsumerSettings {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -5,6 +5,7 @@ import zio._
 import zio.kafka.consumer.Consumer.OffsetRetrieval
 import zio.kafka.consumer.fetch.{ FetchStrategy, QueueSizeBasedFetchStrategy }
 import zio.kafka.security.KafkaCredentialStore
+import zio.metrics.MetricLabel
 
 /**
  * Settings for the consumer.
@@ -31,7 +32,7 @@ final case class ConsumerSettings(
   rebalanceSafeCommits: Boolean = false,
   maxRebalanceDuration: Option[Duration] = None,
   fetchStrategy: FetchStrategy = QueueSizeBasedFetchStrategy(),
-  metricsConsumerId: Option[String] = None
+  metricLabels: Set[MetricLabel] = Set.empty
 ) {
 
   /**
@@ -281,21 +282,11 @@ final case class ConsumerSettings(
     copy(fetchStrategy = fetchStrategy)
 
   /**
-   * @param consumerId
-   *   The value given to the metrics label `consumer_id` for all metrics. When this value is not set, the first set
-   *   value from the following list is used:
-   *   - the group instance id (Kafka config `group.instance.id`),
-   *   - the group id (Kafka config `group.id`),
-   *   - hash code of this consumer settings
+   * @param metricLabels
+   *   The labels given to all metrics collected by zio-kafka. By default no labels are set.
    */
-  def withMetricsConsumerId(consumerId: String): ConsumerSettings =
-    copy(metricsConsumerId = Some(consumerId))
-
-  def derivedMetricsConsumerId: String =
-    metricsConsumerId
-      .orElse(properties.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG).map(_.toString))
-      .orElse(properties.get(ConsumerConfig.GROUP_ID_CONFIG).map(_.toString))
-      .getOrElse(hashCode().abs.toHexString.take(6))
+  def withMetricsLabels(metricLabels: Set[MetricLabel]): ConsumerSettings =
+    copy(metricLabels = metricLabels)
 
 }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -32,7 +32,8 @@ final case class ConsumerSettings(
   rebalanceSafeCommits: Boolean = false,
   maxRebalanceDuration: Option[Duration] = None,
   fetchStrategy: FetchStrategy = QueueSizeBasedFetchStrategy(),
-  metricLabels: Set[MetricLabel] = Set.empty
+  metricLabels: Set[MetricLabel] = Set.empty,
+  runloopMetricsSchedule: Schedule[Any, Unit, Long] = Schedule.fixed(500.millis)
 ) {
 
   /**
@@ -294,6 +295,14 @@ final case class ConsumerSettings(
    */
   def withMetricsLabels(metricLabels: Set[MetricLabel]): ConsumerSettings =
     copy(metricLabels = metricLabels)
+
+  /**
+   * @param runloopMetricsSchedule
+   *   The schedule at which the runloop metrics are measured. Example runloop metrics are queue sizes and number of
+   *   outstanding commits. The default is to measure every 500ms.
+   */
+  def withRunloopMetricsSchedule(runloopMetricsSchedule: Schedule[Any, Unit, Long]): ConsumerSettings =
+    copy(runloopMetricsSchedule = runloopMetricsSchedule)
 
 }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -284,6 +284,13 @@ final case class ConsumerSettings(
   /**
    * @param metricLabels
    *   The labels given to all metrics collected by zio-kafka. By default no labels are set.
+   *
+   * For applications with multiple consumers it is recommended to set some metric labels. For example, if one is used,
+   * the consumer group id could be used as a label:
+   *
+   * {{{
+   *   consumerSettings.withMetricLabels(Set(MetricLabel("group-id", groupId)))
+   * }}}
    */
   def withMetricsLabels(metricLabels: Set[MetricLabel]): ConsumerSettings =
     copy(metricLabels = metricLabels)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
@@ -250,7 +250,7 @@ private[internal] class ZioConsumerMetrics(metricLabels: Set[MetricLabel]) exten
     Metric
       .histogram(
         "ziokafka_consumer_pending_requests",
-        "The number of partition streams that are awaiting new records.",
+        "The number of partition queues that that ran out of records.",
         streamCountBoundaries
       )
       .contramap[Int](_.toDouble)
@@ -270,7 +270,7 @@ private[internal] class ZioConsumerMetrics(metricLabels: Set[MetricLabel]) exten
     Metric
       .histogram(
         "ziokafka_consumer_queue_size",
-        "The number of records queued per partition.",
+        "The number of records in a partition queue.",
         streamSizeBoundaries
       )
       .contramap[Int](_.toDouble)
@@ -280,7 +280,7 @@ private[internal] class ZioConsumerMetrics(metricLabels: Set[MetricLabel]) exten
     Metric
       .histogram(
         "ziokafka_consumer_queue_polls",
-        "The number of polls records are idling in the queue for a partition.",
+        "The number of polls during which records are idling in a partition queue.",
         queuePollSizeBoundaries
       )
       .contramap[Int](_.toDouble)
@@ -290,7 +290,7 @@ private[internal] class ZioConsumerMetrics(metricLabels: Set[MetricLabel]) exten
     Metric
       .histogram(
         "ziokafka_consumer_all_queue_size",
-        "The number of records queued in the consumer (all partitions).",
+        "The total number of records in all partition queues.",
         streamSizeBoundaries
       )
       .contramap[Int](_.toDouble)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
@@ -8,7 +8,7 @@ import zio._
  * Implementations of this trait are responsible for measuring all consumer metrics. The different methods are invoked
  * from different places in the consumer.
  *
- * WARNING: This is an INTERNAL API. If may change in an incompatible way, or disappear, without notice, in any
+ * WARNING: This is an INTERNAL API and may change in an incompatible way, or disappear, without notice, in any
  * zio-kafka version.
  */
 private[internal] trait ConsumerMetrics {
@@ -24,7 +24,7 @@ private[internal] trait ConsumerMetrics {
  *
  * Sub-classes are allowed to override the Histogram boundaries.
  *
- * WARNING: This is an INTERNAL API. If may change in an incompatible way, or disappear, without notice, in any
+ * WARNING: This is an INTERNAL API and may change in an incompatible way, or disappear, without notice, in any
  * zio-kafka version.
  *
  * @param metricLabels

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
@@ -17,7 +17,7 @@ final case class ConsumerMetrics(metricsConsumerId: String) {
   private val pendingRequestsHistogram =
     Metric
       .histogram(
-        "consumer_pending_requests",
+        "ziokafka_consumer_pending_requests",
         "The number of partition streams that are awaiting new records.",
         streamCountBoundaries
       )
@@ -26,7 +26,7 @@ final case class ConsumerMetrics(metricsConsumerId: String) {
   private val pendingCommitsHistogram =
     Metric
       .histogram(
-        "consumer_pending_commits",
+        "ziokafka_consumer_pending_commits",
         "The number of commits that are awaiting completion.",
         streamCountBoundaries
       )
@@ -35,7 +35,7 @@ final case class ConsumerMetrics(metricsConsumerId: String) {
   private val queueSizeHistogram =
     Metric
       .histogram(
-        "consumer_queue_size",
+        "ziokafka_consumer_queue_size",
         "The number of records queued per partition.",
         streamSizeBoundaries
       )
@@ -44,7 +44,7 @@ final case class ConsumerMetrics(metricsConsumerId: String) {
   private val allQueueSizeHistogram =
     Metric
       .histogram(
-        "consumer_all_queue_size",
+        "ziokafka_consumer_all_queue_size",
         "The number of records queued in the consumer (all partitions).",
         streamSizeBoundaries
       )

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
@@ -4,7 +4,7 @@ import zio.metrics.MetricKeyType.Histogram
 import zio.metrics._
 import zio.{ Chunk, UIO, ZIO }
 
-final case class ConsumerMetrics(metricsConsumerId: String) {
+final case class ConsumerMetrics(metricLabels: Set[MetricLabel]) {
 
   // Chunk(0,1,3,8,21,55,149,404,1097,2981)
   private val streamCountBoundaries: Histogram.Boundaries =
@@ -21,7 +21,7 @@ final case class ConsumerMetrics(metricsConsumerId: String) {
         "The number of partition streams that are awaiting new records.",
         streamCountBoundaries
       )
-      .tagged("consumer_id", metricsConsumerId)
+      .tagged(metricLabels)
 
   private val pendingCommitsHistogram =
     Metric
@@ -30,7 +30,7 @@ final case class ConsumerMetrics(metricsConsumerId: String) {
         "The number of commits that are awaiting completion.",
         streamCountBoundaries
       )
-      .tagged("consumer_id", metricsConsumerId)
+      .tagged(metricLabels)
 
   private val queueSizeHistogram =
     Metric
@@ -39,7 +39,7 @@ final case class ConsumerMetrics(metricsConsumerId: String) {
         "The number of records queued per partition.",
         streamSizeBoundaries
       )
-      .tagged("consumer_id", metricsConsumerId)
+      .tagged(metricLabels)
 
   private val allQueueSizeHistogram =
     Metric
@@ -48,7 +48,7 @@ final case class ConsumerMetrics(metricsConsumerId: String) {
         "The number of records queued in the consumer (all partitions).",
         streamSizeBoundaries
       )
-      .tagged("consumer_id", metricsConsumerId)
+      .tagged(metricLabels)
 
   def observeMetrics(state: Runloop.State): UIO[Unit] =
     ZIO

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
@@ -1,0 +1,48 @@
+package zio.kafka.consumer.internal
+
+import zio.metrics.MetricKeyType.Histogram
+import zio.metrics._
+import zio.{ Chunk, UIO, ZIO }
+
+final case class ConsumerMetrics(metricsConsumerId: String) {
+
+  private val streamCountBoundaries: Histogram.Boundaries =
+    MetricKeyType.Histogram.Boundaries.fromChunk(Chunk(0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048))
+
+  private val pendingRequestsHistogram =
+    Metric
+      .histogram(
+        "consumer_pending_requests",
+        "The number of streams that are awaiting new data.",
+        streamCountBoundaries
+      )
+      .tagged("consumer_id", metricsConsumerId)
+
+  private val pendingCommitsHistogram =
+    Metric
+      .histogram(
+        "consumer_pending_commits",
+        "The number of commits that are awaiting completion.",
+        streamCountBoundaries
+      )
+      .tagged("consumer_id", metricsConsumerId)
+
+  private val queueSizeHistogram =
+    Metric
+      .histogram(
+        "consumer_queue_size",
+        "The number of records in stream queues.",
+        MetricKeyType.Histogram.Boundaries.fromChunk(Chunk(0, 128, 256, 512, 1024, 2048, 4096, 8192))
+      )
+      .tagged("consumer_id", metricsConsumerId)
+
+  def observeMetrics(state: Runloop.State): UIO[Unit] =
+    ZIO
+      .when(state.subscriptionState.isSubscribed) {
+        (ZIO.succeed(state.pendingRequests.size.toDouble) @@ pendingRequestsHistogram) *>
+          (ZIO.succeed(state.pendingCommits.size.toDouble) @@ pendingCommitsHistogram) *>
+          ZIO.foreachDiscard(state.assignedStreams)(_.queueSize.map(_.toDouble) @@ queueSizeHistogram)
+      }
+      .unit
+
+}

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
@@ -198,7 +198,7 @@ final case class ConsumerMetrics(metricLabels: Set[MetricLabel]) {
       .contramap[Int](_.toDouble)
       .tagged(metricLabels)
 
-  def observeMetrics(state: Runloop.State): UIO[Unit] =
+  def observePartitionStreamMetrics(state: Runloop.State): UIO[Unit] =
     ZIO
       .when(state.subscriptionState.isSubscribed) {
         for {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -186,9 +186,11 @@ object PartitionStreamControl {
     lastPulledOffset: Option[Offset],
     outstandingPolls: Int
   ) {
+    // To be called when a poll resulted in 0 records.
     def withEmptyPoll: QueueInfo =
       copy(outstandingPolls = outstandingPolls + 1)
 
+    // To be called when a poll resulted in >0 records.
     def withOffer(newPullDeadline: NanoTime, recordCount: Int): QueueInfo =
       QueueInfo(
         pullDeadline = if (size <= 0) newPullDeadline else pullDeadline,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -3,7 +3,7 @@ package zio.kafka.consumer.internal
 import org.apache.kafka.common.TopicPartition
 import zio.kafka.consumer.Offset
 import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
-import zio.kafka.consumer.internal.PartitionStreamControl.{ NanoTime, QueueInfo }
+import zio.kafka.consumer.internal.PartitionStreamControl.QueueInfo
 import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.stream.{ Take, ZStream }
 import zio.{ Chunk, Clock, Duration, LogAnnotation, Promise, Queue, Ref, UIO, ZIO }
@@ -117,8 +117,6 @@ final class PartitionStreamControl private (
 }
 
 object PartitionStreamControl {
-
-  type NanoTime = Long
 
   private[internal] def newPartitionStream(
     tp: TopicPartition,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -372,8 +372,9 @@ private[consumer] final class Runloop private (
         _ <- ZIO.foreachParDiscard(streams) { streamControl =>
                val tp      = streamControl.tp
                val records = polledRecords.records(tp)
-               if (records.isEmpty) ZIO.unit
-               else {
+               if (records.isEmpty) {
+                 streamControl.offerRecords(Chunk.empty)
+               } else {
                  val builder  = ChunkBuilder.make[Record](records.size())
                  val iterator = records.iterator()
                  while (iterator.hasNext) {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -880,18 +880,13 @@ object Runloop {
                 )
       _ <- ZIO.logDebug("Starting Runloop")
 
-      observeFiber <- runloop.observeRunloopMetrics.forkScoped
+      _ <- runloop.observeRunloopMetrics.forkScoped
 
       // Run the entire loop on a dedicated thread to avoid executor shifts
       executor <- RunloopExecutor.newInstance
       fiber    <- ZIO.onExecutor(executor)(runloop.run(initialState)).forkScoped
       waitForRunloopStop = fiber.join.orDie
 
-      _ <- ZIO.addFinalizer(
-             ZIO.logDebug("Shutting down metrics observer") *>
-               observeFiber.interrupt <*
-               ZIO.logDebug("Done shutting down metrics observer")
-           )
       _ <- ZIO.addFinalizer(
              ZIO.logDebug("Shutting down Runloop") *>
                runloop.shutdown *>

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -512,6 +512,12 @@ private[consumer] final class Runloop private (
                     _ <-
                       committedOffsetsRef.update(_.keepPartitions(updatedAssignedStreams.map(_.tp).toSet)): Task[Unit]
 
+                    _ <- consumerMetrics.observeRebalance(
+                           currentAssigned.size,
+                           assignedTps.size,
+                           revokedTps.size,
+                           lostTps.size
+                         )
                     _ <- diagnostics.emit(
                            Rebalance(
                              revoked = revokedTps,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -40,7 +40,7 @@ private[consumer] final class Runloop private (
   private val restartStreamsOnRebalancing = settings.restartStreamOnRebalancing
   private val rebalanceSafeCommits        = settings.rebalanceSafeCommits
 
-  private val consumerMetrics = ConsumerMetrics(settings.metricLabels)
+  private val consumerMetrics = new ZioConsumerMetrics(settings.metricLabels)
 
   private def newPartitionStream(tp: TopicPartition): UIO[PartitionStreamControl] =
     PartitionStreamControl.newPartitionStream(tp, commandQueue, diagnostics, maxPollInterval)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -686,7 +686,7 @@ private[consumer] final class Runloop private (
       .takeWhile(_ != RunloopCommand.StopRunloop)
       .runFoldChunksDiscardZIO(initialState) { (state, commands) =>
         for {
-          _              <- consumerMetrics.observeMetrics(state)
+          _              <- consumerMetrics.observeMetrics(state).fork
           commitCommands <- commitQueue.takeAll
           _ <- ZIO.logDebug(
                  s"Processing ${commitCommands.size} commits," +

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -449,8 +449,11 @@ private[consumer] final class Runloop private (
       pollResult <-
         consumer.runloopAccess { c =>
           for {
-            (toResumeCount, toPauseCount) <- resumeAndPausePartitions(c, partitionsToFetch)
-            (pollDuration, polledRecords) <- doPoll(c).timed
+            resumeAndPauseCounts <- resumeAndPausePartitions(c, partitionsToFetch)
+            (toResumeCount, toPauseCount) = resumeAndPauseCounts
+
+            pullDurationAndRecords <- doPoll(c).timed
+            (pollDuration, polledRecords) = pullDurationAndRecords
 
             _ <- consumerMetrics.observePoll(toResumeCount, toPauseCount, pollDuration, polledRecords.count()) *>
                    diagnostics.emit {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -458,9 +458,10 @@ private[consumer] final class Runloop private (
 
             val (toResumeCount, toPauseCount) = resumeAndPausePartitions(c, prevAssigned, partitionsToFetch)
 
-            val (pollDuration, recordsOrNull) = timed(c.poll(pollTimeout))
-            val polledRecords =
+            val (pollDuration, polledRecords) = timed {
+              val recordsOrNull = c.poll(pollTimeout)
               if (recordsOrNull eq null) ConsumerRecords.empty[Array[Byte], Array[Byte]]() else recordsOrNull
+            }
 
             consumerMetrics.observePoll(toResumeCount, toPauseCount, pollDuration, polledRecords.count()) *>
               diagnostics.emit {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -89,6 +89,7 @@ private[consumer] object RunloopAccess {
       runloopStateRef <- Ref.Synchronized.make[RunloopState](RunloopState.NotStarted)
       makeRunloop = Runloop
                       .make(
+                        metricsConsumerId = settings.derivedMetricsConsumerId,
                         hasGroupId = settings.hasGroupId,
                         consumer = consumerAccess,
                         pollTimeout = settings.pollTimeout,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -89,7 +89,7 @@ private[consumer] object RunloopAccess {
       runloopStateRef <- Ref.Synchronized.make[RunloopState](RunloopState.NotStarted)
       makeRunloop = Runloop
                       .make(
-                        metricsConsumerId = settings.derivedMetricsConsumerId,
+                        metricLabels = settings.metricLabels,
                         hasGroupId = settings.hasGroupId,
                         consumer = consumerAccess,
                         pollTimeout = settings.pollTimeout,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -89,20 +89,12 @@ private[consumer] object RunloopAccess {
       runloopStateRef <- Ref.Synchronized.make[RunloopState](RunloopState.NotStarted)
       makeRunloop = Runloop
                       .make(
-                        metricLabels = settings.metricLabels,
-                        hasGroupId = settings.hasGroupId,
-                        consumer = consumerAccess,
-                        pollTimeout = settings.pollTimeout,
+                        settings = settings,
                         maxPollInterval = maxPollInterval,
-                        commitTimeout = settings.commitTimeout,
-                        diagnostics = diagnostics,
-                        offsetRetrieval = settings.offsetRetrieval,
-                        userRebalanceListener = settings.rebalanceListener,
-                        restartStreamsOnRebalancing = settings.restartStreamOnRebalancing,
-                        rebalanceSafeCommits = settings.rebalanceSafeCommits,
                         maxRebalanceDuration = maxRebalanceDuration,
-                        partitionsHub = partitionsHub,
-                        fetchStrategy = settings.fetchStrategy
+                        diagnostics = diagnostics,
+                        consumer = consumerAccess,
+                        partitionsHub = partitionsHub
                       )
                       .withFinalizer(_ => runloopStateRef.set(RunloopState.Finalized))
                       .provide(ZLayer.succeed(consumerScope))

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/package.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/package.scala
@@ -5,6 +5,8 @@ import zio.internal.ExecutionMetrics
 
 package object internal {
 
+  private[internal] type NanoTime = Long
+
   /**
    * A runtime layer that can be used to run everything on the thread of the caller.
    *


### PR DESCRIPTION
Collect metrics for the consumer using the zio-metrics API. This allows any zio-metrics backend to access and process the observed values.

By default no tags are added, but this can be configured via the new method `ConsumerSettings.withMetricsLabels`.

The following metrics are collected (kudos to @svroonland for most of the ideas):
- Poll metrics: poll count (counter), number of records per poll (histogram), poll latency (histogram).
- Partition stream metrics: queue size per partition (histogram), total queue size per consumer (histogram), number of polls for which records are idle in the queue (histogram).
- The number of partitions that are paused/resumed (gauge).
- Rebalance metrics: currently assigned partitions count (gauge), assigned/revoked/lost partitions (counter).
- Commit metrics: commit count (counter), commit latency (histogram). These metrics measure commit requests issued through zio-kafka's api.
- Aggregated commit metrics: commit count (counter), commit latency (histogram), commit size (number of offsets per commit) (histogram). After every poll zio-kafka combines all outstanding commit requests into 1 aggregated commit. These metrics are for the aggregated commits.
- Number of entries in the command and commit queues (histogram).
- Subscription state, `1` for subscribed, `0` of unsubscribed (gauge).

Like the zio-metrics API we follow Prometheus conventions. This means that:
- durations are expressed in seconds,
- counters can only increase,
- metric names use snake_case and end in the unit where possible.

The histograms each use 10 buckets. To reach a decent range while keeping sufficient accuracy at the low end, most bucket boundaries use an exponential series based on 𝑒.

The following metric ideas were also raised, but these are kept for future work:
- histogram of number of records returned in a poll, tagged per topic-partition,
- number of records ignored (see PollResult),
- number of in-flight records (last fetched offset - last committed offset), per partition or perhaps just the raw fetched and committed offsets per partition.
