### PR TITLE
Fix concurrent modification exception in Consumer release

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -60,7 +60,10 @@ private[consumer] object ConsumerAccess {
                       )
                     }
                   } { consumer =>
-                    ZIO.blocking(access.withPermit(ZIO.attempt(consumer.close(settings.closeTimeout)))).orDie
+                    ZIO
+                      .blocking(access.withPermit(ZIO.attempt(consumer.close(settings.closeTimeout))))
+                      .tapErrorCause(c => ZIO.logErrorCause("Error closing Runloop", c))
+                      .orDie
                   }
     } yield new ConsumerAccess(consumer, access)
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -60,10 +60,7 @@ private[consumer] object ConsumerAccess {
                       )
                     }
                   } { consumer =>
-                    ZIO
-                      .blocking(access.withPermit(ZIO.attempt(consumer.close(settings.closeTimeout))))
-                      .tapErrorCause(c => ZIO.logErrorCause("Error closing Runloop", c))
-                      .orDie
+                    ZIO.blocking(access.withPermit(ZIO.attempt(consumer.close(settings.closeTimeout)))).orDie
                   }
     } yield new ConsumerAccess(consumer, access)
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -50,6 +50,7 @@ private[consumer] object ConsumerAccess {
 
   def make(settings: ConsumerSettings): ZIO[Scope, Throwable, ConsumerAccess] =
     for {
+      access <- Semaphore.make(1)
       consumer <- ZIO.acquireRelease {
                     ZIO.attemptBlocking {
                       new KafkaConsumer[Array[Byte], Array[Byte]](
@@ -59,10 +60,9 @@ private[consumer] object ConsumerAccess {
                       )
                     }
                   } { consumer =>
-                    ZIO.blocking(ZIO.attempt(consumer.close(settings.closeTimeout))).orDie
+                    ZIO.blocking(access.withPermit(ZIO.attempt(consumer.close(settings.closeTimeout)))).orDie
                   }
-      result <- make(consumer)
-    } yield result
+    } yield new ConsumerAccess(consumer, access)
 
   def make(consumer: ByteArrayKafkaConsumer): ZIO[Scope, Throwable, ConsumerAccess] =
     for {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -580,7 +580,7 @@ private[consumer] final class Runloop private (
                               )
                           }
           } yield pollresult
-        }.uninterruptible // Make sure that calls to the consumer are completed, so that its single-thread access protection locks are released
+        }
       fulfillResult <- offerRecordsToStreams(
                          pollResult.assignedStreams,
                          pollResult.pendingRequests,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -580,7 +580,7 @@ private[consumer] final class Runloop private (
                               )
                           }
           } yield pollresult
-        }
+        }.uninterruptible // Make sure that calls to the consumer are completed, so that its single-thread access protection locks are released
       fulfillResult <- offerRecordsToStreams(
                          pollResult.assignedStreams,
                          pollResult.pendingRequests,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -733,7 +733,7 @@ private[consumer] final class Runloop private (
    *     - Poll periodically when we are subscribed but do not have assigned streams yet. This happens after
    *       initialization and rebalancing
    */
-  private def run(initialState: State): ZIO[Scope, Throwable, Any] = {
+  private def run(initialState: State): ZIO[Any, Throwable, Any] = {
     import Runloop.StreamOps
 
     ZStream
@@ -905,12 +905,12 @@ object Runloop {
       // Run the entire loop on a dedicated thread to avoid executor shifts
       executor <- RunloopExecutor.newInstance
       fiber    <- ZIO.onExecutor(executor)(runloop.run(initialState)).forkScoped
-      waitForRunloopStop = fiber.join.orDie
+      waitForRunloopStop = fiber.join
 
       _ <- ZIO.addFinalizer(
              ZIO.logDebug("Shutting down Runloop") *>
                runloop.shutdown *>
-               waitForRunloopStop <*
+               waitForRunloopStop.tapErrorCause(c => ZIO.logErrorCause("Error waiting for Runloop stop", c)).orDie <*
                ZIO.logDebug("Shut down Runloop")
            )
     } yield runloop


### PR DESCRIPTION
By using a semaphore also for the close operation we guard against concurrent access during release. This reverts a change made in in #1011.

The cause of this concurrent access after the Consumer has shutdown is unfortunately unknown and I haven't been able to reproduce it. 

Fixes #1238.