### PR TITLE
[Internal] Micro-optimisation: Reuse previously calculated `java.langSystem.nanoTime`

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -327,7 +327,7 @@ private[consumer] final class Runloop private (
       for {
         p <- Promise.make[Throwable, Unit]
         startTime = java.lang.System.nanoTime()
-        _ <- commitQueue.offer(Runloop.Commit(java.lang.System.nanoTime(), offsets, p))
+        _ <- commitQueue.offer(Runloop.Commit(startTime, offsets, p))
         _ <- commandQueue.offer(RunloopCommand.CommitAvailable)
         _ <- diagnostics.emit(DiagnosticEvent.Commit.Started(offsets))
         _ <- p.await.timeoutFail(CommitTimeout)(commitTimeout)


### PR DESCRIPTION
Hey :)

I'm not contributing much anymore. Sorry about that. I lost the motivation, TBH, but I really enjoy following what you continue to do 👏

I was passing by and was reading some of the new code when I saw this. LMKWYT :)

With this change, we lose some nanoseconds of precision, so it might not be the expected behaviour. 🤔