### PR TITLE
Remove lost partitions from assigned streams

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -106,7 +106,7 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
         Diagnostics.SlidingQueue.make(100).flatMap { diagnostics =>
           var rebalanceListener: ConsumerRebalanceListener = null
 
-          // Catches the rebalance listener so we can
+          // Catches the rebalance listener so we can use it
           val mockConsumer: BinaryMockConsumer = new BinaryMockConsumer(OffsetResetStrategy.LATEST) {
             override def subscribe(
               topics: util.Collection[String],

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -567,9 +567,10 @@ private[consumer] final class Runloop private (
                                       s"Not all assigned partitions have a (single) stream or vice versa. Assigned: ${assignedTps.mkString(",")}, streams: ${updatedAssignedStreams.map(_.tp).mkString(",")}"
                                     )
                                     .when(
-                                      assignedTps != updatedAssignedStreams
-                                        .map(_.tp)
-                                        .toSet || assignedTps.size != updatedAssignedStreams.size
+                                      assignedTps.size != updatedAssignedStreams.size ||
+                                        assignedTps != updatedAssignedStreams
+                                          .map(_.tp)
+                                          .toSet
                                     )
                               } yield Runloop.PollResult(
                                 records = polledRecords,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -560,6 +560,13 @@ private[consumer] final class Runloop private (
                                          ended = endedStreams.map(_.tp).toSet
                                        )
                                      )
+                                // Ensure that all assigned partitions have a stream and no streams are present for unassigned streams
+                                _ <-
+                                  ZIO
+                                    .logWarning(
+                                      s"Not all assigned partitions have a stream or vice versa. Assigned: ${assignedTps.mkString(",")}, streams: ${state.assignedStreams.map(_.tp).mkString(",")}"
+                                    )
+                                    .when(assignedTps != state.assignedStreams.map(_.tp).toSet)
                               } yield Runloop.PollResult(
                                 records = polledRecords,
                                 ignoreRecordsForTps = ignoreRecordsForTps,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -564,9 +564,13 @@ private[consumer] final class Runloop private (
                                 _ <-
                                   ZIO
                                     .logWarning(
-                                      s"Not all assigned partitions have a stream or vice versa. Assigned: ${assignedTps.mkString(",")}, streams: ${state.assignedStreams.map(_.tp).mkString(",")}"
+                                      s"Not all assigned partitions have a (single) stream or vice versa. Assigned: ${assignedTps.mkString(",")}, streams: ${state.assignedStreams.map(_.tp).mkString(",")}"
                                     )
-                                    .when(assignedTps != state.assignedStreams.map(_.tp).toSet)
+                                    .when(
+                                      assignedTps != state.assignedStreams
+                                        .map(_.tp)
+                                        .toSet || assignedTps.size != state.assignedStreams.size
+                                    )
                               } yield Runloop.PollResult(
                                 records = polledRecords,
                                 ignoreRecordsForTps = ignoreRecordsForTps,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -564,12 +564,12 @@ private[consumer] final class Runloop private (
                                 _ <-
                                   ZIO
                                     .logWarning(
-                                      s"Not all assigned partitions have a (single) stream or vice versa. Assigned: ${assignedTps.mkString(",")}, streams: ${state.assignedStreams.map(_.tp).mkString(",")}"
+                                      s"Not all assigned partitions have a (single) stream or vice versa. Assigned: ${assignedTps.mkString(",")}, streams: ${updatedAssignedStreams.map(_.tp).mkString(",")}"
                                     )
                                     .when(
-                                      assignedTps != state.assignedStreams
+                                      assignedTps != updatedAssignedStreams
                                         .map(_.tp)
-                                        .toSet || assignedTps.size != state.assignedStreams.size
+                                        .toSet || assignedTps.size != updatedAssignedStreams.size
                                     )
                               } yield Runloop.PollResult(
                                 records = polledRecords,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -564,13 +564,12 @@ private[consumer] final class Runloop private (
                                 _ <-
                                   ZIO
                                     .logWarning(
-                                      s"Not all assigned partitions have a (single) stream or vice versa. Assigned: ${assignedTps.mkString(",")}, streams: ${updatedAssignedStreams.map(_.tp).mkString(",")}"
+                                      s"Not all assigned partitions have a (single) stream or vice versa. Assigned: ${currentAssigned.mkString(",")}, streams: ${updatedAssignedStreams.map(_.tp).mkString(",")}"
                                     )
                                     .when(
-                                      assignedTps.size != updatedAssignedStreams.size ||
-                                        assignedTps != updatedAssignedStreams
-                                          .map(_.tp)
-                                          .toSet
+                                      currentAssigned != updatedAssignedStreams
+                                        .map(_.tp)
+                                        .toSet || currentAssigned.size != updatedAssignedStreams.size
                                     )
                               } yield Runloop.PollResult(
                                 records = polledRecords,


### PR DESCRIPTION
Fixes #1288. See also #1233 and #1250.

When all partitions are lost after some connection issue to the broker, the streams for lost partitions are ended but polling stops, due to the conditions in `Runloop.State#shouldPoll`. This PR fixes this by removing the lost partition streams from the `assignedStreams` in the state, thereby not disabling polling. 

Also adds a warning that is logged whenever the assigned partitions (according to the apache kafka consumer) are different from the assigned streams, which helps to identify other issues or any future regressions of this issue.

~Still needs a good test, the `MockConsumer` used in other tests unfortunately does not allow simulating lost partitions, and the exact behavior of the kafka client in this situation is hard to predict..~ 
Includes a test that fails when undoing the change to Runloop