### PR TITLE
Retry send records after auth exception

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
@@ -4,10 +4,22 @@ import org.apache.kafka.clients.producer.ProducerConfig
 import zio._
 import zio.kafka.security.KafkaCredentialStore
 
+/**
+ * Settings for the producer.
+ *
+ * To stay source compatible with future releases, you are recommended to construct the settings as follows:
+ * {{{
+ *   ProducerSettings(bootstrapServers)
+ *     .withClientId(clientId)
+ *     .withProperties(properties)
+ *     .... etc.
+ * }}}
+ */
 final case class ProducerSettings(
   closeTimeout: Duration = 30.seconds,
   sendBufferSize: Int = 4096,
-  properties: Map[String, AnyRef] = Map.empty
+  properties: Map[String, AnyRef] = Map.empty,
+  authErrorRetrySchedule: Schedule[Any, Throwable, Any] = Schedule.recurs(5) && Schedule.spaced(500.millis)
 ) {
   def driverSettings: Map[String, AnyRef] = properties
 
@@ -32,7 +44,29 @@ final case class ProducerSettings(
   def withCredentials(credentialsStore: KafkaCredentialStore): ProducerSettings =
     withProperties(credentialsStore.properties)
 
-  def withSendBufferSize(sendBufferSize: Int) = copy(sendBufferSize = sendBufferSize)
+  def withSendBufferSize(sendBufferSize: Int): ProducerSettings =
+    copy(sendBufferSize = sendBufferSize)
+
+  /**
+   * @param authErrorRetrySchedule
+   *   The schedule at which the producer will retry sending records to the broker, even though a send fails with an
+   *   [[org.apache.kafka.common.errors.AuthorizationException]] or
+   *   [[org.apache.kafka.common.errors.AuthenticationException]]. The schedule is fed with the firs auth error in a
+   *   batch of records, but it will decide for the entire batch. If there are any other type of errors in the batch no
+   *   sends are retried for that batch.
+   *
+   * This setting helps with failed sends due to too slow authorization or authentication in the broker.
+   *
+   * Set to `Schedule.stop` to not retry on auth errors.
+   *
+   * The default is {{{Schedule.recurs(5) && Schedule.spaced(500.millis)}}} which is, to retry 5 times, spaced by 500ms.
+   *
+   * Warning: When sending a batch of records fails partially, the failed records are retries. This leads to a
+   * re-ordering of records.
+   */
+  def withAuthErrorRetrySchedule(authErrorRetrySchedule: Schedule[Any, Throwable, Any]): ProducerSettings =
+    copy(authErrorRetrySchedule = authErrorRetrySchedule)
+
 }
 
 object ProducerSettings {

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -100,7 +100,7 @@ object TransactionalProducer {
         Queue.bounded[(Chunk[ByteRecord], Promise[Nothing, Chunk[Either[Throwable, RecordMetadata]]])](
           settings.producerSettings.sendBufferSize
         )
-      live = new ProducerLive(rawProducer, sendQueue)
+      live = new ProducerLive(rawProducer, sendQueue, settings.producerSettings)
       _ <- live.sendFromQueue.forkScoped
     } yield new LiveTransactionalProducer(live, semaphore)
 }


### PR DESCRIPTION
Some brokers are sometimes too slow to authorize or authenticate a send. This results in spurious exceptions. With this change we retry sends unless the error happens too often.

Still todo:
- [ ] make it a bit more efficient for the success case (e.g. only create schedule driver when necessary)
- [ ] make retry setup more efficient (loop through only once to collect firstAuthError, authErrorCount and errorCount
- [ ] add tests
- [ ] fix comment typo `firs auth error` => `first auth error`