### PR TITLE
 Allow for some auth exceptions during poll

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -1,0 +1,126 @@
+package zio.kafka.consumer.internal
+
+import org.apache.kafka.clients.consumer.{ ConsumerRecord, MockConsumer, OffsetResetStrategy }
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.AuthorizationException
+import zio._
+import zio.kafka.consumer.{ ConsumerSettings, Subscription }
+import zio.kafka.consumer.diagnostics.Diagnostics
+import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
+import zio.metrics.MetricState
+import zio.stream.{ Take, ZStream }
+import zio.test.TestAspect.withLiveClock
+import zio.test._
+
+import scala.jdk.CollectionConverters._
+
+object RunloopSpec extends ZIOSpecDefault {
+
+  private type BinaryMockConsumer = MockConsumer[Array[Byte], Array[Byte]]
+  private type PartitionsHub      = Hub[Take[Throwable, PartitionAssignment]]
+
+  private val tp10   = new TopicPartition("t1", 0)
+  private val key123 = "123".getBytes
+
+  private val consumerSettings = ConsumerSettings(List("bootstrap"))
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("RunloopSpec")(
+      test("runloop creates a new partition stream and polls for new records") {
+        withRunloop { (mockConsumer, partitionsHub, runloop) =>
+          mockConsumer.schedulePollTask { () =>
+            mockConsumer.updateEndOffsets(Map(tp10 -> Long.box(0L)).asJava)
+            mockConsumer.rebalance(Seq(tp10).asJava)
+            mockConsumer.addRecord(makeConsumerRecord(tp10, key123))
+          }
+          for {
+            streamStream <- ZStream.fromHubScoped(partitionsHub)
+            _            <- runloop.addSubscription(Subscription.Topics(Set("t1")))
+            record <- streamStream
+                        .map(_.exit)
+                        .flattenExitOption
+                        .flattenChunks
+                        .take(1)
+                        .mapZIO { case (_, stream) =>
+                          stream.runHead
+                            .someOrFail(new AssertionError("Expected at least 1 record"))
+                        }
+                        .runHead
+                        .someOrFail(new AssertionError("Expected at least 1 record from the streams"))
+          } yield assertTrue(
+            record.key sameElements key123
+          )
+        }
+      },
+      test("runloop retries poll upon AuthorizationException") {
+        withRunloop { (mockConsumer, partitionsHub, runloop) =>
+          mockConsumer.schedulePollTask { () =>
+            mockConsumer.updateEndOffsets(Map(tp10 -> Long.box(0L)).asJava)
+            mockConsumer.rebalance(Seq(tp10).asJava)
+          }
+          mockConsumer.schedulePollTask { () =>
+            mockConsumer.setPollException(new AuthorizationException("~~test~~"))
+          }
+          mockConsumer.schedulePollTask { () =>
+            mockConsumer.setPollException(new AuthorizationException("~~test~~"))
+          }
+          mockConsumer.schedulePollTask { () =>
+            mockConsumer.addRecord(makeConsumerRecord(tp10, key123))
+          }
+          for {
+            streamStream <- ZStream.fromHubScoped(partitionsHub)
+            _            <- runloop.addSubscription(Subscription.Topics(Set("t1")))
+            record <- streamStream
+                        .map(_.exit)
+                        .flattenExitOption
+                        .flattenChunks
+                        .take(1)
+                        .mapZIO { case (_, stream) =>
+                          stream.runHead
+                            .someOrFail(new AssertionError("Expected at least 1 record"))
+                        }
+                        .runHead
+                        .someOrFail(new AssertionError("Expected at least 1 record from the streams"))
+            metrics <- ZIO.metrics
+            authErrorCount = metrics.metrics
+                               .find(_.metricKey.name == "ziokafka_consumer_poll_auth_errors")
+                               .map(_.metricState)
+                               .flatMap {
+                                 case MetricState.Counter(count) => Some(count)
+                                 case _                          => Option.empty[Double]
+                               }
+          } yield assertTrue(
+            record.key sameElements key123,
+            authErrorCount.contains(2d)
+          )
+        }
+      }
+    ) @@ withLiveClock
+
+  private def withRunloop(
+    f: (BinaryMockConsumer, PartitionsHub, Runloop) => ZIO[Scope, Throwable, TestResult]
+  ): ZIO[Scope, Throwable, TestResult] =
+    ZIO.scoped {
+      val mockConsumer = new BinaryMockConsumer(OffsetResetStrategy.LATEST)
+      for {
+        consumerAccess <- ConsumerAccess.make(mockConsumer)
+        consumerScope  <- ZIO.scope
+        partitionsHub <- ZIO
+                           .acquireRelease(Hub.unbounded[Take[Throwable, PartitionAssignment]])(_.shutdown)
+                           .provide(ZLayer.succeed(consumerScope))
+        runloop <- Runloop.make(
+                     consumerSettings,
+                     100.millis,
+                     100.millis,
+                     Diagnostics.NoOp,
+                     consumerAccess,
+                     partitionsHub
+                   )
+        result <- f(mockConsumer, partitionsHub, runloop)
+      } yield result
+    }
+
+  private def makeConsumerRecord(tp: TopicPartition, key: Array[Byte]): ConsumerRecord[Array[Byte], Array[Byte]] =
+    new ConsumerRecord[Array[Byte], Array[Byte]](tp.topic(), tp.partition(), 0L, key, "value".getBytes)
+
+}

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -309,7 +309,7 @@ final case class ConsumerSettings(
    *
    * Worded differently: the consumer will fail after this number of polls that are not authorized or authenticated.
    *
-   * The default is 5.
+   * Set to 0 to fail the consumer on the first auth error. The default is 5.
    */
   def withPollAuthErrorRetries(pollAuthErrorRetries: Int): ConsumerSettings =
     copy(pollAuthErrorRetries = pollAuthErrorRetries)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -31,7 +31,7 @@ final case class ConsumerSettings(
   fetchStrategy: FetchStrategy = QueueSizeBasedFetchStrategy(),
   metricLabels: Set[MetricLabel] = Set.empty,
   runloopMetricsSchedule: Schedule[Any, Unit, Long] = Schedule.fixed(500.millis),
-  pollAuthErrorRetrySchedule: Schedule[Any, Throwable, Any] = Schedule.recurs(5) && Schedule.spaced(500.millis)
+  authErrorRetrySchedule: Schedule[Any, Throwable, Any] = Schedule.recurs(5) && Schedule.spaced(500.millis)
 ) {
 
   /**
@@ -299,7 +299,7 @@ final case class ConsumerSettings(
     copy(runloopMetricsSchedule = runloopMetricsSchedule)
 
   /**
-   * @param pollAuthErrorRetrySchedule
+   * @param authErrorRetrySchedule
    *   The schedule at which the consumer will retry polling the broker for more records, even though a poll fails with
    *   an [[org.apache.kafka.common.errors.AuthorizationException]] or
    *   [[org.apache.kafka.common.errors.AuthenticationException]].
@@ -311,8 +311,8 @@ final case class ConsumerSettings(
    *
    * The default is {{{Schedule.recurs(5) && Schedule.spaced(500.millis)}}} which is, to retry 5 times, spaced by 500ms.
    */
-  def withPollAuthErrorRetrySchedule(pollAuthErrorRetrySchedule: Schedule[Any, Throwable, Any]): ConsumerSettings =
-    copy(pollAuthErrorRetrySchedule = pollAuthErrorRetrySchedule)
+  def withAuthErrorRetrySchedule(authErrorRetrySchedule: Schedule[Any, Throwable, Any]): ConsumerSettings =
+    copy(authErrorRetrySchedule = authErrorRetrySchedule)
 
 }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -17,9 +17,6 @@ import zio.metrics.MetricLabel
  *     .withProperties(properties)
  *     .... etc.
  * }}}
- *
- * @param bootstrapServers
- *   the Kafka bootstrap servers
  */
 final case class ConsumerSettings(
   properties: Map[String, AnyRef] = Map.empty,
@@ -34,7 +31,7 @@ final case class ConsumerSettings(
   fetchStrategy: FetchStrategy = QueueSizeBasedFetchStrategy(),
   metricLabels: Set[MetricLabel] = Set.empty,
   runloopMetricsSchedule: Schedule[Any, Unit, Long] = Schedule.fixed(500.millis),
-  notAuthedContinuePollCount: Int = 5
+  pollAuthErrorRetries: Int = 5
 ) {
 
   /**
@@ -302,14 +299,20 @@ final case class ConsumerSettings(
     copy(runloopMetricsSchedule = runloopMetricsSchedule)
 
   /**
-   * @param notAuthedContinuePollCount
-   *   The number of times that the consumer will continue polling even though it is not authorized or authenticated.
-   *   This setting helps with brokers that are sometimes too slow to authorize or authenticate and fail the poll.
-   *   Worded differently: the consumer will fail after this number of polls that are not authorized or authenticated.
-   *   The default is 5.
+   * @param pollAuthErrorRetries
+   *   The number of times that the consumer continues polling the broker for more records, even though a poll fails
+   *   with an [[org.apache.kafka.common.errors.AuthorizationException]] or
+   *   [[org.apache.kafka.common.errors.AuthenticationException]]. Retries are delayed for [[pollTimeout]].
+   *
+   * This setting helps with failed polls due to too slow authorization or authentication in the broker. You may also
+   * consider increasing `pollTimeout` to reduce auth-work on the broker.
+   *
+   * Worded differently: the consumer will fail after this number of polls that are not authorized or authenticated.
+   *
+   * The default is 5.
    */
-  def notAuthedContinuePollCount(notAuthedContinuePollCount: Int): ConsumerSettings =
-    copy(notAuthedContinuePollCount = notAuthedContinuePollCount)
+  def withPollAuthErrorRetries(pollAuthErrorRetries: Int): ConsumerSettings =
+    copy(pollAuthErrorRetries = pollAuthErrorRetries)
 
 }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -33,7 +33,8 @@ final case class ConsumerSettings(
   maxRebalanceDuration: Option[Duration] = None,
   fetchStrategy: FetchStrategy = QueueSizeBasedFetchStrategy(),
   metricLabels: Set[MetricLabel] = Set.empty,
-  runloopMetricsSchedule: Schedule[Any, Unit, Long] = Schedule.fixed(500.millis)
+  runloopMetricsSchedule: Schedule[Any, Unit, Long] = Schedule.fixed(500.millis),
+  notAuthedContinuePollCount: Int = 5
 ) {
 
   /**
@@ -299,6 +300,16 @@ final case class ConsumerSettings(
    */
   def withRunloopMetricsSchedule(runloopMetricsSchedule: Schedule[Any, Unit, Long]): ConsumerSettings =
     copy(runloopMetricsSchedule = runloopMetricsSchedule)
+
+  /**
+   * @param notAuthedContinuePollCount
+   *   The number of times that the consumer will continue polling even though it is not authorized or authenticated.
+   *   This setting helps with brokers that are sometimes too slow to authorize or authenticate and fail the poll.
+   *   Worded differently: the consumer will fail after this number of polls that are not authorized or authenticated.
+   *   The default is 5.
+   */
+  def notAuthedContinuePollCount(notAuthedContinuePollCount: Int): ConsumerSettings =
+    copy(notAuthedContinuePollCount = notAuthedContinuePollCount)
 
 }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
@@ -12,7 +12,7 @@ import zio._
  * zio-kafka version.
  */
 private[internal] trait ConsumerMetrics {
-  def observePoll(resumedCount: Int, pausedCount: Int, latency: Duration, pollSize: Int): UIO[Unit]
+  def observePoll(resumedCount: Int, pausedCount: Int, latency: Duration, pollSize: Int, authFail: Boolean): UIO[Unit]
   def observeCommit(latency: Duration): UIO[Unit]
   def observeAggregatedCommit(latency: Duration, commitSize: Long): UIO[Unit]
   def observeRebalance(currentlyAssignedCount: Int, assignedCount: Int, revokedCount: Int, lostCount: Int): UIO[Unit]
@@ -92,13 +92,28 @@ private[internal] class ZioConsumerMetrics(metricLabels: Set[MetricLabel]) exten
       .contramap[Int](_.toDouble)
       .tagged(metricLabels)
 
-  override def observePoll(resumedCount: Int, pausedCount: Int, latency: Duration, pollSize: Int): UIO[Unit] =
+  private val authFailCounter: Metric.Counter[Int] =
+    Metric
+      .counterInt(
+        "ziokafka_consumer_polls_auth_fail",
+        "The number of polls that failed authorization or authentication."
+      )
+      .tagged(metricLabels)
+
+  override def observePoll(
+    resumedCount: Int,
+    pausedCount: Int,
+    latency: Duration,
+    pollSize: Int,
+    authFail: Boolean
+  ): UIO[Unit] =
     for {
       _ <- pollCounter.increment
       _ <- partitionsResumedInLatestPollGauge.update(resumedCount)
       _ <- partitionsPausedInLatestPollGauge.update(pausedCount)
       _ <- pollLatencyHistogram.update(latency)
       _ <- pollSizeHistogram.update(pollSize)
+      _ <- authFailCounter.increment
     } yield ()
 
   // -----------------------------------------------------

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -451,7 +451,7 @@ private[consumer] final class Runloop private (
       .catchSome {
         case _: AuthorizationException | AuthenticationException
             if state.pollAuthFailureCount < settings.notAuthedContinuePollCount =>
-          ZIO.succeed(RawPollResult.authFail())
+          ZIO.sleep(settings.pollTimeout).as(RawPollResult.authFail())
       }
 
   private def handlePoll(state: State): Task[State] = {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -457,7 +457,7 @@ private[consumer] final class Runloop private (
             consumerMetrics.observePollAuthError().as(true)
           case _ => ZIO.succeed(false)
         } &&
-          settings.pollAuthErrorRetrySchedule
+          settings.authErrorRetrySchedule
       )
 
   private def handlePoll(state: State): Task[State] = {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -457,8 +457,7 @@ private[consumer] final class Runloop private (
             consumerMetrics.observePollAuthError().as(true)
           case _ => ZIO.succeed(false)
         } &&
-          Schedule.recurs(settings.pollAuthErrorRetries) &&
-          Schedule.spaced(settings.pollTimeout)
+          settings.pollAuthErrorRetrySchedule
       )
 
   private def handlePoll(state: State): Task[State] = {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -450,7 +450,7 @@ private[consumer] final class Runloop private (
       // Recover from spurious auth failures:
       .catchSome {
         case _: AuthorizationException | _: AuthenticationException
-            if state.pollAuthErrorCount < settings.pollAuthErrorRetries =>
+            if state.pollAuthErrorCount + 1 <= settings.pollAuthErrorRetries =>
           ZIO.sleep(settings.pollTimeout).as(RawPollResult.authFail())
       }
 


### PR DESCRIPTION
Some brokers are sometimes too slow to authorize or authenticate a poll. This results in spurious exceptions. With this change we continue polling unless the error happens too often.

We test the change with a new type of unit test for Runloop.