### PR TITLE
Produce sequentially and in parallel in benchmark

### DIFF
--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ProducerBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ProducerBenchmark.scala
@@ -8,7 +8,7 @@ import zio.kafka.serde.Serde
 import zio.kafka.testkit.Kafka
 import zio.kafka.testkit.KafkaTestUtils.producer
 import zio.stream.ZStream
-import zio.{Chunk, ZIO, ZLayer}
+import zio.{ Chunk, ZIO, ZLayer }
 
 import java.util.concurrent.TimeUnit
 


### PR DESCRIPTION
Tests the produced in sequential and parallel settings.

Also, changes the number of iterations to reduce runtime. Because the results are now no longer comparable to the previous tests, the existing tests have been renamed.