### PR TITLE
Small improvements to the Producer

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -488,7 +488,7 @@ private[producer] final class ProducerLive(
 
             // Since we might be sending to multiple partitions, the callbacks
             // are _not_ necessarily called in order.
-            p.send(
+            val _ = p.send(
               rec,
               (metadata: RecordMetadata, err: Exception) => {
                 res(idx) = Either.cond(err == null, metadata, err)

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -96,12 +96,11 @@ object TransactionalProducer {
                      )(p => ZIO.attemptBlocking(p.close(settings.producerSettings.closeTimeout)).orDie)
       _         <- ZIO.attemptBlocking(rawProducer.initTransactions())
       semaphore <- Semaphore.make(1)
-      runtime   <- ZIO.runtime[Any]
       sendQueue <-
         Queue.bounded[(Chunk[ByteRecord], Promise[Nothing, Chunk[Either[Throwable, RecordMetadata]]])](
           settings.producerSettings.sendBufferSize
         )
-      live = new ProducerLive(rawProducer, runtime, sendQueue)
-      _ <- ZIO.blocking(live.sendFromQueue).forkScoped
+      live = new ProducerLive(rawProducer, sendQueue)
+      _ <- live.sendFromQueue.forkScoped
     } yield new LiveTransactionalProducer(live, semaphore)
 }


### PR DESCRIPTION
By using ZIO.async, we no longer need a reference to the zio runtime, nor do we need the `exec` trickery anymore.