### PR TITLE
More precise batch publish errors

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/producer/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/producer/ProducerSpec.scala
@@ -1,0 +1,228 @@
+package zio.kafka.producer
+
+import org.apache.kafka.clients.producer
+import org.apache.kafka.clients.producer.{ MockProducer, ProducerRecord, RecordMetadata }
+import org.apache.kafka.common.KafkaException
+import org.apache.kafka.common.errors.AuthenticationException
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import zio._
+import zio.test.TestAspect.withLiveClock
+import zio.test._
+
+import java.util.concurrent.Future
+import java.util.concurrent.atomic.AtomicBoolean
+
+object ProducerSpec extends ZIOSpecDefault {
+
+  private object TestKeyValueSerializer extends ByteArraySerializer
+
+  private class BinaryMockProducer(autoComplete: Boolean)
+      extends MockProducer[Array[Byte], Array[Byte]](
+        autoComplete,
+        TestKeyValueSerializer,
+        TestKeyValueSerializer
+      ) {
+
+    private val nextSendAllowed = new AtomicBoolean(autoComplete)
+
+    override def send(
+      record: ProducerRecord[Array[Byte], Array[Byte]],
+      callback: producer.Callback
+    ): Future[RecordMetadata] = {
+      awaitSendAllowed()
+      val sendResult = super.send(record, callback)
+      nextSendAllowed.set(autoComplete)
+
+      sendResult
+    }
+
+    def allowNextSendAndAwaitSendCompletion(): Unit = {
+      allowNextSend()
+      awaitSendCompletion()
+    }
+
+    def allowNextSend(): Unit =
+      nextSendAllowed.set(true)
+
+    def awaitSendAllowed(): Unit =
+      awaitSendCondition(true)
+
+    def awaitSendCompletion(): Unit =
+      awaitSendCondition(false)
+
+    private def awaitSendCondition(expectedCondition: Boolean): Unit = {
+      var awaitingSendCondition = true
+      while (awaitingSendCondition)
+        awaitingSendCondition = expectedCondition != nextSendAllowed.get()
+    }
+
+  }
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("Producer")(
+      suite("produceChunkAsyncWithFailures")(
+        test("successfully produces chunk of records") {
+          withProducer() { (_, producer) =>
+            val recordsToSend = Chunk(
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord()
+            )
+            for {
+              results <- producer.produceChunkAsyncWithFailures(recordsToSend).flatten
+            } yield assertTrue(
+              results.length == recordsToSend.length,
+              results.forall(_.isRight)
+            )
+          }
+        },
+        test("omits sending further records in chunk in case the first send call fails") {
+          withProducer() { (mockJavaProducer, producer) =>
+            val recordsToSend = Chunk(
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord()
+            )
+            val testAuthenticationExceptionMessage = "test authentication exception"
+            mockJavaProducer.sendException = new AuthenticationException(testAuthenticationExceptionMessage)
+            for {
+              results <- producer.produceChunkAsyncWithFailures(recordsToSend).flatten
+            } yield assertTrue(
+              results.length == recordsToSend.length,
+              results.head.isLeft,
+              results.head.left.forall(_.getMessage == testAuthenticationExceptionMessage),
+              results.tail.forall(_ == Left(Producer.PublishOmittedException))
+            )
+          }
+        },
+        test("provides correct results in case last send call fails") {
+          withProducer(autoCompleteProducerRequests = false) { (mockJavaProducer, producer) =>
+            val recordsToSend = Chunk(
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord()
+            )
+            val testAuthenticationExceptionMessage = "test authentication exception"
+            val mockJavaProducerBehaviour = ZIO.succeed {
+              // Send calls behaviours
+              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
+              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
+              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
+              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
+              mockJavaProducer.sendException = new AuthenticationException(testAuthenticationExceptionMessage)
+              mockJavaProducer.allowNextSend()
+              // Send callbacks behaviours
+              mockJavaProducer.completeNext()
+              mockJavaProducer.completeNext()
+              mockJavaProducer.completeNext()
+              mockJavaProducer.completeNext()
+            }
+            for {
+              _       <- mockJavaProducerBehaviour.forkScoped
+              results <- producer.produceChunkAsyncWithFailures(recordsToSend).flatten
+            } yield assertTrue(
+              results.length == recordsToSend.length,
+              results.init.forall(_.isRight),
+              results.last.isLeft,
+              results.last.left.forall(_.getMessage == testAuthenticationExceptionMessage)
+            )
+          }
+        },
+        test("omits sending further records in chunk and provides correct results in case middle send call fails") {
+          withProducer(autoCompleteProducerRequests = false) { (mockJavaProducer, producer) =>
+            val recordsToSend = Chunk(
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord()
+            )
+            val testAuthenticationExceptionMessage = "test authentication exception"
+            val mockJavaProducerBehaviour = ZIO.succeed {
+              // Send calls behaviours
+              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
+              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
+              mockJavaProducer.sendException = new AuthenticationException(testAuthenticationExceptionMessage)
+              mockJavaProducer.allowNextSend()
+              // Send callbacks behaviours
+              mockJavaProducer.completeNext()
+              mockJavaProducer.completeNext()
+            }
+            for {
+              _       <- mockJavaProducerBehaviour.forkScoped
+              results <- producer.produceChunkAsyncWithFailures(recordsToSend).flatten
+            } yield assertTrue(
+              results.length == recordsToSend.length,
+              results(0).isRight,
+              results(1).isRight,
+              results(2).left.forall(_.getMessage == testAuthenticationExceptionMessage),
+              results(3) == Left(Producer.PublishOmittedException),
+              results(4) == Left(Producer.PublishOmittedException)
+            )
+          }
+        },
+        test(
+          "omits sending further records in chunk and provides correct results in case second publication to broker fails along with middle send call fails"
+        ) {
+          withProducer(autoCompleteProducerRequests = false) { (mockJavaProducer, producer) =>
+            val recordsToSend = Chunk(
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord(),
+              makeProducerRecord()
+            )
+            val testAuthenticationExceptionMessage = "test authentication exception"
+            val testKafkaExceptionMessage          = "unexpected broker exception"
+            val mockJavaProducerBehaviour = ZIO.succeed {
+              // Send calls behaviours
+              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
+              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
+              mockJavaProducer.sendException = new AuthenticationException(testAuthenticationExceptionMessage)
+              mockJavaProducer.allowNextSend()
+              // Send callbacks behaviours
+              mockJavaProducer.completeNext()
+              mockJavaProducer.errorNext(new KafkaException(testKafkaExceptionMessage))
+            }
+            for {
+              _       <- mockJavaProducerBehaviour.forkScoped
+              results <- producer.produceChunkAsyncWithFailures(recordsToSend).flatten
+            } yield assertTrue(
+              results.length == recordsToSend.length,
+              results(0).isRight,
+              results(1).isLeft,
+              results(1).left.forall(_.getMessage == testKafkaExceptionMessage),
+              results(2).left.forall(_.getMessage == testAuthenticationExceptionMessage),
+              results(3) == Left(Producer.PublishOmittedException),
+              results(4) == Left(Producer.PublishOmittedException)
+            )
+          }
+        }
+      )
+    ) @@ withLiveClock
+
+  private def withProducer(autoCompleteProducerRequests: Boolean = true)(
+    producerTest: (BinaryMockProducer, Producer) => ZIO[Scope, Throwable, TestResult]
+  ): ZIO[Scope, Throwable, TestResult] =
+    ZIO.scoped {
+      val mockJavaProducer = new BinaryMockProducer(autoCompleteProducerRequests)
+
+      Producer
+        .fromJavaProducer(mockJavaProducer, ProducerSettings())
+        .flatMap(producerTest(mockJavaProducer, _))
+    }
+
+  private def makeProducerRecord(
+    topic: String = "testTopic",
+    key: String = "key",
+    value: String = "value"
+  ): ProducerRecord[Array[Byte], Array[Byte]] =
+    new ProducerRecord[Array[Byte], Array[Byte]](topic, key.getBytes, value.getBytes)
+
+}

--- a/zio-kafka-test/src/test/scala/zio/kafka/producer/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/producer/ProducerSpec.scala
@@ -168,7 +168,7 @@ object ProducerSpec extends ZIOSpecDefault {
           }
         },
         test(
-          "omits sending further records in chunk and provides correct results in case second publication to broker fails along with middle send call fails"
+          "omits sending further records in chunk and provides correct results in case second publication to broker fails along with middle send call failure"
         ) {
           withProducer(autoCompleteProducerRequests = false) { (mockJavaProducer, producer) =>
             val recordsToSend = Chunk(

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -8,9 +8,8 @@ import zio.kafka.serde.Serializer
 import zio.kafka.utils.SslHelper
 import zio.stream.{ ZPipeline, ZStream }
 
-import java.util.concurrent.atomic.AtomicInteger
 import scala.jdk.CollectionConverters._
-import scala.util.control.NonFatal
+import scala.util.control.{ NoStackTrace, NonFatal }
 
 trait Producer {
 
@@ -187,6 +186,10 @@ trait Producer {
 }
 
 object Producer {
+  case object SendOmittedDueToPreviousRecordSendCallFailureError
+      extends RuntimeException("Send omitted due to the previous record send call failure")
+      with NoStackTrace
+
   val live: RLayer[ProducerSettings, Producer] =
     ZLayer.scoped {
       for {
@@ -466,41 +469,72 @@ private[producer] final class ProducerLive(
     ZStream
       .fromQueueWithShutdown(sendQueue)
       .mapZIO { case (serializedRecords, done) =>
-        ZIO.succeed {
-          try {
-            val it: Iterator[(ByteRecord, Int)] = serializedRecords.iterator.zipWithIndex
-            val res: Array[Either[Throwable, RecordMetadata]] =
-              new Array[Either[Throwable, RecordMetadata]](serializedRecords.length)
-            val count: AtomicInteger = new AtomicInteger
-            val length               = serializedRecords.length
+        ZIO.suspendSucceed {
+          val recordsLength                                = serializedRecords.length
+          val recordsIterator: Iterator[(ByteRecord, Int)] = serializedRecords.iterator.zipWithIndex
+          val sentResults: Array[Either[Throwable, RecordMetadata]] =
+            new Array[Either[Throwable, RecordMetadata]](recordsLength)
 
-            while (it.hasNext) {
-              val (rec, idx): (ByteRecord, Int) = it.next()
-
-              val _ = p.send(
-                rec,
-                (metadata: RecordMetadata, err: Exception) =>
-                  Unsafe.unsafe { implicit u =>
-                    exec {
-                      if (err != null) res(idx) = Left(err)
-                      else res(idx) = Right(metadata)
-
-                      if (count.incrementAndGet == length) {
-                        exec {
-                          runtime.unsafe.run(done.succeed(Chunk.fromArray(res))).getOrThrowFiberFailure()
-                        }
-                      }
-                    }
-                  }
-              )
-            }
-          } catch {
-            case NonFatal(e) =>
+          Ref.make(0).map { sentRecordsCountRef =>
+            @inline def safelyInsertSentResult(resultIndex: Int, sentResult: Either[Throwable, RecordMetadata]): Unit =
               Unsafe.unsafe { implicit u =>
                 exec {
-                  runtime.unsafe.run(done.succeed(Chunk.fill(serializedRecords.size)(Left(e)))).getOrThrowFiberFailure()
+                  runtime.unsafe.run(
+                    sentRecordsCountRef.update { sentRecordsCount =>
+                      // Updating sentResults[resultIndex] here is safe:
+                      //  - Ref.update guarantees sentResults.update executed atomically
+                      //  - Ref.update starts with volatile variable read and ends with volatile variable write,
+                      //    which guarantees sentResults.update executed on the latest updated version of sentResults
+                      //    and currently updated version of sentResults
+                      //    will be visible to the next sentResults read or update called within Ref.update
+                      sentResults.update(resultIndex, sentResult)
+
+                      val newSentRecordsCount = sentRecordsCount + 1
+                      if (newSentRecordsCount == recordsLength) {
+                        val sentResultsChunk = Chunk.fromArray(sentResults)
+
+                        exec {
+                          runtime.unsafe.run(done.succeed(sentResultsChunk))
+                        }
+                      }
+
+                      newSentRecordsCount
+                    }
+                  )
                 }
               }
+
+            var previousSendCallSucceed = true
+
+            while (recordsIterator.hasNext) {
+              val (record: ByteRecord, recordIndex: Int) = recordsIterator.next()
+
+              if (previousSendCallSucceed) {
+                try {
+                  val _ = p.send(
+                    record,
+                    (metadata: RecordMetadata, err: Exception) =>
+                      safelyInsertSentResult(
+                        recordIndex,
+                        if (err eq null) Right(metadata) else Left(err)
+                      )
+                  )
+                } catch {
+                  case NonFatal(err) =>
+                    previousSendCallSucceed = false
+
+                    safelyInsertSentResult(
+                      recordIndex,
+                      Left(err)
+                    )
+                }
+              } else {
+                safelyInsertSentResult(
+                  recordIndex,
+                  Left(Producer.SendOmittedDueToPreviousRecordSendCallFailureError)
+                )
+              }
+            }
           }
         }
       }

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -186,8 +186,8 @@ trait Producer {
 }
 
 object Producer {
-  case object SendOmittedException
-      extends RuntimeException("Send omitted due to a send error for a previous record in the chunk")
+  case object PublishOmittedException
+      extends RuntimeException("Publish omitted due to a publish error for a previous record in the chunk")
       with NoStackTrace
 
   val live: RLayer[ProducerSettings, Producer] =
@@ -528,7 +528,7 @@ private[producer] final class ProducerLive(
               } else {
                 safelyInsertSentResult(
                   recordIndex,
-                  Left(Producer.SendOmittedException)
+                  Left(Producer.PublishOmittedException)
                 )
               }
             }

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -103,6 +103,9 @@ trait Producer {
   /**
    * Produces a chunk of records. See [[produceChunkAsync(records*]] for version that allows to avoid round-trip-time
    * penalty for each chunk.
+   *
+   * When publishing any of the records fails, the whole batch fails even though some records might have been published.
+   * Use [[produceChunkAsyncWithFailures]] to get results per record.
    */
   def produceChunk(
     records: Chunk[ProducerRecord[Array[Byte], Array[Byte]]]
@@ -111,6 +114,9 @@ trait Producer {
   /**
    * Produces a chunk of records. See [[produceChunkAsync(records*]] for version that allows to avoid round-trip-time
    * penalty for each chunk.
+   *
+   * When publishing any of the records fails, the whole batch fails even though some records might have been published.
+   * Use [[produceChunkAsyncWithFailures]] to get results per record.
    */
   def produceChunk[R, K, V](
     records: Chunk[ProducerRecord[K, V]],
@@ -127,6 +133,9 @@ trait Producer {
    * It is possible that for chunks that exceed the producer's internal buffer size, the outer layer will also signal
    * the transmission of part of the chunk. Regardless, awaiting the inner layer guarantees the transmission of the
    * entire chunk.
+   *
+   * When publishing any of the records fails, the whole batch fails even though some records might have been published.
+   * Use [[produceChunkAsyncWithFailures]] to get results per record.
    */
   def produceChunkAsync(
     records: Chunk[ProducerRecord[Array[Byte], Array[Byte]]]
@@ -141,6 +150,9 @@ trait Producer {
    * It is possible that for chunks that exceed the producer's internal buffer size, the outer layer will also signal
    * the transmission of part of the chunk. Regardless, awaiting the inner layer guarantees the transmission of the
    * entire chunk.
+   *
+   * When publishing any of the records fails, the whole batch fails even though some records might have been published.
+   * Use [[produceChunkAsyncWithFailures]] to get results per record.
    */
   def produceChunkAsync[R, K, V](
     records: Chunk[ProducerRecord[K, V]],
@@ -160,6 +172,9 @@ trait Producer {
    *
    * This variant of `produceChunkAsync` more accurately reflects that individual records within the Chunk can fail to
    * publish, rather than the failure being at the level of the Chunk.
+   *
+   * When attempt to send a record into buffer for publication fails, the following records in the chunk are not
+   * published. This is indicated with a [[Producer.PublishOmittedException]].
    *
    * This variant does not accept serializers as they may also fail independently of each record and this is not
    * reflected in the return type.


### PR DESCRIPTION
This increases the precision of the result of producer method `produceChunkAsyncWithFailures` for cases where something went wrong. There are two changes compared to before:

1. Each entry in the result of`produceChunkAsyncWithFailures` now accurately corresponds to each record in the input chunk. Previously, if sending fails directly (*) on any of the given records, the error would be used for _all_ records in the batch, ignoring the send-outcome of the other records. An advantage of this change is that if sending some records failed, but some other records were actually sent, you can now correctly see all of that in the method's response.
2. In addition, if sending fails directly for a record (*), we no longer attempt to send subsequent records from the input. The result contains a `PublishOmittedException` for each record that is not sent. When implementing retries, this change makes it easier to publish records in the original order.

In addition, we introduce unit-level tests for the producer.

(*) By 'sending' we mean offering a record to the underlying java Kafka producer. Sending can fail directly (when we call the method), or later on (from a callback).