### PR TITLE
Remove 'experimental' label from `FetchStrategy`

### DIFF
--- a/docs/consumer-tuning.md
+++ b/docs/consumer-tuning.md
@@ -57,8 +57,7 @@ the partition queues. A very rough estimate for the maximum amount of heap neede
 The total can be tuned by changing the `partitionPreFetchBufferLimit`, `max.poll.records` settings.
 
 Another option is to write a custom `FetchStrategy`. For example the `ManyPartitionsQueueSizeBasedFetchStrategy` in
-[draft PR 970](https://github.com/zio/zio-kafka/pull/970) (merged into zio-kafka since 2.8.1). Note that the fetch strategy API is marked as
-experimental and may change without notice in any future zio-kafka version.
+[draft PR 970](https://github.com/zio/zio-kafka/pull/970) (merged into zio-kafka since 2.8.1).
 
 ## Long processing durations
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -284,9 +284,6 @@ final case class ConsumerSettings(
     withPartitionPreFetchBufferLimit(partitionPreFetchBufferLimit)
 
   /**
-   * WARNING: [[zio.kafka.consumer.fetch.FetchStrategy]] is an EXPERIMENTAL API and may change in an incompatible way
-   * without notice in any zio-kafka version.
-   *
    * @param fetchStrategy
    *   The fetch strategy which selects which partitions can fetch data in the next poll. The default is to use the
    *   [[zio.kafka.consumer.fetch.QueueSizeBasedFetchStrategy]] with a `partitionPreFetchBufferLimit` parameter of 1024,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/fetch/FetchStrategy.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/fetch/FetchStrategy.scala
@@ -8,8 +8,6 @@ import scala.collection.mutable
 
 /**
  * A fetch strategy determined which stream are allowed to fetch data in the next poll.
- *
- * WARNING: this is an EXPERIMENTAL API and may change in an incompatible way without notice in any zio-kafka version.
  */
 trait FetchStrategy {
 


### PR DESCRIPTION
The `FetchStrategy` trait has not seen any change since its introduction over a year ago. It is time to remove the experimental label.