### PR TITLE
Aborts builds when a newer build is ready

### DIFF
--- a/.github/workflows/benchs.yml
+++ b/.github/workflows/benchs.yml
@@ -9,6 +9,11 @@ on:
     branches-ignore:
       - gh-pages
 
+# Prevent multiple builds at the same time from the same branch (except for 'master').
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.run_id || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   # deployments permission to deploy GitHub pages website
   deployments: write

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize ]
 
+# Prevent multiple builds at the same time from the same branch (except for 'master').
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.run_id || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   deployments: write

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,6 +1,6 @@
 name: Scala Steward
 
-# This workflow will launch everyday at 00:00
+# This workflow will launch every day at 00:00
 on:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
Right now, we run all the test suites, a full benchmark, and a memory/CPU profiler on _every commit_. These builds continue, even when a newer commit is available. This PR reduces this considerably by cancelling builds when a newer commit was created. Builds on the default branch ('master') are never cancelled.

The `ci` workflow is generated and therefore not changed in the same way.