### PR TITLE
Optimize Producer sendFromQueue implementation

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -8,6 +8,7 @@ import zio.kafka.serde.Serializer
 import zio.kafka.utils.SslHelper
 import zio.stream.{ ZPipeline, ZStream }
 
+import java.util.concurrent.atomic.AtomicInteger
 import scala.jdk.CollectionConverters._
 import scala.util.control.{ NoStackTrace, NonFatal }
 
@@ -484,68 +485,68 @@ private[producer] final class ProducerLive(
     ZStream
       .fromQueueWithShutdown(sendQueue)
       .mapZIO { case (serializedRecords, done) =>
-        ZIO.suspendSucceed {
+        ZIO.succeed {
           val recordsLength                                = serializedRecords.length
+          val sentRecordsCounter                           = new AtomicInteger(0)
           val recordsIterator: Iterator[(ByteRecord, Int)] = serializedRecords.iterator.zipWithIndex
           val sentResults: Array[Either[Throwable, RecordMetadata]] =
             new Array[Either[Throwable, RecordMetadata]](recordsLength)
 
-          Ref.make(0).map { sentRecordsCountRef =>
-            @inline def safelyInsertSentResult(resultIndex: Int, sentResult: Either[Throwable, RecordMetadata]): Unit =
-              Unsafe.unsafe { implicit u =>
-                exec {
-                  runtime.unsafe.run(
-                    sentRecordsCountRef.update { sentRecordsCount =>
-                      // Updating sentResults[resultIndex] here is safe,
-                      //  cause Ref.update starts with volatile variable read and ends with volatile variable write,
-                      //  which guarantees sentResults.update executed on the latest updated version of sentResults
-                      //  and currently updated version of sentResults
-                      //  will be visible to the next sentResults read or update called within Ref.update
-                      sentResults.update(resultIndex, sentResult)
+          @inline def insertSentResult(resultIndex: Int, sentResult: Either[Throwable, RecordMetadata]): Unit = {
+            var notInserted = true
 
-                      val newSentRecordsCount = sentRecordsCount + 1
-                      if (newSentRecordsCount == recordsLength) {
-                        val sentResultsChunk = Chunk.fromArray(sentResults)
+            while (notInserted) {
+              val sentRecordsCount = sentRecordsCounter.get()
 
-                        exec {
-                          runtime.unsafe.run(done.succeed(sentResultsChunk))
-                        }
-                      }
+              // Updating sentResults[resultIndex] here is safe,
+              //  because volatile variable read performed right before the update and volatile variable write after,
+              //  which guarantees sentResults.update executed on the latest updated version of sentResults
+              //  and currently updated version of sentResults
+              //  will be visible to the next sentResults read or update called after volatile variable read
+              sentResults.update(resultIndex, sentResult)
 
-                      newSentRecordsCount
-                    }
-                  )
+              val newSentRecordsCount = sentRecordsCount + 1
+              if (newSentRecordsCount == recordsLength) {
+                val sentResultsChunk = Chunk.fromArray(sentResults)
+
+                Unsafe.unsafe { implicit u =>
+                  exec {
+                    runtime.unsafe.run(done.succeed(sentResultsChunk))
+                  }
                 }
               }
 
-            var previousSendCallsSucceed = true
+              notInserted = !sentRecordsCounter.compareAndSet(sentRecordsCount, newSentRecordsCount)
+            }
+          }
 
-            recordsIterator.foreach { case (record: ByteRecord, recordIndex: Int) =>
-              if (previousSendCallsSucceed) {
-                try {
-                  val _ = p.send(
-                    record,
-                    (metadata: RecordMetadata, err: Exception) =>
-                      safelyInsertSentResult(
-                        recordIndex,
-                        if (err eq null) Right(metadata) else Left(err)
-                      )
-                  )
-                } catch {
-                  case NonFatal(err) =>
-                    previousSendCallsSucceed = false
+          var previousSendCallsSucceed = true
 
-                    safelyInsertSentResult(
+          recordsIterator.foreach { case (record: ByteRecord, recordIndex: Int) =>
+            if (previousSendCallsSucceed) {
+              try {
+                val _ = p.send(
+                  record,
+                  (metadata: RecordMetadata, err: Exception) =>
+                    insertSentResult(
                       recordIndex,
-                      Left(err)
+                      if (err eq null) Right(metadata) else Left(err)
                     )
-                }
-              } else {
-                safelyInsertSentResult(
-                  recordIndex,
-                  Left(Producer.PublishOmittedException)
                 )
+              } catch {
+                case NonFatal(err) =>
+                  previousSendCallsSucceed = false
+
+                  insertSentResult(
+                    recordIndex,
+                    Left(err)
+                  )
               }
+            } else {
+              insertSentResult(
+                recordIndex,
+                Left(Producer.PublishOmittedException)
+              )
             }
           }
         }


### PR DESCRIPTION
From java's producer send method doc: `Note that callbacks will generally execute in the I/O thread of the producer and so should be reasonably fast or they will delay the sending of messages from other threads`.
I believe we should try to keep callback implementation fast, but with recent changes we added to provide proper error responses, we make the callback slower. In general we are talking approximately about 1-3 microseconds (current master) instead of 0,1-0,2 microseconds (version 2.8.2) for single callback execution time on my laptop. I believe it was reasonable, but at the same time wanted to keep implementation fast, and provided the fastest version I come up with at that time.
Now, I got with an idea of faster implementation (with keeping the same proper error semantics). With this implementation single callback execution takes approximately 0,05-0,2 microseconds (even a bit faster than version 2.8.2).
