### PR TITLE
Simplify transactional producing

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -1534,8 +1534,8 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
 
         // Test for both default partition assignment strategies
         Seq(
-          testForPartitionAssignmentStrategy[RangeAssignor]
-//          testForPartitionAssignmentStrategy[CooperativeStickyAssignor] // TODO not yet supported
+          testForPartitionAssignmentStrategy[RangeAssignor],
+          testForPartitionAssignmentStrategy[CooperativeStickyAssignor]
         )
 
       }: _*) @@ TestAspect.nonFlaky(2),

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -1425,7 +1425,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                            .fork
 
                     transactionalId   <- randomThing("transactional")
-                    tProducerSettings <- transactionalProducerSettings(transactionalId)
+                    tProducerSettings <- KafkaTestUtils.transactionalProducerSettings(transactionalId)
                     tProducer <-
                       TransactionalProducer.make(tProducerSettings, consumer)
 
@@ -1453,7 +1453,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                         .tapError(e => ZIO.logError(s"Error: $e") *> consumerCreated.fail(e)) <* ZIO.logDebug("Done")
                   } yield tConsumer)
                     .provideSome[Kafka & Scope](
-                      transactionalConsumer(
+                      KafkaTestUtils.transactionalConsumer(
                         clientId,
                         consumerGroupId,
                         rebalanceSafeCommits = true,
@@ -1468,10 +1468,6 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
               }
 
             for {
-              transactionalId   <- randomThing("transactional")
-              tProducerSettings <- KafkaTestUtils.transactionalProducerSettings(transactionalId)
-              tProducer         <- TransactionalProducer.make(tProducerSettings)
-
               topicA <- randomTopic
               topicB <- randomTopic
               _      <- KafkaTestUtils.createCustomTopic(topicA, partitionCount)

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -1406,87 +1406,65 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             val allMessages                                       = (1 to messageCount).map(i => s"$i" -> f"msg$i%06d")
             val (messagesBeforeRebalance, messagesAfterRebalance) = allMessages.splitAt(messageCount / 2)
 
-            def transactionalRebalanceListener(streamCompleteOnRebalanceRef: Ref[Option[Promise[Nothing, Unit]]]) =
-              RebalanceListener(
-                onAssigned = _ => ZIO.unit,
-                onRevoked = _ =>
-                  streamCompleteOnRebalanceRef.get.flatMap {
-                    case Some(p) =>
-                      ZIO.logDebug("onRevoked, awaiting stream completion") *>
-                        p.await.timeoutFail(new InterruptedException("Timed out waiting stream to complete"))(1.minute)
-                    case None => ZIO.unit
-                  },
-                onLost = _ => ZIO.logDebug("Lost some partitions")
-              )
-
             def makeCopyingTransactionalConsumer(
               name: String,
               consumerGroupId: String,
               clientId: String,
               fromTopic: String,
               toTopic: String,
-              tProducer: TransactionalProducer,
-              consumerCreated: Promise[Nothing, Unit]
-            ): ZIO[Scope & Kafka, Throwable, Unit] =
+              consumerCreated: Promise[Throwable, Unit]
+            ): ZIO[Kafka, Throwable, Unit] =
               ZIO.logAnnotate("consumer", name) {
-                for {
-                  consumedMessagesCounter <- Ref.make(0)
-                  _ <- consumedMessagesCounter.get
-                         .flatMap(consumed => ZIO.logDebug(s"Consumed so far: $consumed"))
-                         .repeat(Schedule.fixed(1.second))
-                         .fork
-                  streamCompleteOnRebalanceRef <- Ref.make[Option[Promise[Nothing, Unit]]](None)
-                  consumer <- KafkaTestUtils.makeTransactionalConsumer(
-                                clientId,
-                                consumerGroupId,
-                                restartStreamOnRebalancing = true,
-                                properties = Map(
-                                  ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG ->
-                                    implicitly[ClassTag[T]].runtimeClass.getName,
-                                  ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> "200"
-                                ),
-                                rebalanceListener = transactionalRebalanceListener(streamCompleteOnRebalanceRef)
-                              )
-                  tConsumer <-
-                    consumer
-                      .partitionedAssignmentStream(Subscription.topics(fromTopic), Serde.string, Serde.string)
-                      .mapZIO { assignedPartitions =>
-                        for {
-                          p <- Promise.make[Nothing, Unit]
-                          _ <- streamCompleteOnRebalanceRef.set(Some(p))
-                          _ <- ZIO.logDebug(s"${assignedPartitions.size} partitions assigned")
-                          _ <- consumerCreated.succeed(())
-                          partitionStreams = assignedPartitions.map(_._2)
-                          s <- ZStream
-                                 .mergeAllUnbounded(64)(partitionStreams: _*)
-                                 .mapChunksZIO { records =>
-                                   ZIO.scoped {
-                                     for {
-                                       t <- tProducer.createTransaction
-                                       _ <- t.produceChunkBatch(
-                                              records.map(r => new ProducerRecord(toTopic, r.key, r.value)),
-                                              Serde.string,
-                                              Serde.string,
-                                              OffsetBatch(records.map(_.offset))
-                                            )
-                                       _ <- consumedMessagesCounter.update(_ + records.size)
-                                     } yield Chunk.empty
-                                   }.uninterruptible
-                                 }
-                                 .runDrain
-                                 .ensuring {
-                                   for {
-                                     _ <- streamCompleteOnRebalanceRef.set(None)
-                                     _ <- p.succeed(())
-                                     c <- consumedMessagesCounter.get
-                                     _ <- ZIO.logDebug(s"Consumed $c messages")
-                                   } yield ()
-                                 }
-                        } yield s
-                      }
-                      .runDrain
-                      .tapError(e => ZIO.logError(s"Error: $e")) <* ZIO.logDebug("Done")
-                } yield tConsumer
+                ZIO.scoped {
+                  (for {
+                    consumer                <- ZIO.service[Consumer]
+                    consumedMessagesCounter <- Ref.make(0)
+                    _ <- consumedMessagesCounter.get
+                           .flatMap(consumed => ZIO.logDebug(s"Consumed so far: $consumed"))
+                           .repeat(Schedule.fixed(1.second))
+                           .fork
+
+                    transactionalId   <- randomThing("transactional")
+                    tProducerSettings <- transactionalProducerSettings(transactionalId)
+                    tProducer <-
+                      TransactionalProducer.make(tProducerSettings, consumer)
+
+                    tConsumer <-
+                      consumer
+                        .partitionedStream(Subscription.topics(fromTopic), Serde.string, Serde.string)
+                        .flatMapPar(Int.MaxValue) { case (_, partitionStream) =>
+                          ZStream.fromZIO(consumerCreated.succeed(())) *>
+                            partitionStream.mapChunksZIO { records =>
+                              ZIO.scoped {
+                                for {
+                                  t <- tProducer.createTransaction
+                                  _ <- t.produceChunkBatch(
+                                         records.map(r => new ProducerRecord(toTopic, r.key, r.value)),
+                                         Serde.string,
+                                         Serde.string,
+                                         OffsetBatch(records.map(_.offset))
+                                       )
+                                  _ <- consumedMessagesCounter.update(_ + records.size)
+                                } yield Chunk.empty
+                              }
+                            }
+                        }
+                        .runDrain
+                        .tapError(e => ZIO.logError(s"Error: $e") *> consumerCreated.fail(e)) <* ZIO.logDebug("Done")
+                  } yield tConsumer)
+                    .provideSome[Kafka & Scope](
+                      transactionalConsumer(
+                        clientId,
+                        consumerGroupId,
+                        rebalanceSafeCommits = true,
+                        properties = Map(
+                          ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG ->
+                            implicitly[ClassTag[T]].runtimeClass.getName,
+                          ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> "200"
+                        )
+                      )
+                    )
+                }
               }
 
             for {
@@ -1506,28 +1484,26 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
 
               _ <- ZIO.logDebug("Starting copier 1")
               copier1ClientId = copyingGroup + "-1"
-              copier1Created <- Promise.make[Nothing, Unit]
+              copier1Created <- Promise.make[Throwable, Unit]
               copier1 <- makeCopyingTransactionalConsumer(
                            "1",
                            copyingGroup,
                            copier1ClientId,
                            topicA,
                            topicB,
-                           tProducer,
                            copier1Created
                          ).fork
               _ <- copier1Created.await
 
               _ <- ZIO.logDebug("Starting copier 2")
               copier2ClientId = copyingGroup + "-2"
-              copier2Created <- Promise.make[Nothing, Unit]
+              copier2Created <- Promise.make[Throwable, Unit]
               copier2 <- makeCopyingTransactionalConsumer(
                            "2",
                            copyingGroup,
                            copier2ClientId,
                            topicA,
                            topicB,
-                           tProducer,
                            copier2Created
                          ).fork
               _ <- ZIO.logDebug("Waiting for copier 2 to start")

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -75,10 +75,11 @@ object KafkaTestUtils {
    *
    * Note: to run multiple tests in parallel, every test needs a different transactional id.
    */
-  def makeTransactionalProducer(transactionalId: String): ZIO[Scope & Kafka, Throwable, TransactionalProducer] =
-    transactionalProducerSettings(transactionalId).flatMap(TransactionalProducer.make)
-
-  def FIX_METHOD: []**
+  def makeTransactionalProducer(
+    transactionalId: String,
+    consumer: Consumer
+  ): ZIO[Scope & Kafka, Throwable, TransactionalProducer] =
+    transactionalProducerSettings(transactionalId).flatMap(TransactionalProducer.make(_, consumer))
 
   /**
    * `TransactionalProducer` layer for use in tests.
@@ -99,7 +100,9 @@ object KafkaTestUtils {
    * producer.
    */
   def transactionalProducer(transactionalId: String): ZLayer[Kafka with Consumer, Throwable, TransactionalProducer] =
-    ZLayer.scoped(makeTransactionalProducer(transactionalId))
+    ZLayer.scoped {
+      ZIO.serviceWithZIO[Consumer](makeTransactionalProducer(transactionalId, _))
+    }
 
   // -----------------------------------------------------------------------------------------
   //

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -78,6 +78,8 @@ object KafkaTestUtils {
   def makeTransactionalProducer(transactionalId: String): ZIO[Scope & Kafka, Throwable, TransactionalProducer] =
     transactionalProducerSettings(transactionalId).flatMap(TransactionalProducer.make)
 
+  def FIX_METHOD: []**
+
   /**
    * `TransactionalProducer` layer for use in tests.
    *
@@ -87,7 +89,7 @@ object KafkaTestUtils {
    * ℹ️ Instead of using a layer, consider using [[KafkaTestUtils.makeTransactionalProducer]] to directly get a
    * producer.
    */
-  val transactionalProducer: ZLayer[Kafka, Throwable, TransactionalProducer] =
+  val transactionalProducer: ZLayer[Kafka with Consumer, Throwable, TransactionalProducer] =
     transactionalProducer("test-transaction")
 
   /**
@@ -96,7 +98,7 @@ object KafkaTestUtils {
    * ℹ️ Instead of using a layer, consider using [[KafkaTestUtils.makeTransactionalProducer]] to directly get a
    * producer.
    */
-  def transactionalProducer(transactionalId: String): ZLayer[Kafka, Throwable, TransactionalProducer] =
+  def transactionalProducer(transactionalId: String): ZLayer[Kafka with Consumer, Throwable, TransactionalProducer] =
     ZLayer.scoped(makeTransactionalProducer(transactionalId))
 
   // -----------------------------------------------------------------------------------------

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -164,6 +164,9 @@ trait Consumer {
    * This method is useful when you want to use rebalance-safe-commits, but you are not committing to the Kafka brokers,
    * but to some external system, for example a relational database.
    *
+   * When this consumer is used in combination with a [[zio.kafka.producer.TransactionalProducer]], the transactional
+   * producer calls this method when the transaction is committed.
+   *
    * See also [[zio.kafka.consumer.ConsumerSettings.withRebalanceSafeCommits]].
    */
   def registerExternalCommits(offsetBatch: OffsetBatch): Task[Unit]

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -240,6 +240,8 @@ final case class ConsumerSettings(
    * External commits (that is, commits to an external system, e.g. a relational database) must be registered to the
    * consumer with [[Consumer.registerExternalCommits]].
    *
+   * When this consumer is coupled to a TransactionalProducer, `rebalanceSafeCommits` must be enabled.
+   *
    * When `false`, streams for revoked partitions may continue to run even though the rebalance is not held up. Any
    * offset commits from these streams have a high chance of being delayed (commits are not possible during some phases
    * of a rebalance). The consumer that takes over the partition will likely not see these delayed commits and will


### PR DESCRIPTION
Introduce a much simpler way to use the transactional producer. It is no longer needed to install a complex rebalance listener, coupling your `TransactionalProducer` to a `Consumer`is enough.

See #1432 for documentation.