### PR TITLE
Non-effectful serialization and deserialization

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/AdminSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/AdminSpec.scala
@@ -219,7 +219,7 @@ object AdminSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
 
           def consumeAndCommit(count: Long) =
             Consumer
-              .partitionedStream[Kafka, String, String](Subscription.Topics(Set(topic)), Serde.string, Serde.string)
+              .partitionedStream[Any, String, String](Subscription.Topics(Set(topic)), Serde.string, Serde.string)
               .flatMapPar(partitionCount)(_._2)
               .take(count)
               .transduce(ZSink.collectAllN[CommittableRecord[String, String]](20))
@@ -293,7 +293,7 @@ object AdminSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
 
         def consumeAndCommit(count: Long, topic: String, groupId: String) =
           Consumer
-            .plainStream[Kafka, String, String](Subscription.Topics(Set(topic)), Serde.string, Serde.string)
+            .plainStream[Any, String, String](Subscription.Topics(Set(topic)), Serde.string, Serde.string)
             .take(count)
             .foreach(_.offset.commit)
             .provideSomeLayer[Kafka](consumer(topic, Some(groupId)))
@@ -336,7 +336,7 @@ object AdminSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
 
         def consumeAndCommit(count: Long, topic: String, groupId: String) =
           Consumer
-            .plainStream[Kafka, String, String](Subscription.Topics(Set(topic)), Serde.string, Serde.string)
+            .plainStream[Any, String, String](Subscription.Topics(Set(topic)), Serde.string, Serde.string)
             .take(count)
             .foreach(_.offset.commit)
             .provideSomeLayer[Kafka](consumer(topic, Some(groupId)))

--- a/zio-kafka-test/src/test/scala/zio/kafka/Benchmarks.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/Benchmarks.scala
@@ -25,7 +25,7 @@ object PopulateTopic extends ZIOAppDefault {
   override def run: ZIO[Any, Throwable, Unit] =
     dataStream(872000).map { case (k, v) =>
       new ProducerRecord("inputs-topic", null, null, k, v)
-    }.mapChunksZIO(Producer.produceChunkAsync[Any, String, String](_, Serde.string, Serde.string).map(Chunk(_)))
+    }.mapChunksZIO(Producer.produceChunkAsync[String, String](_, Serde.string, Serde.string).map(Chunk(_)))
       .mapZIOPar(5)(_.flatMap(chunk => Console.printLine(s"Wrote chunk of ${chunk.size}")))
       .runDrain
       .provide(

--- a/zio-kafka-test/src/test/scala/zio/kafka/serde/DeserializerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/serde/DeserializerSpec.scala
@@ -2,13 +2,12 @@ package zio.kafka.serde
 
 import org.apache.kafka.common.header.internals.RecordHeaders
 import zio._
+import zio.kafka.ZIOSpecDefaultSlf4j
 import zio.test.Assertion._
 import zio.test._
-import zio.ZAny
-import zio.kafka.ZIOSpecDefaultSlf4j
 
 object DeserializerSpec extends ZIOSpecDefaultSlf4j {
-  override def spec: Spec[ZAny with Any, Throwable] = suite("Deserializer")(
+  override def spec: Spec[TestEnvironment with Scope, Any] = suite("Deserializer")(
     suite("asOption")(
       test("deserialize to None when value is null") {
         assertZIO(stringDeserializer.asOption.deserialize("topic1", new RecordHeaders, null))(isNone)

--- a/zio-kafka-test/src/test/scala/zio/kafka/serde/SerializerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/serde/SerializerSpec.scala
@@ -3,19 +3,21 @@ package zio.kafka.serde
 import org.apache.kafka.common.header.internals.RecordHeaders
 import zio.test.Assertion._
 import zio.test._
-import zio.ZAny
+import zio.{ ZAny, ZIO }
 import zio.kafka.ZIOSpecDefaultSlf4j
 
 object SerializerSpec extends ZIOSpecDefaultSlf4j {
   override def spec: Spec[ZAny with Any, Throwable] = suite("Serializer")(
     suite("asOption")(
       test("serialize None values to null") {
-        assertZIO(stringSerializer.asOption.serialize("topic1", new RecordHeaders, None))(isNull)
+        assert(stringSerializer.asOption.serialize("topic1", new RecordHeaders, None))(isNull)
       },
       test("serialize Some values") {
         check(Gen.string) { string =>
           assertZIO(
-            stringSerializer.asOption.serialize("topic1", new RecordHeaders, Some(string)).map(new String(_, "UTF-8"))
+            ZIO
+              .succeed(stringSerializer.asOption.serialize("topic1", new RecordHeaders, Some(string)))
+              .map(new String(_, "UTF-8"))
           )(
             equalTo(string)
           )
@@ -23,5 +25,5 @@ object SerializerSpec extends ZIOSpecDefaultSlf4j {
       }
     )
   )
-  private lazy val stringSerializer: Serializer[Any, String] = Serde.string
+  private lazy val stringSerializer: Serializer[String] = Serde.string
 }

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -70,7 +70,7 @@ object KafkaTestUtils {
     key: String,
     message: String
   ): ZIO[Producer, Throwable, RecordMetadata] =
-    Producer.produce[Any, String, String](new ProducerRecord(topic, key, message), Serde.string, Serde.string)
+    Producer.produce[String, String](new ProducerRecord(topic, key, message), Serde.string, Serde.string)
 
   /**
    * Utility function to produce many messages in give Partition of a Topic.
@@ -81,7 +81,7 @@ object KafkaTestUtils {
     kvs: Iterable[(String, String)]
   ): ZIO[Producer, Throwable, Chunk[RecordMetadata]] =
     Producer
-      .produceChunk[Any, String, String](
+      .produceChunk[String, String](
         Chunk.fromIterable(kvs.map { case (k, v) =>
           new ProducerRecord(topic, partition, null, k, v)
         }),
@@ -97,7 +97,7 @@ object KafkaTestUtils {
     kvs: Iterable[(String, String)]
   ): ZIO[Producer, Throwable, Chunk[RecordMetadata]] =
     Producer
-      .produceChunk[Any, String, String](
+      .produceChunk[String, String](
         Chunk.fromIterable(kvs.map { case (k, v) =>
           new ProducerRecord(topic, k, v)
         }),

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
@@ -3,17 +3,17 @@ package zio.kafka.consumer
 import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, ConsumerRecord, OffsetAndMetadata }
 import org.apache.kafka.common.TopicPartition
 import zio.kafka.serde.Deserializer
-import zio.{ RIO, Task }
+import zio.{ IO, Task }
 
 final case class CommittableRecord[K, V](
   record: ConsumerRecord[K, V],
   private val commitHandle: Map[TopicPartition, OffsetAndMetadata] => Task[Unit],
   private val consumerGroupMetadata: Option[ConsumerGroupMetadata]
 ) {
-  def deserializeWith[R, K1, V1](
-    keyDeserializer: Deserializer[R, K1],
-    valueDeserializer: Deserializer[R, V1]
-  )(implicit ev1: K <:< Array[Byte], ev2: V <:< Array[Byte]): RIO[R, CommittableRecord[K1, V1]] =
+  def deserializeWith[E, K1, V1](
+    keyDeserializer: Deserializer[E, K1],
+    valueDeserializer: Deserializer[E, V1]
+  )(implicit ev1: K <:< Array[Byte], ev2: V <:< Array[Byte]): IO[E, CommittableRecord[K1, V1]] =
     for {
       key   <- keyDeserializer.deserialize(record.topic(), record.headers(), record.key())
       value <- valueDeserializer.deserialize(record.topic(), record.headers(), record.value())

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Transaction.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Transaction.scala
@@ -4,38 +4,38 @@ import org.apache.kafka.clients.producer.{ ProducerRecord, RecordMetadata }
 import zio.kafka.consumer.{ Offset, OffsetBatch }
 import zio.kafka.producer.TransactionalProducer.{ TransactionLeaked, UserInitiatedAbort }
 import zio.kafka.serde.Serializer
-import zio.{ Chunk, IO, RIO, Ref, UIO, ZIO }
+import zio.{ Chunk, IO, Ref, Task, UIO, ZIO }
 
 trait Transaction {
-  def produce[R, K, V](
+  def produce[K, V](
     topic: String,
     key: K,
     value: V,
-    keySerializer: Serializer[R, K],
-    valueSerializer: Serializer[R, V],
+    keySerializer: Serializer[K],
+    valueSerializer: Serializer[V],
     offset: Option[Offset]
-  ): RIO[R, RecordMetadata]
+  ): Task[RecordMetadata]
 
-  def produce[R, K, V](
+  def produce[K, V](
     producerRecord: ProducerRecord[K, V],
-    keySerializer: Serializer[R, K],
-    valueSerializer: Serializer[R, V],
+    keySerializer: Serializer[K],
+    valueSerializer: Serializer[V],
     offset: Option[Offset]
-  ): RIO[R, RecordMetadata]
+  ): Task[RecordMetadata]
 
-  def produceChunk[R, K, V](
+  def produceChunk[K, V](
     records: Chunk[ProducerRecord[K, V]],
-    keySerializer: Serializer[R, K],
-    valueSerializer: Serializer[R, V],
+    keySerializer: Serializer[K],
+    valueSerializer: Serializer[V],
     offset: Option[Offset]
-  ): RIO[R, Chunk[RecordMetadata]]
+  ): Task[Chunk[RecordMetadata]]
 
-  def produceChunkBatch[R, K, V](
+  def produceChunkBatch[K, V](
     records: Chunk[ProducerRecord[K, V]],
-    keySerializer: Serializer[R, K],
-    valueSerializer: Serializer[R, V],
+    keySerializer: Serializer[K],
+    valueSerializer: Serializer[V],
     offsets: OffsetBatch
-  ): RIO[R, Chunk[RecordMetadata]]
+  ): Task[Chunk[RecordMetadata]]
 
   def abort: IO[TransactionalProducer.UserInitiatedAbort.type, Nothing]
 }
@@ -45,45 +45,45 @@ private[producer] final class TransactionImpl(
   private[producer] val offsetBatchRef: Ref[OffsetBatch],
   closed: Ref[Boolean]
 ) extends Transaction {
-  def produce[R, K, V](
+  def produce[K, V](
     topic: String,
     key: K,
     value: V,
-    keySerializer: Serializer[R, K],
-    valueSerializer: Serializer[R, V],
+    keySerializer: Serializer[K],
+    valueSerializer: Serializer[V],
     offset: Option[Offset]
-  ): RIO[R, RecordMetadata] =
+  ): Task[RecordMetadata] =
     produce(new ProducerRecord[K, V](topic, key, value), keySerializer, valueSerializer, offset)
 
-  def produce[R, K, V](
+  def produce[K, V](
     producerRecord: ProducerRecord[K, V],
-    keySerializer: Serializer[R, K],
-    valueSerializer: Serializer[R, V],
+    keySerializer: Serializer[K],
+    valueSerializer: Serializer[V],
     offset: Option[Offset]
-  ): RIO[R, RecordMetadata] =
+  ): Task[RecordMetadata] =
     haltIfClosed *>
       ZIO.whenCase(offset) { case Some(offset) => offsetBatchRef.update(_ add offset) } *>
-      producer.produce[R, K, V](producerRecord, keySerializer, valueSerializer)
+      producer.produce[K, V](producerRecord, keySerializer, valueSerializer)
 
-  def produceChunk[R, K, V](
+  def produceChunk[K, V](
     records: Chunk[ProducerRecord[K, V]],
-    keySerializer: Serializer[R, K],
-    valueSerializer: Serializer[R, V],
+    keySerializer: Serializer[K],
+    valueSerializer: Serializer[V],
     offset: Option[Offset]
-  ): RIO[R, Chunk[RecordMetadata]] =
+  ): Task[Chunk[RecordMetadata]] =
     haltIfClosed *>
       ZIO.whenCase(offset) { case Some(offset) => offsetBatchRef.update(_ add offset) } *>
-      producer.produceChunk[R, K, V](records, keySerializer, valueSerializer)
+      producer.produceChunk[K, V](records, keySerializer, valueSerializer)
 
-  def produceChunkBatch[R, K, V](
+  def produceChunkBatch[K, V](
     records: Chunk[ProducerRecord[K, V]],
-    keySerializer: Serializer[R, K],
-    valueSerializer: Serializer[R, V],
+    keySerializer: Serializer[K],
+    valueSerializer: Serializer[V],
     offsets: OffsetBatch
-  ): RIO[R, Chunk[RecordMetadata]] =
+  ): Task[Chunk[RecordMetadata]] =
     haltIfClosed *>
       offsetBatchRef.update(_ merge offsets) *>
-      producer.produceChunk[R, K, V](records, keySerializer, valueSerializer)
+      producer.produceChunk[K, V](records, keySerializer, valueSerializer)
 
   def abort: IO[TransactionalProducer.UserInitiatedAbort.type, Nothing] =
     ZIO.fail(UserInitiatedAbort)

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
@@ -1,11 +1,7 @@
 package zio.kafka.serde
 
 import org.apache.kafka.common.header.Headers
-import org.apache.kafka.common.serialization.{ Deserializer => KafkaDeserializer }
-import zio.{ RIO, Task, ZIO }
-
-import scala.jdk.CollectionConverters._
-import scala.util.{ Failure, Success, Try }
+import zio.{ IO, ZIO }
 
 /**
  * Deserializer from byte array to a value of some type T
@@ -15,48 +11,40 @@ import scala.util.{ Failure, Success, Try }
  * @tparam T
  *   Value type
  */
-trait Deserializer[-R, +T] {
-  def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[R, T]
-
-  /**
-   * Returns a new deserializer that executes its deserialization function on the blocking threadpool.
-   */
-  def blocking: Deserializer[R, T] =
-    Deserializer((topic, headers, data) => ZIO.blocking(deserialize(topic, headers, data)))
+trait Deserializer[+E, T] {
+  def deserialize(topic: String, headers: Headers, data: Array[Byte]): IO[E, T]
 
   /**
    * Create a deserializer for a type U based on the deserializer for type T and a mapping function
    */
-  def map[U](f: T => U): Deserializer[R, U] = Deserializer(deserialize(_, _, _).map(f))
+  def map[U](f: T => U): Deserializer[E, U] = Deserializer(deserialize(_, _, _).map(f))
 
   /**
    * Create a deserializer for a type U based on the deserializer for type T and an effectful mapping function
    */
-  def mapM[R1 <: R, U](f: T => RIO[R1, U]): Deserializer[R1, U] = Deserializer(deserialize(_, _, _).flatMap(f))
+  def mapM[E1 >: E, U](f: T => IO[E1, U]): Deserializer[E1, U] = Deserializer(deserialize(_, _, _).flatMap(f))
 
   /**
    * When this serializer fails, attempt to deserialize with the alternative
    *
    * If both deserializers fail, the error will be the last deserializer's exception.
    */
-  def orElse[R1 <: R, U >: T](alternative: Deserializer[R1, U]): Deserializer[R1, U] =
+  def orElse[E1 >: E, U >: T](alternative: Deserializer[E1, U]): Deserializer[E1, U] =
     Deserializer { (topic, headers, data) =>
       deserialize(topic, headers, data) orElse alternative.deserialize(topic, headers, data)
     }
 
   /**
-   * Serde that handles deserialization failures by returning a Task
-   *
-   * This is useful for explicitly handling deserialization failures.
-   */
-  def asTry: Deserializer[R, Try[T]] =
-    Deserializer(deserialize(_, _, _).fold(e => Failure(e), v => Success(v)))
-
-  /**
    * Returns a new deserializer that deserializes values as Option values, mapping null data to None values.
    */
-  def asOption: Deserializer[R, Option[T]] =
+  def asOption: Deserializer[E, Option[T]] =
     Deserializer((topic, headers, data) => ZIO.foreach(Option(data))(deserialize(topic, headers, _)))
+
+  def mapError[E1](f: E => E1): Deserializer[E1, T] =
+    Deserializer((topic, headers, data) => deserialize(topic, headers, data).mapError(f))
+
+  def catchAll[E1 >: E](f: E => IO[E1, T]): Deserializer[E1, T] =
+    Deserializer((topic, headers, data) => deserialize(topic, headers, data).catchAll(f))
 }
 
 object Deserializer extends Serdes {
@@ -64,23 +52,6 @@ object Deserializer extends Serdes {
   /**
    * Create a deserializer from a function
    */
-  def apply[R, T](deser: (String, Headers, Array[Byte]) => RIO[R, T]): Deserializer[R, T] =
+  def apply[E, T](deser: (String, Headers, Array[Byte]) => IO[E, T]): Deserializer[E, T] =
     (topic: String, headers: Headers, data: Array[Byte]) => deser(topic, headers, data)
-
-  /**
-   * Create a Deserializer from a Kafka Deserializer
-   */
-  def fromKafkaDeserializer[T](
-    deserializer: KafkaDeserializer[T],
-    props: Map[String, AnyRef],
-    isKey: Boolean
-  ): Task[Deserializer[Any, T]] =
-    ZIO
-      .attempt(deserializer.configure(props.asJava, isKey))
-      .as(
-        new Deserializer[Any, T] {
-          override def deserialize(topic: String, headers: Headers, data: Array[Byte]): Task[T] =
-            ZIO.attempt(deserializer.deserialize(topic, headers, data))
-        }
-      )
 }

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serdes.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serdes.scala
@@ -3,21 +3,21 @@ package zio.kafka.serde
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.{ Serde => KafkaSerde, Serdes => KafkaSerdes }
 import org.apache.kafka.common.utils.Bytes
-import zio.{ RIO, ZIO }
+import zio.{ IO, ZIO }
 
 import java.nio.ByteBuffer
 import java.util.UUID
 
 private[zio] trait Serdes {
-  val long: Serde[Any, Long]     = convertPrimitiveSerde(KafkaSerdes.Long()).inmap(Long2long)(long2Long)
-  val int: Serde[Any, Int]       = convertPrimitiveSerde(KafkaSerdes.Integer()).inmap(Integer2int)(int2Integer)
-  val short: Serde[Any, Short]   = convertPrimitiveSerde(KafkaSerdes.Short()).inmap(Short2short)(short2Short)
-  val float: Serde[Any, Float]   = convertPrimitiveSerde(KafkaSerdes.Float()).inmap(Float2float)(float2Float)
-  val double: Serde[Any, Double] = convertPrimitiveSerde(KafkaSerdes.Double()).inmap(Double2double)(double2Double)
-  val string: Serde[Any, String] = convertPrimitiveSerde(KafkaSerdes.String())
-  val bytes: Serde[Any, Bytes]   = convertPrimitiveSerde(KafkaSerdes.Bytes())
-  val byteBuffer: Serde[Any, ByteBuffer] = convertPrimitiveSerde(KafkaSerdes.ByteBuffer())
-  val uuid: Serde[Any, UUID]             = convertPrimitiveSerde(KafkaSerdes.UUID())
+  val long: Serde[Throwable, Long]     = convertPrimitiveSerde(KafkaSerdes.Long()).inmap(Long2long)(long2Long)
+  val int: Serde[Throwable, Int]       = convertPrimitiveSerde(KafkaSerdes.Integer()).inmap(Integer2int)(int2Integer)
+  val short: Serde[Throwable, Short]   = convertPrimitiveSerde(KafkaSerdes.Short()).inmap(Short2short)(short2Short)
+  val float: Serde[Throwable, Float]   = convertPrimitiveSerde(KafkaSerdes.Float()).inmap(Float2float)(float2Float)
+  val double: Serde[Throwable, Double] = convertPrimitiveSerde(KafkaSerdes.Double()).inmap(Double2double)(double2Double)
+  val string: Serde[Throwable, String] = convertPrimitiveSerde(KafkaSerdes.String())
+  val bytes: Serde[Throwable, Bytes]   = convertPrimitiveSerde(KafkaSerdes.Bytes())
+  val byteBuffer: Serde[Throwable, ByteBuffer] = convertPrimitiveSerde(KafkaSerdes.ByteBuffer())
+  val uuid: Serde[Throwable, UUID]             = convertPrimitiveSerde(KafkaSerdes.UUID())
 
   /**
    * Optimisation
@@ -27,24 +27,24 @@ private[zio] trait Serdes {
    *
    * That allows us to use [[ZIO.succeed]] instead of [[ZIO.attempt]].
    */
-  val byteArray: Serde[Any, Array[Byte]] =
-    new Serde[Any, Array[Byte]] {
-      override final def serialize(topic: String, headers: Headers, value: Array[Byte]): RIO[Any, Array[Byte]] =
-        ZIO.succeed(value)
+  val byteArray: Serde[Nothing, Array[Byte]] =
+    new Serde[Nothing, Array[Byte]] {
+      override final def serialize(topic: String, headers: Headers, value: Array[Byte]): Array[Byte] =
+        value
 
-      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[Any, Array[Byte]] =
+      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): IO[Nothing, Array[Byte]] =
         ZIO.succeed(data)
     }
 
-  private[this] def convertPrimitiveSerde[T](serde: KafkaSerde[T]): Serde[Any, T] =
-    new Serde[Any, T] {
+  private[this] def convertPrimitiveSerde[T](serde: KafkaSerde[T]): Serde[Throwable, T] =
+    new Serde[Throwable, T] {
       private final val serializer   = serde.serializer()
       private final val deserializer = serde.deserializer()
 
-      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[Any, T] =
+      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): IO[Throwable, T] =
         ZIO.attempt(deserializer.deserialize(topic, headers, data))
 
-      override final def serialize(topic: String, headers: Headers, value: T): RIO[Any, Array[Byte]] =
-        ZIO.attempt(serializer.serialize(topic, headers, value))
+      override final def serialize(topic: String, headers: Headers, value: T): Array[Byte] =
+        serializer.serialize(topic, headers, value)
     }
 }

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -1,46 +1,31 @@
 package zio.kafka.serde
 
 import org.apache.kafka.common.header.Headers
-import org.apache.kafka.common.serialization.{ Serializer => KafkaSerializer }
-import zio.{ RIO, Task, ZIO }
-
-import scala.jdk.CollectionConverters._
 
 /**
  * Serializer from values of some type T to a byte array
  *
- * @tparam R
- *   Environment available to the serializer
+ * Serialization may not fail and any value can be serialized. If effectful operations are needed for serialization,
+ * this must be done before passing a serialized value to the Producer. Use [[Serdes.byteArray]]
+ *
  * @tparam T
  */
-trait Serializer[-R, -T] {
-  def serialize(topic: String, headers: Headers, value: T): RIO[R, Array[Byte]]
+trait Serializer[T] {
+  def serialize(topic: String, headers: Headers, value: T): Array[Byte]
 
   /**
    * Create a serializer for a type U based on the serializer for type T and a mapping function
    */
-  def contramap[U](f: U => T): Serializer[R, U] =
+  def contramap[U](f: U => T): Serializer[U] =
     Serializer((topic, headers, u) => serialize(topic, headers, f(u)))
-
-  /**
-   * Create a serializer for a type U based on the serializer for type T and an effectful mapping function
-   */
-  def contramapM[R1 <: R, U](f: U => RIO[R1, T]): Serializer[R1, U] =
-    Serializer((topic, headers, u) => f(u).flatMap(serialize(topic, headers, _)))
-
-  /**
-   * Returns a new serializer that executes its serialization function on the blocking threadpool.
-   */
-  def blocking: Serializer[R, T] =
-    Serializer((topic, headers, t) => ZIO.blocking(serialize(topic, headers, t)))
 
   /**
    * Returns a new serializer that handles optional values and serializes them as nulls.
    */
-  def asOption[U <: T]: Serializer[R, Option[U]] =
+  def asOption[U <: T]: Serializer[Option[U]] =
     Serializer { (topic, headers, valueOpt) =>
       valueOpt match {
-        case None        => ZIO.succeed(null)
+        case None        => null
         case Some(value) => serialize(topic, headers, value)
       }
     }
@@ -51,24 +36,6 @@ object Serializer extends Serdes {
   /**
    * Create a serializer from a function
    */
-  def apply[R, T](ser: (String, Headers, T) => RIO[R, Array[Byte]]): Serializer[R, T] =
+  def apply[T](ser: (String, Headers, T) => Array[Byte]): Serializer[T] =
     (topic: String, headers: Headers, value: T) => ser(topic, headers, value)
-
-  /**
-   * Create a Serializer from a Kafka Serializer
-   */
-  def fromKafkaSerializer[T](
-    serializer: KafkaSerializer[T],
-    props: Map[String, AnyRef],
-    isKey: Boolean
-  ): Task[Serializer[Any, T]] =
-    ZIO
-      .attempt(serializer.configure(props.asJava, isKey))
-      .as(
-        new Serializer[Any, T] {
-          override def serialize(topic: String, headers: Headers, value: T): Task[Array[Byte]] =
-            ZIO.attempt(serializer.serialize(topic, headers, value))
-        }
-      )
-
 }


### PR DESCRIPTION
This is an exploration of #853.

Serializers cannot fail, like in zio-json. Deserialization is no longer allowed to be side-effectful, so serializers like the Confluent Avro serde (which communicates with a schema registry) will have to be run in the user's own code. We should add an example to the documentation.

I thought a free error type for the deserialization error would be nice, but at some point it has to be integrated with other errors in the Runloop, which means wrapping it in an exception for now. Needs something better..