### PR TITLE
Update to Kafka 3.8.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ import MimaSettings.mimaSettings
  */
 lazy val binCompatVersionToCompare = None // Some("2.8.0")
 
-lazy val kafkaVersion         = "3.7.1"
+lazy val kafkaVersion         = "3.8.0"
 lazy val embeddedKafkaVersion = "3.7.1.1" // Should be the same as kafkaVersion, except for the patch part
 
 lazy val kafkaClients = "org.apache.kafka" % "kafka-clients"   % kafkaVersion

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ import MimaSettings.mimaSettings
 lazy val binCompatVersionToCompare = None // Some("2.8.0")
 
 lazy val kafkaVersion         = "3.8.0"
-lazy val embeddedKafkaVersion = "3.7.1.1" // Should be the same as kafkaVersion, except for the patch part
+lazy val embeddedKafkaVersion = "3.8.0" // Should be the same as kafkaVersion, except for the patch part
 
 lazy val kafkaClients = "org.apache.kafka" % "kafka-clients"   % kafkaVersion
 lazy val logback      = "ch.qos.logback"   % "logback-classic" % "1.5.7"

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/Kafka.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/Kafka.scala
@@ -1,6 +1,5 @@
 package zio.kafka.testkit
 
-import _root_.kafka.server.KafkaConfig
 import io.github.embeddedkafka.{ EmbeddedK, EmbeddedKafka, EmbeddedKafkaConfig }
 import zio._
 
@@ -78,23 +77,23 @@ object Kafka {
     embeddedWithBrokerProps(
       ports =>
         Map(
-          "group.min.session.timeout.ms"          -> "500",
-          "group.initial.rebalance.delay.ms"      -> "0",
-          "authorizer.class.name"                 -> "kafka.security.authorizer.AclAuthorizer",
-          "super.users"                           -> "User:ANONYMOUS",
-          "ssl.client.auth"                       -> "required",
-          "ssl.enabled.protocols"                 -> "TLSv1.2",
-          "ssl.truststore.type"                   -> "JKS",
-          "ssl.keystore.type"                     -> "JKS",
-          "ssl.truststore.location"               -> KafkaTestUtils.trustStoreFile.getAbsolutePath,
-          "ssl.truststore.password"               -> "123456",
-          "ssl.keystore.location"                 -> KafkaTestUtils.keyStoreFile.getAbsolutePath,
-          "ssl.keystore.password"                 -> "123456",
-          "ssl.key.password"                      -> "123456",
-          KafkaConfig.InterBrokerListenerNameProp -> "SSL",
-          KafkaConfig.ListenersProp               -> s"SSL://localhost:${ports.kafkaPort}",
-          KafkaConfig.AdvertisedListenersProp     -> s"SSL://localhost:${ports.kafkaPort}",
-          KafkaConfig.ZkConnectionTimeoutMsProp   -> s"${30.second.toMillis}"
+          "group.min.session.timeout.ms"     -> "500",
+          "group.initial.rebalance.delay.ms" -> "0",
+          "authorizer.class.name"            -> "kafka.security.authorizer.AclAuthorizer",
+          "super.users"                      -> "User:ANONYMOUS",
+          "ssl.client.auth"                  -> "required",
+          "ssl.enabled.protocols"            -> "TLSv1.2",
+          "ssl.truststore.type"              -> "JKS",
+          "ssl.keystore.type"                -> "JKS",
+          "ssl.truststore.location"          -> KafkaTestUtils.trustStoreFile.getAbsolutePath,
+          "ssl.truststore.password"          -> "123456",
+          "ssl.keystore.location"            -> KafkaTestUtils.keyStoreFile.getAbsolutePath,
+          "ssl.keystore.password"            -> "123456",
+          "ssl.key.password"                 -> "123456",
+          "inter.broker.listener.name"       -> "SSL",
+          "listeners"                        -> s"SSL://localhost:${ports.kafkaPort}",
+          "advertised.listeners"             -> s"SSL://localhost:${ports.kafkaPort}",
+          "zookeeper.connection.timeout.ms"  -> s"${30.second.toMillis}"
         ),
       customBrokerProps
     )

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -1046,6 +1046,14 @@ object AdminClient {
       override def asJava: JConsumerGroupState = JConsumerGroupState.EMPTY
     }
 
+    case object Assigning extends ConsumerGroupState {
+      override def asJava: JConsumerGroupState = JConsumerGroupState.ASSIGNING
+    }
+
+    case object Reconciling extends ConsumerGroupState {
+      override def asJava: JConsumerGroupState = JConsumerGroupState.RECONCILING
+    }
+
     def apply(state: JConsumerGroupState): ConsumerGroupState =
       state match {
         case JConsumerGroupState.UNKNOWN              => ConsumerGroupState.Unknown
@@ -1054,6 +1062,8 @@ object AdminClient {
         case JConsumerGroupState.STABLE               => ConsumerGroupState.Stable
         case JConsumerGroupState.DEAD                 => ConsumerGroupState.Dead
         case JConsumerGroupState.EMPTY                => ConsumerGroupState.Empty
+        case JConsumerGroupState.ASSIGNING            => ConsumerGroupState.Assigning
+        case JConsumerGroupState.RECONCILING          => ConsumerGroupState.Reconciling
       }
   }
 


### PR DESCRIPTION
📦 Updates [org.apache.kafka:kafka-clients](https://kafka.apache.org/) from 3.7.1 to 3.8.0

📦 Updates [io.github.embeddedkafka:embedded-kafka](https://github.com/embeddedkafka/embedded-kafka) from `3.7.1.1` to `3.8.0`

📜 [GitHub Release Notes](https://github.com/embeddedkafka/embedded-kafka/releases/tag/v3.8.0) - [Version Diff](https://github.com/embeddedkafka/embedded-kafka/compare/v3.7.1.1...v3.8.0)
