### PR TITLE
ZioKafkaConsumerbenchmark.throughput: increase count per batch

### DIFF
--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaConsumerBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaConsumerBenchmark.scala
@@ -46,7 +46,7 @@ class ZioKafkaConsumerBenchmark extends ConsumerZioBenchmark[Kafka with Producer
              .tap { batch =>
                counter
                  .updateAndGet(_ + batch.size)
-                 .flatMap(count => Consumer.stopConsumption.when(count == recordCount))
+                 .flatMap(count => Consumer.stopConsumption.when(count >= recordCount))
              }
              .runDrain
              .provideSome[Kafka](env)


### PR DESCRIPTION
This is more consistent with the manual kafka client benchmark equivalent