### PR TITLE
Initialize Java Producer in blocking threadpool

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -199,7 +199,7 @@ object Producer {
     for {
       _ <- SslHelper.validateEndpoint(settings.driverSettings)
       rawProducer <- ZIO.acquireRelease(
-                       ZIO.attempt(
+                       ZIO.attemptBlocking(
                          new KafkaProducer[Array[Byte], Array[Byte]](
                            settings.driverSettings.asJava,
                            new ByteArraySerializer(),


### PR DESCRIPTION
As far as I understand, the initialization of the Java producer is side-effecting and blocking. It seems that while the Consumer initialization is wrapped in ZIO.blocking, the initialization of the Producer is not