### PR TITLE
Update consumer docs

### DIFF
--- a/docs/consuming-kafka-topics-using-zio-streams.md
+++ b/docs/consuming-kafka-topics-using-zio-streams.md
@@ -26,7 +26,7 @@ import zio._
 import zio.kafka.consumer._
 import zio.kafka.serde._
 
-val data: Task[Chunk[CommittableRecord[String, String]]] = 
+val data: Task[Chunk[CommittableRecord[String, String]]] =
   Consumer.plainStream(Subscription.topics("topic"), Serde.string, Serde.string).take(50).runCollect
     .provideSomeLayer(consumer)
 ```
@@ -62,3 +62,5 @@ Consumer.partitionedStream(Subscription.topics("topic150"), Serde.string, Serde.
   .mapZIO(_.commit)
   .runDrain
 ```
+
+When using partitionedStream with `flatMapPar(n)`, it is recommended to set n to `Int.MaxValue`. N must be equal or greater than the number of partitions your consumer subscribes to otherwise there'll be unhandled partitions and Kafka will eventually evict your consumer.


### PR DESCRIPTION
- Mention the importance of using Int.MaxValue or similar when using partitionedStream with flatMapPar, otherwise it will lead to a hung consumer that gets evicted by Kafka.

Addresses https://github.com/zio/zio-kafka/issues/1239