### PR TITLE
Add MIMA checks to ensure binary compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,16 @@
 import sbt.Def
 import MimaSettings.mimaSettings
 
+/**
+ * As of zio-kafka version 2.8.0 releases are binary compatible. This is checked with Mima.
+ *
+ * Keep this value set to the oldest minor release (with patch version set to "0") that is still binary compatible.
+ *
+ * Set this value to `None` when master is _not_ binary compatible with te last minor release, the next release shall
+ * increase the minor version.
+ */
+lazy val binCompatVersionToCompare = None // Some("2.8.0")
+
 lazy val kafkaVersion         = "3.7.0"
 lazy val embeddedKafkaVersion = "3.7.0" // Should be the same as kafkaVersion, except for the patch part
 
@@ -106,7 +116,7 @@ lazy val zioKafka =
     .enablePlugins(BuildInfoPlugin)
     .settings(stdSettings("zio-kafka"))
     .settings(buildInfoSettings("zio.kafka"))
-    .settings(mimaSettings(failOnProblem = true))
+    .settings(mimaSettings(binCompatVersionToCompare, failOnProblem = true))
     .settings(enableZIO(enableStreaming = true))
     .settings(
       libraryDependencies ++= Seq(
@@ -129,7 +139,7 @@ lazy val zioKafkaTestkit =
     .dependsOn(zioKafka)
     .enablePlugins(BuildInfoPlugin)
     .settings(stdSettings("zio-kafka-testkit"))
-    .settings(mimaSettings(failOnProblem = false))
+    .settings(mimaSettings(binCompatVersionToCompare, failOnProblem = false))
     .settings(
       libraryDependencies ++= Seq(
         "dev.zio" %% "zio"      % zioVersion.value,
@@ -212,6 +222,7 @@ lazy val docs = project
   .enablePlugins(WebsitePlugin)
   .dependsOn(zioKafka, zioKafkaTestkit)
 
+// Extend 'lint' with mimaCheck
 lazy val lint = {
   val defaultLint = zio.sbt.Commands.ComposableCommand.lint
   defaultLint.copy(commandStrings = defaultLint.commandStrings :+ "mimaCheck").toCommand

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import MimaSettings.mimaSettings
  *
  * Keep this value set to the oldest minor release (with patch version set to "0") that is still binary compatible.
  *
- * Set this value to `None` when master is _not_ binary compatible with te last minor release, the next release shall
+ * Set this value to `None` when master is _not_ binary compatible with the latest minor release, the next release shall
  * increase the minor version.
  */
 lazy val binCompatVersionToCompare = None // Some("2.8.0")

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -1,0 +1,18 @@
+import com.typesafe.tools.mima.core.*
+import com.typesafe.tools.mima.core.ProblemFilters.*
+import com.typesafe.tools.mima.plugin.MimaKeys.*
+import sbt.*
+import sbt.Keys.{ name, organization }
+
+object MimaSettings {
+  lazy val bincompatVersionToCompare = "2.4.2"
+
+  def mimaSettings(failOnProblem: Boolean) =
+    Seq(
+      mimaPreviousArtifacts := Set(organization.value %% name.value % bincompatVersionToCompare),
+      mimaBinaryIssueFilters ++= Seq(
+        exclude[Problem]("zio.kafka.consumer.internal.*")
+      ),
+      mimaFailOnProblem := failOnProblem
+    )
+}

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -5,14 +5,20 @@ import sbt.*
 import sbt.Keys.{ name, organization }
 
 object MimaSettings {
-  lazy val bincompatVersionToCompare = "2.4.2"
 
-  def mimaSettings(failOnProblem: Boolean) =
-    Seq(
-      mimaPreviousArtifacts := Set(organization.value %% name.value % bincompatVersionToCompare),
-      mimaBinaryIssueFilters ++= Seq(
-        exclude[Problem]("zio.kafka.consumer.internal.*")
-      ),
-      mimaFailOnProblem := failOnProblem
-    )
+  def mimaSettings(binCompatVersionToCompare: Option[String], failOnProblem: Boolean): Seq[Def.Setting[?]] =
+    binCompatVersionToCompare match {
+      case None =>
+        Seq.empty
+      case Some(binCompatVersion) =>
+        Seq(
+          mimaPreviousArtifacts := Set(organization.value %% name.value % binCompatVersion),
+          mimaBinaryIssueFilters ++= Seq(
+            exclude[Problem]("zio.kafka.consumer.internal.*")
+          ),
+          mimaFailOnProblem := failOnProblem
+        )
+
+    }
+
 }

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -9,7 +9,7 @@ object MimaSettings {
   def mimaSettings(binCompatVersionToCompare: Option[String], failOnProblem: Boolean): Seq[Def.Setting[?]] =
     binCompatVersionToCompare match {
       case None =>
-        Seq.empty
+        Seq(mimaFailOnProblem := false)
       case Some(binCompatVersion) =>
         Seq(
           mimaPreviousArtifacts := Set(organization.value %% name.value % binCompatVersion),

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -9,7 +9,7 @@ object MimaSettings {
   def mimaSettings(binCompatVersionToCompare: Option[String], failOnProblem: Boolean): Seq[Def.Setting[?]] =
     binCompatVersionToCompare match {
       case None =>
-        Seq(mimaFailOnProblem := false)
+        Seq(mimaPreviousArtifacts := Set.empty)
       case Some(binCompatVersion) =>
         Seq(
           mimaPreviousArtifacts := Set(organization.value %% name.value % binCompatVersion),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,6 @@ addSbtPlugin("dev.zio" % "zio-sbt-ci"        % zioSbtVersion)
 addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"        % "0.12.0")
 addSbtPlugin("org.typelevel"  % "sbt-tpolecat"        % "0.5.1")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
+addSbtPlugin("com.typesafe"   % "sbt-mima-plugin"     % "1.1.3")
 
 resolvers ++= Resolver.sonatypeOssRepos("public")


### PR DESCRIPTION
Add MIMA checks to ensure binary compatibility across different zio-kafka versions.

Also: use scala 3 syntax in sbt files.

Based on #1018 by @myazinn.

Mima is disabled in this PR because master is currently _not_ binary compatible with the latest released version.