### PR TITLE
Tests for PartitionStreamControl + fix issue with interruptionPromise

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/PartitionStreamControlSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/PartitionStreamControlSpec.scala
@@ -1,0 +1,177 @@
+package zio.kafka.consumer.internal
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+import zio.kafka.consumer.diagnostics.Diagnostics
+import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
+import zio.test.Assertion._
+import zio.test._
+import zio._
+import zio.kafka.consumer.CommittableRecord
+
+import java.util.concurrent.TimeoutException
+
+object PartitionStreamControlSpec extends ZIOSpecDefault {
+  override def spec: Spec[Any, Throwable] = suite("PartitionStreamControl")(
+    suite("Queue info")(
+      test("offerRecords updates queue size correctly") {
+        for {
+          control <- createTestControl
+          records = createTestRecords(3)
+          _    <- control.offerRecords(records)
+          size <- control.queueSize
+        } yield assert(size)(equalTo(3))
+      },
+      test("empty offerRecords updates outstandingPolls") {
+        for {
+          control <- createTestControl
+          _       <- control.offerRecords(Chunk.empty)
+          _       <- control.offerRecords(Chunk.empty)
+          polls   <- control.outstandingPolls
+        } yield assert(polls)(equalTo(2))
+      },
+      test("multiple offers accumulate correctly") {
+        for {
+          control <- createTestControl
+          _       <- control.offerRecords(createTestRecords(2))
+          _       <- control.offerRecords(createTestRecords(3))
+          size    <- control.queueSize
+        } yield assert(size)(equalTo(5))
+      }
+    ),
+    // Stream Control Tests
+    suite("Stream control")(
+      test("offered records end up in the stream") {
+        for {
+          control <- createTestControl
+          records = createTestRecords(3)
+          _ <- control.offerRecords(records)
+          stream = control.stream
+          pulledRecords <- stream.take(3).runCollect
+        } yield assertTrue(records == pulledRecords)
+      },
+      test("end will end the stream") {
+        for {
+          control <- createTestControl
+          records = createTestRecords(3)
+          _             <- control.offerRecords(records)
+          _             <- control.end
+          pulledRecords <- control.stream.runCollect
+        } yield assertTrue(records == pulledRecords)
+      },
+      test("halt completes the stream with a TimeoutException") {
+        for {
+          control <- createTestControl
+          _       <- control.halt
+          result  <- control.stream.runCollect.exit
+        } yield assertTrue(result.isFailure && result.causeOrNull.squash.isInstanceOf[TimeoutException])
+      },
+      test("lost clears queue and ends stream") {
+        for {
+          control   <- createTestControl
+          _         <- control.offerRecords(createTestRecords(5))
+          _         <- control.lost
+          _         <- control.stream.runCollect
+          size      <- control.queueSize
+          completed <- control.isCompleted
+        } yield assert(size)(equalTo(0)) && assert(completed)(isTrue)
+      },
+      test("finalizing the stream will set isCompleted") {
+        for {
+          control            <- createTestControl
+          initialIsCompleted <- control.isCompleted
+          records = createTestRecords(3)
+          _                <- control.offerRecords(records)
+          _                <- control.end
+          _                <- control.stream.runCollect
+          finalIsCompleted <- control.isCompleted
+        } yield assertTrue(!initialIsCompleted && finalIsCompleted)
+      },
+      test("pulling from the stream will request data") {
+        ZIO.scoped {
+          for {
+            requested <- Promise.make[Nothing, Unit]
+            control   <- createTestControlWithRequestData(requested.succeed(()))
+            _         <- control.stream.runCollect.forkScoped
+            _         <- requested.await
+          } yield assertCompletes
+        }
+      },
+      test("pulling from the stream when there are records in the queue will request additional data") {
+        ZIO.scoped {
+          for {
+            requested <- Promise.make[Nothing, Unit]
+            control   <- createTestControlWithRequestData(requested.succeed(()))
+            records = createTestRecords(3)
+            _ <- control.offerRecords(records)
+            _ <- control.stream.runCollect.forkScoped
+            _ <- requested.await
+          } yield assertCompletes
+        }
+      }
+    ),
+    suite("Poll deadline")(
+      test("maxPollIntervalExceeded returns false initially") {
+        for {
+          control  <- createTestControl
+          now      <- Clock.nanoTime
+          exceeded <- control.maxPollIntervalExceeded(now)
+        } yield assert(exceeded)(isFalse)
+      },
+      test("maxPollIntervalExceeded returns true after timeout") {
+        for {
+          control <- createTestControl
+          _       <- control.offerRecords(createTestRecords(1))
+          now     <- Clock.nanoTime
+          futureTime = now + Duration.fromSeconds(31).toNanos
+          exceeded <- control.maxPollIntervalExceeded(futureTime)
+        } yield assert(exceeded)(isTrue)
+      }
+    ),
+    suite("Offset Tracking")(
+      test("lastPulledOffset updates correctly") {
+        for {
+          control <- createTestControl
+          records = createTestRecords(6)
+          _       <- control.offerRecords(records.take(3))
+          _       <- control.offerRecords(records.slice(3, 5))
+          _       <- control.stream.take(3).runCollect
+          offset1 <- control.lastPulledOffset
+          _       <- control.stream.take(3).runCollect
+          offset2 <- control.lastPulledOffset
+        } yield assertTrue(offset1.get.offset == 3L && offset2.get.offset == 6L)
+      }
+    )
+  )
+
+  private def createTestControl: ZIO[Any, Nothing, PartitionStreamControl] =
+    createTestControlWithRequestData(ZIO.unit)
+
+  private def createTestControlWithRequestData(requestData: UIO[Any]): ZIO[Any, Nothing, PartitionStreamControl] = {
+    val tp          = new TopicPartition("test-topic", 0)
+    val diagnostics = Diagnostics.NoOp
+    PartitionStreamControl.newPartitionStream(
+      tp,
+      requestData.unit,
+      diagnostics,
+      Duration.fromSeconds(30)
+    )
+  }
+
+  private def createTestRecords(count: Int): Chunk[ByteArrayCommittableRecord] =
+    Chunk.fromIterable(
+      (1 to count).map(i =>
+        CommittableRecord(
+          record = new ConsumerRecord[Array[Byte], Array[Byte]](
+            "test-topic",
+            0,
+            i.toLong,
+            Array[Byte](),
+            Array[Byte]()
+          ),
+          commitHandle = _ => ZIO.unit,
+          consumerGroupMetadata = None
+        )
+      )
+    )
+}

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -36,7 +36,7 @@ abstract class PartitionStream {
  */
 final class PartitionStreamControl private (
   val tp: TopicPartition,
-  stream: ZStream[Any, Throwable, ByteArrayCommittableRecord],
+  val stream: ZStream[Any, Throwable, ByteArrayCommittableRecord],
   dataQueue: Queue[Take[Throwable, ByteArrayCommittableRecord]],
   interruptionPromise: Promise[Throwable, Nothing],
   val completedPromise: Promise[Nothing, Option[Offset]],
@@ -85,7 +85,7 @@ final class PartitionStreamControl private (
     queueInfoRef.get.map(_.deadlineExceeded(now))
 
   /** To be invoked when the stream is no longer processing. */
-  private[internal] def halt: UIO[Boolean] = {
+  private[internal] def halt: UIO[Any] = {
     val timeOutMessage = s"No records were polled for more than $maxPollInterval for topic partition $tp. " +
       "Use ConsumerSettings.withMaxPollInterval to set a longer interval if processing a batch of records " +
       "needs more time."
@@ -100,6 +100,7 @@ final class PartitionStreamControl private (
         _     <- ZIO.logDebug(s"Partition ${tp.toString} lost")
         taken <- dataQueue.takeAll.map(_.size)
         _     <- dataQueue.offer(Take.end)
+        _     <- queueInfoRef.update(_.withQueueClearedOnLost)
         _     <- ZIO.logDebug(s"Ignored ${taken} records on lost partition").when(taken != 0)
       } yield ()
     }
@@ -127,7 +128,7 @@ object PartitionStreamControl {
 
   private[internal] def newPartitionStream(
     tp: TopicPartition,
-    commandQueue: Queue[RunloopCommand],
+    requestData: UIO[Unit],
     diagnostics: Diagnostics,
     maxPollInterval: Duration
   ): UIO[PartitionStreamControl] = {
@@ -149,11 +150,11 @@ object PartitionStreamControl {
       queueInfo           <- Ref.make(QueueInfo(now, 0, None, 0))
       requestAndAwaitData =
         for {
-          _ <- commandQueue.offer(RunloopCommand.Request(tp))
+          _ <- requestData
           _ <- diagnostics.emit(DiagnosticEvent.Request(tp))
           taken <- dataQueue
                      .takeBetween(1, Int.MaxValue)
-                     .race(interruptionPromise.await)
+                     .raceFirst(interruptionPromise.await)
         } yield taken
 
       stream = ZStream.logAnnotate(
@@ -215,6 +216,9 @@ object PartitionStreamControl {
         lastPulledOffset = records.lastOption.map(_.offset).orElse(lastPulledOffset),
         outstandingPolls = 0
       )
+
+    def withQueueClearedOnLost: QueueInfo =
+      copy(size = 0)
 
     def deadlineExceeded(now: NanoTime): Boolean =
       size > 0 && pullDeadline <= now

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -85,12 +85,12 @@ final class PartitionStreamControl private (
     queueInfoRef.get.map(_.deadlineExceeded(now))
 
   /** To be invoked when the stream is no longer processing. */
-  private[internal] def halt: UIO[Any] = {
+  private[internal] def halt: UIO[Unit] = {
     val timeOutMessage = s"No records were polled for more than $maxPollInterval for topic partition $tp. " +
       "Use ConsumerSettings.withMaxPollInterval to set a longer interval if processing a batch of records " +
       "needs more time."
     val consumeTimeout = new TimeoutException(timeOutMessage) with NoStackTrace
-    interruptionPromise.fail(consumeTimeout)
+    interruptionPromise.fail(consumeTimeout).unit
   }
 
   /** To be invoked when the partition was lost. It clears the queue and ends the stream. */

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -611,7 +611,7 @@ private[consumer] final class Runloop private (
       anyExceeded <- ZIO.foldLeft(streams)(false) { case (acc, stream) =>
                        stream
                          .maxPollIntervalExceeded(now)
-                         .tap(exceeded => if (exceeded) stream.halt.as(exceeded) else ZIO.unit)
+                         .tap(exceeded => if (exceeded) stream.halt else ZIO.unit)
                          .map(acc || _)
                      }
       _ <- shutdown.when(anyExceeded)


### PR DESCRIPTION
The issue became apparent from the tests. It unfortunately means that #1251 did not fix the issue of blocking when partitions are lost when there is no more data in the queue.

* Fix: race should be raceFirst, because interruptionPromise will only ever fail (relates to #1251)
* Reset queue size on lost
* Abstract requesting data for testing purposes