### PR TITLE
More specific errors than Throwable for Consumer

### DIFF
--- a/zio-kafka-example/src/main/scala/zio/kafka/example/Main.scala
+++ b/zio-kafka-example/src/main/scala/zio/kafka/example/Main.scala
@@ -2,6 +2,7 @@ package zio.kafka.example
 
 import io.github.embeddedkafka.{ EmbeddedK, EmbeddedKafka, EmbeddedKafkaConfig }
 import zio._
+import zio.kafka.consumer.Consumer.ConsumerError
 import zio.kafka.consumer.diagnostics.Diagnostics
 import zio.kafka.consumer.{ Consumer, ConsumerSettings, Subscription }
 import zio.kafka.serde.Serde
@@ -49,7 +50,7 @@ object Main extends ZIOAppDefault {
       .withGroupId("test")
   }
 
-  private val runConsumerStream: ZIO[Consumer, Throwable, Unit] =
+  private val runConsumerStream: ZIO[Consumer, ConsumerError, Unit] =
     for {
       _ <- ZIO.logInfo("Consuming messages...")
       consumed <- Consumer

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -2,7 +2,7 @@ package zio.kafka.consumer
 
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import zio._
-import zio.kafka.consumer.Consumer.OffsetRetrieval
+import zio.kafka.consumer.Consumer.{ ConsumerError, OffsetRetrieval }
 import zio.kafka.consumer.fetch.{ FetchStrategy, QueueSizeBasedFetchStrategy }
 import zio.kafka.security.KafkaCredentialStore
 import zio.metrics.MetricLabel
@@ -31,7 +31,7 @@ final case class ConsumerSettings(
   fetchStrategy: FetchStrategy = QueueSizeBasedFetchStrategy(),
   metricLabels: Set[MetricLabel] = Set.empty,
   runloopMetricsSchedule: Schedule[Any, Unit, Long] = Schedule.fixed(500.millis),
-  authErrorRetrySchedule: Schedule[Any, Throwable, Any] = Schedule.recurs(5) && Schedule.spaced(500.millis)
+  authErrorRetrySchedule: Schedule[Any, ConsumerError, Any] = Schedule.recurs(5) && Schedule.spaced(500.millis)
 ) {
   // Parse booleans in a way compatible with how Kafka does this in org.apache.kafka.common.config.ConfigDef.parseType:
   require(
@@ -316,7 +316,7 @@ final case class ConsumerSettings(
    *
    * The default is {{{Schedule.recurs(5) && Schedule.spaced(500.millis)}}} which is, to retry 5 times, spaced by 500ms.
    */
-  def withAuthErrorRetrySchedule(authErrorRetrySchedule: Schedule[Any, Throwable, Any]): ConsumerSettings =
+  def withAuthErrorRetrySchedule(authErrorRetrySchedule: Schedule[Any, ConsumerError, Any]): ConsumerSettings =
     copy(authErrorRetrySchedule = authErrorRetrySchedule)
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/InvalidSubscriptionUnion.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/InvalidSubscriptionUnion.scala
@@ -1,6 +1,0 @@
-package zio.kafka.consumer
-
-import zio.Chunk
-
-final case class InvalidSubscriptionUnion(subscriptions: Chunk[Subscription])
-    extends RuntimeException(s"Unable to calculate union of subscriptions: ${subscriptions.mkString(",")}")

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
@@ -2,6 +2,7 @@ package zio.kafka.consumer.diagnostics
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
+import zio.kafka.consumer.Consumer.CommitError
 
 sealed trait DiagnosticEvent
 object DiagnosticEvent {
@@ -17,7 +18,7 @@ object DiagnosticEvent {
   object Commit {
     final case class Started(offsets: Map[TopicPartition, OffsetAndMetadata])                   extends Commit
     final case class Success(offsets: Map[TopicPartition, OffsetAndMetadata])                   extends Commit
-    final case class Failure(offsets: Map[TopicPartition, OffsetAndMetadata], cause: Throwable) extends Commit
+    final case class Failure(offsets: Map[TopicPartition, OffsetAndMetadata], cause: CommitError) extends Commit
   }
 
   final case class Rebalance(

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
@@ -2,7 +2,8 @@ package zio.kafka.consumer.internal
 
 import org.apache.kafka.common.TopicPartition
 import zio._
-import zio.kafka.consumer.{ InvalidSubscriptionUnion, Subscription }
+import zio.kafka.consumer.Consumer.InvalidSubscriptionUnion
+import zio.kafka.consumer.Subscription
 
 sealed trait RunloopCommand
 object RunloopCommand {

--- a/zio-kafka/src/main/scala/zio/kafka/utils/SslHelper.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/SslHelper.scala
@@ -105,7 +105,7 @@ object SslHelper {
    * Mimic behaviour of KafkaAdminClient.createInternal
    */
   private def kafkaException(e: Throwable): KafkaException =
-    new KafkaException("Failed to create new KafkaAdminClient", e)
+    new KafkaException("Failed to validate SSL configuration", e)
 
   /**
    * Let's take some time here to discuss the algorithm of this function as it's a bit tricky and uses obscure Java


### PR DESCRIPTION
Mostly replaces Throwable with `ConsumerError`, a hierarchy of custom types we can later extend, and a fallback `UnknownConsumerException`. Some exceptions that can be thrown from the underlying `KafkaConsumer` which would indicate programming errors in zio-kafka are translated to fiber deaths (as per ZIO recommendations). 

At some places we have more specific errors.
* The partition stream can fail with just a `PartitionStreamPullTimeout` or `DeserializationError`.
* Committing can fail with a `CommitError`, which is a `CommitTimeout` or `UnknownCommitException`.

I hope in the future these sub-hierarchies don't cause any conflicts. 

Build still fails because test and bench projects have not been migrated yet, first want to gather some feedback on this change.

Implements #241