### PR TITLE
Do not start streams for immediately revoked/lost partitions

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
@@ -20,6 +20,21 @@ object DiagnosticEvent {
     final case class Failure(offsets: Map[TopicPartition, OffsetAndMetadata], cause: Throwable) extends Commit
   }
 
+  /**
+   * The partitions that were involved in a rebalance.
+   *
+   * Note: when a partition was assigned and immediately revoked/lost, it will occur in multiple sets.
+   *
+   * @param revoked
+   *   the partitions that were revoked during the rebalance
+   * @param assigned
+   *   the partitions that were assigned during the rebalance
+   * @param lost
+   *   the partitions that were lost during the rebalance
+   * @param ended
+   *   the partition streams that were ended during the rebalance, a partition stream can be ended because it was
+   *   revoked/lost or because `restartStreamsOnRebalancing` is used
+   */
   final case class Rebalance(
     revoked: Set[TopicPartition],
     assigned: Set[TopicPartition],


### PR DESCRIPTION
As discovered by @ytalashko (see https://github.com/zio/zio-kafka/pull/1294), it is possible that a partition is assigned and immediately revoked in the same poll. No stream should be started for these partitions.

Unlike #1294, this PR does _not_ hide the assigned+revoked partitions from the diagnostic events and rebalance metrics. In addition, this PR also supports the unlikely event of a assigned+lost partition.