### PR TITLE
Rename Serde methods for consistency with ZIO 2

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
@@ -34,6 +34,9 @@ trait Deserializer[-R, +T] {
    */
   def mapZIO[R1 <: R, U](f: T => RIO[R1, U]): Deserializer[R1, U] = Deserializer(deserialize(_, _, _).flatMap(f))
 
+  @deprecated("Use mapZIO", since = "2.9.0")
+  def mapM[R1 <: R, U](f: T => RIO[R1, U]): Deserializer[R1, U] = mapZIO(f)
+
   /**
    * When this serializer fails, attempt to deserialize with the alternative
    *

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
@@ -32,7 +32,7 @@ trait Deserializer[-R, +T] {
   /**
    * Create a deserializer for a type U based on the deserializer for type T and an effectful mapping function
    */
-  def mapM[R1 <: R, U](f: T => RIO[R1, U]): Deserializer[R1, U] = Deserializer(deserialize(_, _, _).flatMap(f))
+  def mapZIO[R1 <: R, U](f: T => RIO[R1, U]): Deserializer[R1, U] = Deserializer(deserialize(_, _, _).flatMap(f))
 
   /**
    * When this serializer fails, attempt to deserialize with the alternative

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
@@ -40,6 +40,9 @@ trait Serde[-R, T] extends Deserializer[R, T] with Serializer[R, T] {
    */
   def inmapZIO[R1 <: R, U](f: T => RIO[R1, U])(g: U => RIO[R1, T]): Serde[R1, U] =
     Serde(mapZIO(f))(contramapZIO(g))
+
+  @deprecated("Use inmapZIO", since = "2.9.0")
+  def inmapM[R1 <: R, U](f: T => RIO[R1, U])(g: U => RIO[R1, T]): Serde[R1, U] = inmapZIO(f)(g)
 }
 
 object Serde extends Serdes {

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
@@ -38,8 +38,8 @@ trait Serde[-R, T] extends Deserializer[R, T] with Serializer[R, T] {
   /**
    * Convert to a Serde of type U with effectful transformations
    */
-  def inmapM[R1 <: R, U](f: T => RIO[R1, U])(g: U => RIO[R1, T]): Serde[R1, U] =
-    Serde(mapM(f))(contramapM(g))
+  def inmapZIO[R1 <: R, U](f: T => RIO[R1, U])(g: U => RIO[R1, T]): Serde[R1, U] =
+    Serde(mapZIO(f))(contramapZIO(g))
 }
 
 object Serde extends Serdes {

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -25,7 +25,7 @@ trait Serializer[-R, -T] {
   /**
    * Create a serializer for a type U based on the serializer for type T and an effectful mapping function
    */
-  def contramapM[R1 <: R, U](f: U => RIO[R1, T]): Serializer[R1, U] =
+  def contramapZIO[R1 <: R, U](f: U => RIO[R1, T]): Serializer[R1, U] =
     Serializer((topic, headers, u) => f(u).flatMap(serialize(topic, headers, _)))
 
   /**

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -28,6 +28,9 @@ trait Serializer[-R, -T] {
   def contramapZIO[R1 <: R, U](f: U => RIO[R1, T]): Serializer[R1, U] =
     Serializer((topic, headers, u) => f(u).flatMap(serialize(topic, headers, _)))
 
+  @deprecated("Use contramapZIO", since = "2.9.0")
+  def contramapM[R1 <: R, U](f: U => RIO[R1, T]): Serializer[R1, U] = contramapZIO(f)
+
   /**
    * Returns a new serializer that executes its serialization function on the blocking threadpool.
    */


### PR DESCRIPTION
Renames:
* mapM -> mapZIO
* contramapM -> contramapZIO
* inmapM -> inmapZIO

The existing methods are now deprecated.

See also https://github.com/scala-steward-org/scala-steward/pull/3474.

Fixes #1325.