### PR TITLE
Producer fails faster, Retry publish after Auth error

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/producer/AsyncProducerTestSupport.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/producer/AsyncProducerTestSupport.scala
@@ -13,14 +13,16 @@ import java.util.concurrent.{ CompletableFuture, Future => JFuture }
 import scala.collection.mutable
 
 /**
- * A test framework for testing use of the async `send(ProducerRecord, Callback)` method of the Kafka producer, where
- * the resulting [[java.util.concurrent.Future]] is ignored.
+ * A test framework for unit testing users of the async `send(ProducerRecord, Callback)` method of the Kafka producer,
+ * featuring precise control over when the callback is called.
+ *
+ * This was build because the MockProducer from the Kafka library does not provide callback control.
  *
  * Use it as follows:
  * {{{
  * val sendException = new RuntimeException("fail from send")
  * val callbackException = new RuntimeException("fail from callback")
- * val expectations = AsyncProducerTestSupport.expectations[Array[Byte], Array[Byte]]()
+ * val mockBehavior = AsyncProducerTestSupport.newMockBehavior[Array[Byte], Array[Byte]]()
  *   .sendSucceed()                   // send 0
  *   .sendFail(sendException)         // send fails immediately (no number)
  *   .sendSucceed()                   // send 1
@@ -38,189 +40,192 @@ import scala.collection.mutable
  *   .callbackSucceed(1)  // Fails because send 1 already has a callback
  * }}}
  *
- * When all expectations have been set, you can use the `run` method and use the given mock producer as if it is a
- * regular Kafka producer. The mock producer is thread-safe; multiple threads can use it simultaneously.
+ * When all mock behavior have been given, you can use the `run` method and use the given mock producer as if it is a
+ * regular Kafka producer.
  *
  * {{{
- * expectations.run { producer =>
- *   // use the producer, make assertions
+ * mockBehavior.run { mockProducer =>
+ *   // use the producer, make assertions, etc.
  * }
  * }}}
  *
- * The 'send' expectations are expected in the order they are given. When 'publisher.send' is invoked while a callback
- * expectation is pending, the 'send' operation is blocked until the callback expectation is met.
+ * The 'send' invocations are expected in the order they are given. When 'publisher.send' is invoked while a callback
+ * mock behavior is pending, the 'send' operation is blocked until the callback is done.
  *
- * Get a history of all send records (all 'send' attempts) with: `expectations.history()`.
+ * Get a history of all send records (all 'send' attempts) with: `mockBehavior.history()`.
+ *
+ * Current limitations:
+ *   - the given mock producer is not thread-safe; only one threads can use it at a time
+ *   - the future that is returned from the `send` method never completes
+ *   - the metadata that is returned is always the same, it contains no information
  */
 object AsyncProducerTestSupport {
 
-  trait AsyncMockProducerExpectations[K, V] {
-    def sendSucceed(): AsyncMockProducerExpectations[K, V]
-    def sendFail(e: Throwable): AsyncMockProducerExpectations[K, V]
-    def callbackSucceed(): AsyncMockProducerExpectations[K, V]
-    def callbackSucceed(n: Int): AsyncMockProducerExpectations[K, V]
-    def callbackFail(e: Exception): AsyncMockProducerExpectations[K, V]
-    def callbackFail(n: Int, e: Exception): AsyncMockProducerExpectations[K, V]
+  // Developer notes:
+  // `n` is used as the callback index (and therefore the index of `sendSuccess` mock behavior)
+  //
+  // While the behavior methods are invoked, and with a final check in `run`, we check that every callback behavior
+  // (either a `callbackSucceed` or a `callbackException`) is coupled to exactly 1 `sendSuccess` behavior. Too
+  // little, or additional callbacks result in an exception.
+  //
+  // Method `run` works with 2 fibers that run concurrently:
+  //  - a coordinator fiber, that loops over the behaviors, awaiting `send`s and invoking callbacks
+  //  - the test code that can use `mockProducer.send`
+  // The two coordinate via several promises:
+  //  - the test code awaits a start-promise that tells the `send` may proceed
+  //  - the coordinator awaits the callback-promise that tells that send was invoked, and to get the callback
+  //    that can later be invoked
+
+  trait AsyncProducerTestSupportBehavior[K, V] {
+    def sendSucceed(): AsyncProducerTestSupportBehavior[K, V]
+    def sendFail(e: Throwable): AsyncProducerTestSupportBehavior[K, V]
+    def callbackSucceed(): AsyncProducerTestSupportBehavior[K, V]
+    def callbackSucceed(n: Int): AsyncProducerTestSupportBehavior[K, V]
+    def callbackFail(e: Exception): AsyncProducerTestSupportBehavior[K, V]
+    def callbackFail(n: Int, e: Exception): AsyncProducerTestSupportBehavior[K, V]
     def run[R, A](testCode: KafkaProducer[K, V] => ZIO[R, Throwable, A]): ZIO[R, Throwable, A]
     def history: Chunk[ProducerRecord[K, V]]
   }
 
-  private sealed trait MockOperation
-  private case class SendSucceed(n: Int) extends MockOperation
-  private case class SendFail(e: Throwable) extends MockOperation {
+  private sealed trait MockBehavior
+  private case class SendSucceed(n: Int) extends MockBehavior
+  private case class SendFail(e: Throwable) extends MockBehavior {
     override def toString: String = s"SendFail(${e.getClass.getSimpleName})"
   }
-  private case class CallbackSucceed(n: Int) extends MockOperation
-  private case class CallbackFail(n: Int, e: Exception) extends MockOperation {
+  private case class CallbackSucceed(n: Int) extends MockBehavior
+  private case class CallbackFail(n: Int, e: Exception) extends MockBehavior {
     override def toString: String = s"CallbackFail($n, ${e.getClass.getSimpleName})"
   }
 
-  def expectations[K, V](): AsyncMockProducerExpectations[K, V] = new AsyncMockProducerExpectations[K, V] {
-    private val operations: ChunkBuilder[MockOperation]      = Chunk.newBuilder
+  def newMockBehavior[K, V](): AsyncProducerTestSupportBehavior[K, V] = new AsyncProducerTestSupportBehavior[K, V] {
+    private val behaviorBuilder: ChunkBuilder[MockBehavior]  = Chunk.newBuilder
     private val callbacksAvailable: mutable.Set[Int]         = mutable.BitSet.empty
     private var callbackCount: Int                           = 0
     private val _history: ChunkBuilder[ProducerRecord[K, V]] = Chunk.newBuilder
 
-    override def sendSucceed(): AsyncMockProducerExpectations[K, V] = {
-      operations += SendSucceed(callbackCount)
+    override def sendSucceed(): AsyncProducerTestSupportBehavior[K, V] = {
+      behaviorBuilder += SendSucceed(callbackCount)
       callbacksAvailable += callbackCount
       callbackCount += 1
       this
     }
-    override def sendFail(e: Throwable): AsyncMockProducerExpectations[K, V] = {
-      operations += SendFail(e)
+    override def sendFail(e: Throwable): AsyncProducerTestSupportBehavior[K, V] = {
+      behaviorBuilder += SendFail(e)
       this
     }
-    private def addCallback(n: Option[Int], op: Int => MockOperation): AsyncMockProducerExpectations[K, V] = {
+    private def addCallback(n: Option[Int], op: Int => MockBehavior): AsyncProducerTestSupportBehavior[K, V] = {
       n match {
         case Some(n) =>
           if (callbacksAvailable.contains(n)) {
             callbacksAvailable -= n
-            operations += op(n)
+            behaviorBuilder += op(n)
           } else {
             throw new AssertionError(
-              s"Callback expectation for send $n can not be added because that send expectation does not exist, or it already has a callback"
+              s"Callback mock behavior for send $n can not be added because that send expectation does not exist, or it already has a callback"
             )
           }
         case None =>
           throw new AssertionError(
-            s"Callback expectation can not be added because all send expectations already have a callback"
+            s"Callback mock behavior can not be added because all send expectations already have a callback"
           )
       }
       this
     }
-    override def callbackSucceed(): AsyncMockProducerExpectations[K, V] =
+    override def callbackSucceed(): AsyncProducerTestSupportBehavior[K, V] =
       addCallback(callbacksAvailable.minOption, CallbackSucceed(_))
-    override def callbackSucceed(n: Int): AsyncMockProducerExpectations[K, V] =
+    override def callbackSucceed(n: Int): AsyncProducerTestSupportBehavior[K, V] =
       addCallback(Some(n), CallbackSucceed(_))
-    override def callbackFail(e: Exception): AsyncMockProducerExpectations[K, V] =
+    override def callbackFail(e: Exception): AsyncProducerTestSupportBehavior[K, V] =
       addCallback(callbacksAvailable.minOption, CallbackFail(_, e))
-    override def callbackFail(n: Int, e: Exception): AsyncMockProducerExpectations[K, V] =
+    override def callbackFail(n: Int, e: Exception): AsyncProducerTestSupportBehavior[K, V] =
       addCallback(Some(n), CallbackFail(_, e))
 
     override def run[R, A](testCode: KafkaProducer[K, V] => ZIO[R, Throwable, A]): ZIO[R, Throwable, A] = {
       if (callbacksAvailable.nonEmpty) {
-        throw new AssertionError(s"Missing ${callbacksAvailable.size} callback expectations")
+        throw new AssertionError(s"Missing ${callbacksAvailable.size} callback mock behaviors")
       }
 
-      sealed trait SendOperation {
-        def startPromise: Promise[Nothing, Unit]
-        def callbackPromise: Promise[Nothing, Callback]
-      }
-      case class SendSucceedOperation(
-        n: Int,
+      case class SendExpectation(
+        mockBehavior: MockBehavior, // For scala 3 change to: `SendSucceed | SendFail`
         startPromise: Promise[Nothing, Unit],
         callbackPromise: Promise[Nothing, Callback]
-      ) extends SendOperation
-      case class SendFailOperation(
-        e: Throwable,
-        startPromise: Promise[Nothing, Unit],
-        callbackPromise: Promise[Nothing, Callback]
-      ) extends SendOperation
+      )
 
-      val ops = operations.result()
+      def fromOptionOrDie[A1](value: => Option[A1]): ZIO[Any, Nothing, A1] =
+        ZIO
+          .fromOption(value)
+          .orDieWith(_ => new AssertionError("Bug in AsyncProducerTestSupport"))
+
+      def callbackPromiseForN(sendExpectations: Seq[SendExpectation], n: Int): Option[Promise[Nothing, Callback]] =
+        sendExpectations.collectFirst {
+          case SendExpectation(SendSucceed(n1), _, callbackPromise) if n1 == n => callbackPromise
+        }
+
+      val behaviors = behaviorBuilder.result()
       for {
-        sendOperations <- ZIO.collect(ops) {
-                            case SendSucceed(n) =>
-                              for {
-                                startPromise    <- Promise.make[Nothing, Unit]
-                                callbackPromise <- Promise.make[Nothing, Callback]
-                              } yield SendSucceedOperation(n, startPromise, callbackPromise)
-                            case SendFail(e) =>
-                              for {
-                                startPromise    <- Promise.make[Nothing, Unit]
-                                callbackPromise <- Promise.make[Nothing, Callback]
-                              } yield SendFailOperation(e, startPromise, callbackPromise)
-                            case _ => ZIO.fail(None)
-                          }
+        sendExpectations <- ZIO.collect(behaviors) {
+                              case behavior @ (SendSucceed(_) | SendFail(_)) =>
+                                for {
+                                  startPromise    <- Promise.make[Nothing, Unit]
+                                  callbackPromise <- Promise.make[Nothing, Callback]
+                                } yield SendExpectation(behavior, startPromise, callbackPromise)
+                              case _ => ZIO.fail(None)
+                            }
         runtime <- ZIO.runtime[Any]
         mockProducer = new NotSupportedProducer[K, V] {
-                         private val sendCount = new AtomicInteger(0)
+                         private val currentSendIndex = new AtomicInteger(0)
                          override def send(
                            record: ProducerRecord[K, V],
                            callback: Callback
                          ): JFuture[RecordMetadata] = {
                            _history += record
-                           val n = sendCount.getAndIncrement()
-                           if (n >= sendOperations.size)
-                             throw new AssertionError(s"There is no expectation for send $n")
-                           val sendOperation = sendOperations(n)
+                           val sendIndex = currentSendIndex.getAndIncrement()
+                           if (sendIndex >= sendExpectations.size)
+                             throw new AssertionError(s"No mock behavior defined for send $sendIndex")
+                           val sendExpectation = sendExpectations(sendIndex)
                            Unsafe.unsafe { implicit u =>
                              runtime.unsafe.run {
                                for {
-                                 _ <- sendOperation.startPromise.await
-                                 _ <- sendOperation.callbackPromise.succeed(callback)
+                                 _ <- sendExpectation.startPromise.await
+                                 _ <- sendExpectation.callbackPromise.succeed(callback)
                                } yield ()
                              }
                                .getOrThrowFiberFailure()
                            }
-                           sendOperation match {
+                           (sendExpectation.mockBehavior: @unchecked) match {
                              // return a dummy future, it is never completed
-                             case _: SendSucceedOperation => new CompletableFuture[RecordMetadata]()
-                             case sfo: SendFailOperation  => throw sfo.e
+                             case _: SendSucceed => new CompletableFuture[RecordMetadata]()
+                             case SendFail(e)    => throw e
                            }
                          }
                        }
-        soi = sendOperations.iterator
-        handleOperations = ZIO.foreach(ops) {
-                             case op @ (SendSucceed(_) | SendFail(_)) =>
-                               for {
-                                 sendOperation <-
-                                   ZIO
-                                     .fromOption(soi.nextOption())
-                                     .orElseFail(new AssertionError("Bug in AsyncProducerTestSupport: unexpected operation"))
-                                 _ <- sendOperation.startPromise.succeed(())
-                                 _ <- ZIO.raceFirst(
-                                        sendOperation.callbackPromise.await,
-                                        Seq(ZIO.logInfo(s"Expectation for $op still not met").delay(5.seconds).forever)
-                                      )
-                               } yield ()
-                             case CallbackSucceed(n) =>
-                               for {
-                                 callbackPromise <-
-                                   ZIO
-                                     .fromOption(sendOperations.collectFirst {
-                                       case SendSucceedOperation(n2, _, callbackPromise) if n2 == n => callbackPromise
-                                     })
-                                     .orElseFail(new AssertionError("Bug in AsyncProducerTestSupport: unexpected operation"))
-                                 callback <- callbackPromise.await
-                                 // return dummy metadata
-                                 metadata = new RecordMetadata(new TopicPartition("", 0), 0, 0, 0, 0, 0)
-                                 _ <- ZIO.attempt(callback.onCompletion(metadata, null))
-                               } yield ()
-                             case CallbackFail(n, e) =>
-                               for {
-                                 callbackPromise <-
-                                   ZIO
-                                     .fromOption(sendOperations.collectFirst {
-                                       case SendSucceedOperation(n2, _, callbackPromise) if n2 == n => callbackPromise
-                                     })
-                                     .orElseFail(new AssertionError("Bug in AsyncProducerTestSupport: unexpected operation"))
-                                 callback <- callbackPromise.await
-                                 _        <- ZIO.attempt(callback.onCompletion(null, e))
-                               } yield ()
-                           }
-        result <- handleOperations &> testCode(mockProducer)
+        sei = sendExpectations.iterator
+        handleBehaviors = ZIO.foreach(behaviors) {
+                            case mb @ (SendSucceed(_) | SendFail(_)) =>
+                              for {
+                                sendOperation <- fromOptionOrDie(sei.nextOption())
+                                _             <- sendOperation.startPromise.succeed(())
+                                _ <- ZIO.raceFirst(
+                                       sendOperation.callbackPromise.await,
+                                       Seq(ZIO.logInfo(s"Still expecting mock behavior $mb").delay(3.seconds).forever)
+                                     )
+                              } yield ()
+                            case CallbackSucceed(n) =>
+                              for {
+                                callbackPromise <- fromOptionOrDie(callbackPromiseForN(sendExpectations, n))
+                                callback        <- callbackPromise.await
+                                // return dummy metadata
+                                metadata = new RecordMetadata(new TopicPartition("", 0), 0, 0, 0, 0, 0)
+                                _ <- ZIO.attempt(callback.onCompletion(metadata, null))
+                              } yield ()
+                            case CallbackFail(n, e) =>
+                              for {
+                                callbackPromise <- fromOptionOrDie(callbackPromiseForN(sendExpectations, n))
+                                callback        <- callbackPromise.await
+                                _               <- ZIO.attempt(callback.onCompletion(null, e))
+                              } yield ()
+                          }
+        result <- handleBehaviors &> testCode(mockProducer)
       } yield result
     }
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/producer/AsyncProducerTestSupport.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/producer/AsyncProducerTestSupport.scala
@@ -88,12 +88,12 @@ object AsyncProducerTestSupport {
   }
 
   private sealed trait MockBehavior
-  private case class SendSucceed(n: Int) extends MockBehavior
-  private case class SendFail(e: Throwable) extends MockBehavior {
+  private final case class SendSucceed(n: Int) extends MockBehavior
+  private final case class SendFail(e: Throwable) extends MockBehavior {
     override def toString: String = s"SendFail(${e.getClass.getSimpleName})"
   }
-  private case class CallbackSucceed(n: Int) extends MockBehavior
-  private case class CallbackFail(n: Int, e: Exception) extends MockBehavior {
+  private final case class CallbackSucceed(n: Int) extends MockBehavior
+  private final case class CallbackFail(n: Int, e: Exception) extends MockBehavior {
     override def toString: String = s"CallbackFail($n, ${e.getClass.getSimpleName})"
   }
 
@@ -145,7 +145,7 @@ object AsyncProducerTestSupport {
         throw new AssertionError(s"Missing ${callbacksAvailable.size} callback mock behaviors")
       }
 
-      case class SendExpectation(
+      final case class SendExpectation(
         mockBehavior: MockBehavior, // For scala 3 change to: `SendSucceed | SendFail`
         startPromise: Promise[Nothing, Unit],
         callbackPromise: Promise[Nothing, Callback]

--- a/zio-kafka-test/src/test/scala/zio/kafka/producer/AsyncProducerTestSupport.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/producer/AsyncProducerTestSupport.scala
@@ -211,7 +211,7 @@ object AsyncProducerTestSupport {
                          sendOperation.callbackPromise.await,
                          Seq(ZIO.logInfo(s"Still expecting mock behavior $mb").delay(3.seconds).forever)
                        )
-                       .timeoutFail(new AssertionError("Timed out waiting for mock behavior $mb"))(1.minute)
+                       .timeoutFail(new AssertionError(s"Timed out waiting for mock behavior $mb"))(1.minute)
               } yield ()
             case CallbackSucceed(n) =>
               for {

--- a/zio-kafka-test/src/test/scala/zio/kafka/producer/AsyncProducerTestSupport.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/producer/AsyncProducerTestSupport.scala
@@ -1,0 +1,274 @@
+package zio.kafka.producer
+
+import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, OffsetAndMetadata }
+import org.apache.kafka.clients.producer.{ Callback, ProducerRecord, RecordMetadata }
+import org.apache.kafka.common.{ Metric, MetricName, PartitionInfo, TopicPartition, Uuid }
+import org.apache.kafka.clients.producer.{ Producer => KafkaProducer }
+import zio._
+
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.{ List => JList, Map => JMap }
+import java.util.concurrent.{ CompletableFuture, Future => JFuture }
+import scala.collection.mutable
+
+/**
+ * A test framework for testing use of the async `send(ProducerRecord, Callback)` method of the Kafka producer, where
+ * the resulting [[java.util.concurrent.Future]] is ignored.
+ *
+ * Use it as follows:
+ * {{{
+ * val sendException = new RuntimeException("fail from send")
+ * val callbackException = new RuntimeException("fail from callback")
+ * val expectations = AsyncProducerTestSupport.expectations[Array[Byte], Array[Byte]]()
+ *   .sendSucceed()                   // send 0
+ *   .sendFail(sendException)         // send fails immediately (no number)
+ *   .sendSucceed()                   // send 1
+ *   .callbackSucceed()               // callback for send 0
+ *   .callbackFail(callbackException) // callback for send 1
+ *   ////// Out of order callbacks:
+ *   .sendSucceed() // send 2
+ *   .sendSucceed() // send 3
+ *   .sendSucceed() // send 4
+ *   .callbackSucceed(3) // out of order callback of send 3
+ *   .callbackSucceed()  // callback of send 2
+ *   .callbackSucceed()  // callback of send 4
+ *   ////// Basic checks
+ *   .callbackSucceed()   // Fails because all sends already have a callback
+ *   .callbackSucceed(1)  // Fails because send 1 already has a callback
+ * }}}
+ *
+ * When all expectations have been set, you can use the `run` method and use the given mock producer as if it is a
+ * regular Kafka producer. The mock producer is thread-safe; multiple threads can use it simultaneously.
+ *
+ * {{{
+ * expectations.run { producer =>
+ *   // use the producer, make assertions
+ * }
+ * }}}
+ *
+ * The 'send' expectations are expected in the order they are given. When 'publisher.send' is invoked while a callback
+ * expectation is pending, the 'send' operation is blocked until the callback expectation is met.
+ *
+ * Get a history of all send records (all 'send' attempts) with: `expectations.history()`.
+ */
+object AsyncProducerTestSupport {
+
+  trait AsyncMockProducerExpectations[K, V] {
+    def sendSucceed(): AsyncMockProducerExpectations[K, V]
+    def sendFail(e: Throwable): AsyncMockProducerExpectations[K, V]
+    def callbackSucceed(): AsyncMockProducerExpectations[K, V]
+    def callbackSucceed(n: Int): AsyncMockProducerExpectations[K, V]
+    def callbackFail(e: Exception): AsyncMockProducerExpectations[K, V]
+    def callbackFail(n: Int, e: Exception): AsyncMockProducerExpectations[K, V]
+    def run[R, A](testCode: KafkaProducer[K, V] => ZIO[R, Throwable, A]): ZIO[R, Throwable, A]
+    def history: Chunk[ProducerRecord[K, V]]
+  }
+
+  private sealed trait MockOperation
+  private case class SendSucceed(n: Int) extends MockOperation
+  private case class SendFail(e: Throwable) extends MockOperation {
+    override def toString: String = s"SendFail(${e.getClass.getSimpleName})"
+  }
+  private case class CallbackSucceed(n: Int) extends MockOperation
+  private case class CallbackFail(n: Int, e: Exception) extends MockOperation {
+    override def toString: String = s"CallbackFail($n, ${e.getClass.getSimpleName})"
+  }
+
+  def expectations[K, V](): AsyncMockProducerExpectations[K, V] = new AsyncMockProducerExpectations[K, V] {
+    private val operations: ChunkBuilder[MockOperation]      = Chunk.newBuilder
+    private val callbacksAvailable: mutable.Set[Int]         = mutable.BitSet.empty
+    private var callbackCount: Int                           = 0
+    private val _history: ChunkBuilder[ProducerRecord[K, V]] = Chunk.newBuilder
+
+    override def sendSucceed(): AsyncMockProducerExpectations[K, V] = {
+      operations += SendSucceed(callbackCount)
+      callbacksAvailable += callbackCount
+      callbackCount += 1
+      this
+    }
+    override def sendFail(e: Throwable): AsyncMockProducerExpectations[K, V] = {
+      operations += SendFail(e)
+      this
+    }
+    private def addCallback(n: Option[Int], op: Int => MockOperation): AsyncMockProducerExpectations[K, V] = {
+      n match {
+        case Some(n) =>
+          if (callbacksAvailable.contains(n)) {
+            callbacksAvailable -= n
+            operations += op(n)
+          } else {
+            throw new AssertionError(
+              s"Callback expectation for send $n can not be added because that send expectation does not exist, or it already has a callback"
+            )
+          }
+        case None =>
+          throw new AssertionError(
+            s"Callback expectation can not be added because all send expectations already have a callback"
+          )
+      }
+      this
+    }
+    override def callbackSucceed(): AsyncMockProducerExpectations[K, V] =
+      addCallback(callbacksAvailable.minOption, CallbackSucceed(_))
+    override def callbackSucceed(n: Int): AsyncMockProducerExpectations[K, V] =
+      addCallback(Some(n), CallbackSucceed(_))
+    override def callbackFail(e: Exception): AsyncMockProducerExpectations[K, V] =
+      addCallback(callbacksAvailable.minOption, CallbackFail(_, e))
+    override def callbackFail(n: Int, e: Exception): AsyncMockProducerExpectations[K, V] =
+      addCallback(Some(n), CallbackFail(_, e))
+
+    override def run[R, A](testCode: KafkaProducer[K, V] => ZIO[R, Throwable, A]): ZIO[R, Throwable, A] = {
+      if (callbacksAvailable.nonEmpty) {
+        throw new AssertionError(s"Missing ${callbacksAvailable.size} callback expectations")
+      }
+
+      sealed trait SendOperation {
+        def startPromise: Promise[Nothing, Unit]
+        def callbackPromise: Promise[Nothing, Callback]
+      }
+      case class SendSucceedOperation(
+        n: Int,
+        startPromise: Promise[Nothing, Unit],
+        callbackPromise: Promise[Nothing, Callback]
+      ) extends SendOperation
+      case class SendFailOperation(
+        e: Throwable,
+        startPromise: Promise[Nothing, Unit],
+        callbackPromise: Promise[Nothing, Callback]
+      ) extends SendOperation
+
+      val ops = operations.result()
+      for {
+        sendOperations <- ZIO.collect(ops) {
+                            case SendSucceed(n) =>
+                              for {
+                                startPromise    <- Promise.make[Nothing, Unit]
+                                callbackPromise <- Promise.make[Nothing, Callback]
+                              } yield SendSucceedOperation(n, startPromise, callbackPromise)
+                            case SendFail(e) =>
+                              for {
+                                startPromise    <- Promise.make[Nothing, Unit]
+                                callbackPromise <- Promise.make[Nothing, Callback]
+                              } yield SendFailOperation(e, startPromise, callbackPromise)
+                            case _ => ZIO.fail(None)
+                          }
+        runtime <- ZIO.runtime[Any]
+        mockProducer = new NotSupportedProducer[K, V] {
+                         private val sendCount = new AtomicInteger(0)
+                         override def send(
+                           record: ProducerRecord[K, V],
+                           callback: Callback
+                         ): JFuture[RecordMetadata] = {
+                           _history += record
+                           val n = sendCount.getAndIncrement()
+                           if (n >= sendOperations.size)
+                             throw new AssertionError(s"There is no expectation for send $n")
+                           val sendOperation = sendOperations(n)
+                           Unsafe.unsafe { implicit u =>
+                             runtime.unsafe.run {
+                               for {
+                                 _ <- sendOperation.startPromise.await
+                                 _ <- sendOperation.callbackPromise.succeed(callback)
+                               } yield ()
+                             }
+                               .getOrThrowFiberFailure()
+                           }
+                           sendOperation match {
+                             // return a dummy future, it is never completed
+                             case _: SendSucceedOperation => new CompletableFuture[RecordMetadata]()
+                             case sfo: SendFailOperation  => throw sfo.e
+                           }
+                         }
+                       }
+        soi = sendOperations.iterator
+        handleOperations = ZIO.foreach(ops) {
+                             case op @ (SendSucceed(_) | SendFail(_)) =>
+                               for {
+                                 sendOperation <-
+                                   ZIO
+                                     .fromOption(soi.nextOption())
+                                     .orElseFail(new AssertionError("Bug in AsyncProducerTestSupport: unexpected operation"))
+                                 _ <- sendOperation.startPromise.succeed(())
+                                 _ <- ZIO.raceFirst(
+                                        sendOperation.callbackPromise.await,
+                                        Seq(ZIO.logInfo(s"Expectation for $op still not met").delay(5.seconds).forever)
+                                      )
+                               } yield ()
+                             case CallbackSucceed(n) =>
+                               for {
+                                 callbackPromise <-
+                                   ZIO
+                                     .fromOption(sendOperations.collectFirst {
+                                       case SendSucceedOperation(n2, _, callbackPromise) if n2 == n => callbackPromise
+                                     })
+                                     .orElseFail(new AssertionError("Bug in AsyncProducerTestSupport: unexpected operation"))
+                                 callback <- callbackPromise.await
+                                 // return dummy metadata
+                                 metadata = new RecordMetadata(new TopicPartition("", 0), 0, 0, 0, 0, 0)
+                                 _ <- ZIO.attempt(callback.onCompletion(metadata, null))
+                               } yield ()
+                             case CallbackFail(n, e) =>
+                               for {
+                                 callbackPromise <-
+                                   ZIO
+                                     .fromOption(sendOperations.collectFirst {
+                                       case SendSucceedOperation(n2, _, callbackPromise) if n2 == n => callbackPromise
+                                     })
+                                     .orElseFail(new AssertionError("Bug in AsyncProducerTestSupport: unexpected operation"))
+                                 callback <- callbackPromise.await
+                                 _        <- ZIO.attempt(callback.onCompletion(null, e))
+                               } yield ()
+                           }
+        result <- handleOperations &> testCode(mockProducer)
+      } yield result
+    }
+
+    override def history: Chunk[ProducerRecord[K, V]] = _history.result()
+  }
+}
+
+/**
+ * A [[KafkaProducer]] that does not support any operation.
+ *
+ * @tparam K
+ *   key type
+ * @tparam V
+ *   value type
+ */
+class NotSupportedProducer[K, V] extends KafkaProducer[K, V] {
+  override def initTransactions(): Unit = throw new UnsupportedOperationException()
+
+  override def beginTransaction(): Unit = throw new UnsupportedOperationException()
+
+  override def sendOffsetsToTransaction(
+    offsets: JMap[TopicPartition, OffsetAndMetadata],
+    consumerGroupId: String
+  ): Unit = throw new UnsupportedOperationException()
+
+  override def sendOffsetsToTransaction(
+    offsets: JMap[TopicPartition, OffsetAndMetadata],
+    groupMetadata: ConsumerGroupMetadata
+  ): Unit = throw new UnsupportedOperationException()
+
+  override def commitTransaction(): Unit = throw new UnsupportedOperationException()
+
+  override def abortTransaction(): Unit = throw new UnsupportedOperationException()
+
+  override def send(record: ProducerRecord[K, V]): JFuture[RecordMetadata] = throw new UnsupportedOperationException()
+
+  override def send(record: ProducerRecord[K, V], callback: Callback): JFuture[RecordMetadata] =
+    throw new UnsupportedOperationException()
+
+  override def flush(): Unit = throw new UnsupportedOperationException()
+
+  override def partitionsFor(topic: String): JList[PartitionInfo] = throw new UnsupportedOperationException()
+
+  override def metrics(): JMap[MetricName, _ <: Metric] = throw new UnsupportedOperationException()
+
+  override def clientInstanceId(timeout: Duration): Uuid = throw new UnsupportedOperationException()
+
+  override def close(): Unit = throw new UnsupportedOperationException()
+
+  override def close(timeout: Duration): Unit = throw new UnsupportedOperationException()
+}

--- a/zio-kafka-test/src/test/scala/zio/kafka/producer/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/producer/ProducerSpec.scala
@@ -1,221 +1,262 @@
 package zio.kafka.producer
 
-import org.apache.kafka.clients.producer
-import org.apache.kafka.clients.producer.{ MockProducer, ProducerRecord, RecordMetadata }
-import org.apache.kafka.common.KafkaException
+import org.apache.kafka.clients.producer.{ Producer => KafkaProducer, ProducerRecord, RecordMetadata }
 import org.apache.kafka.common.errors.AuthenticationException
-import org.apache.kafka.common.serialization.ByteArraySerializer
 import zio._
 import zio.test.TestAspect.withLiveClock
 import zio.test._
 
-import java.util.concurrent.Future
-import java.util.concurrent.atomic.AtomicBoolean
-
 object ProducerSpec extends ZIOSpecDefault {
-
-  private object TestKeyValueSerializer extends ByteArraySerializer
-
-  private class BinaryMockProducer(autoComplete: Boolean)
-      extends MockProducer[Array[Byte], Array[Byte]](
-        autoComplete,
-        TestKeyValueSerializer,
-        TestKeyValueSerializer
-      ) {
-
-    private val nextSendAllowed = new AtomicBoolean(autoComplete)
-
-    override def send(
-      record: ProducerRecord[Array[Byte], Array[Byte]],
-      callback: producer.Callback
-    ): Future[RecordMetadata] = {
-      awaitSendAllowed()
-      val sendResult = super.send(record, callback)
-      nextSendAllowed.set(autoComplete)
-
-      sendResult
-    }
-
-    def allowNextSendAndAwaitSendCompletion(): Unit = {
-      allowNextSend()
-      awaitSendCompletion()
-    }
-
-    def allowNextSend(): Unit =
-      nextSendAllowed.set(true)
-
-    def awaitSendAllowed(): Unit =
-      awaitSendCondition(true)
-
-    def awaitSendCompletion(): Unit =
-      awaitSendCondition(false)
-
-    private def awaitSendCondition(expectedCondition: Boolean): Unit = {
-      var awaitingSendCondition = true
-      while (awaitingSendCondition)
-        awaitingSendCondition = expectedCondition != nextSendAllowed.get()
-    }
-
-  }
+  private val recordsToSend = Chunk(
+    makeProducerRecord(),
+    makeProducerRecord(),
+    makeProducerRecord(),
+    makeProducerRecord(),
+    makeProducerRecord()
+  )
+  private val testAuthenticationExceptionMessage = "test authentication exception"
+  private val authException                      = new AuthenticationException(testAuthenticationExceptionMessage)
 
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("Producer")(
       suite("produceChunkAsyncWithFailures")(
         test("successfully produces chunk of records") {
-          withProducer() { (_, producer) =>
-            val recordsToSend = Chunk(
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord()
-            )
-            for {
-              results <- producer.produceChunkAsyncWithFailures(recordsToSend).flatten
-            } yield assertTrue(
+          val expectations = AsyncProducerTestSupport
+            .expectations[Array[Byte], Array[Byte]]()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .callbackSucceed()
+            .callbackSucceed()
+            .callbackSucceed()
+            .callbackSucceed()
+            .callbackSucceed()
+          for {
+            results <- runTest(expectations, recordsToSend)
+          } yield {
+            val history = expectations.history
+            assertTrue(
               results.length == recordsToSend.length,
-              results.forall(_.isRight)
+              results.forall(_.isRight),
+              history.size == 5
             )
           }
         },
-        test("omits sending further records in chunk in case the first send call fails") {
-          withProducer() { (mockJavaProducer, producer) =>
-            val recordsToSend = Chunk(
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord()
-            )
-            val testAuthenticationExceptionMessage = "test authentication exception"
-            mockJavaProducer.sendException = new AuthenticationException(testAuthenticationExceptionMessage)
-            for {
-              results <- producer.produceChunkAsyncWithFailures(recordsToSend).flatten
-            } yield assertTrue(
+        test("successfully produces chunk of records, with callbacks in an arbitrary order") {
+          val expectations = AsyncProducerTestSupport
+            .expectations[Array[Byte], Array[Byte]]()
+            .sendSucceed()
+            .sendSucceed()
+            .callbackSucceed(1)
+            .sendSucceed()
+            .callbackSucceed(0)
+            .sendSucceed()
+            .callbackSucceed(2)
+            .sendSucceed()
+            .callbackSucceed(4)
+            .callbackSucceed(3)
+          for {
+            results <- runTest(expectations, recordsToSend)
+          } yield {
+            val history = expectations.history
+            assertTrue(
               results.length == recordsToSend.length,
-              results.head.isLeft,
-              results.head.left.forall(_.getMessage == testAuthenticationExceptionMessage),
-              results.tail.forall(_ == Left(Producer.PublishOmittedException))
+              results.forall(_.isRight),
+              history.size == 5
             )
           }
         },
-        test("provides correct results in case last send call fails") {
-          withProducer(autoCompleteProducerRequests = false) { (mockJavaProducer, producer) =>
-            val recordsToSend = Chunk(
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord()
-            )
-            val testAuthenticationExceptionMessage = "test authentication exception"
-            val mockJavaProducerBehaviour = ZIO.succeed {
-              // Send calls behaviours
-              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
-              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
-              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
-              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
-              mockJavaProducer.sendException = new AuthenticationException(testAuthenticationExceptionMessage)
-              mockJavaProducer.allowNextSend()
-              // Send callbacks behaviours
-              mockJavaProducer.completeNext()
-              mockJavaProducer.completeNext()
-              mockJavaProducer.completeNext()
-              mockJavaProducer.completeNext()
-            }
-            for {
-              _       <- mockJavaProducerBehaviour.forkScoped
-              results <- producer.produceChunkAsyncWithFailures(recordsToSend).flatten
-            } yield assertTrue(
+        test("omits sending further records in chunk when send call fails") {
+          val expectations = AsyncProducerTestSupport
+            .expectations[Array[Byte], Array[Byte]]()
+            .sendSucceed()
+            .sendFail(authException)
+            .callbackSucceed()
+          for {
+            results <- runTest(expectations, recordsToSend)
+          } yield {
+            val history = expectations.history
+            assertTrue(
               results.length == recordsToSend.length,
-              results.init.forall(_.isRight),
-              results.last.isLeft,
-              results.last.left.forall(_.getMessage == testAuthenticationExceptionMessage)
+              results.head.isRight,
+              results(1).left.forall(_.getMessage == testAuthenticationExceptionMessage),
+              results.drop(2).forall(_ == Left(Producer.PublishOmittedException)),
+              history.size == 2
             )
           }
         },
-        test("omits sending further records in chunk and provides correct results in case middle send call fails") {
-          withProducer(autoCompleteProducerRequests = false) { (mockJavaProducer, producer) =>
-            val recordsToSend = Chunk(
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord()
-            )
-            val testAuthenticationExceptionMessage = "test authentication exception"
-            val mockJavaProducerBehaviour = ZIO.succeed {
-              // Send calls behaviours
-              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
-              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
-              mockJavaProducer.sendException = new AuthenticationException(testAuthenticationExceptionMessage)
-              mockJavaProducer.allowNextSend()
-              // Send callbacks behaviours
-              mockJavaProducer.completeNext()
-              mockJavaProducer.completeNext()
-            }
-            for {
-              _       <- mockJavaProducerBehaviour.forkScoped
-              results <- producer.produceChunkAsyncWithFailures(recordsToSend).flatten
-            } yield assertTrue(
+        test("retries send after an AuthenticationException from send") {
+          val expectations = AsyncProducerTestSupport
+            .expectations[Array[Byte], Array[Byte]]()
+            .sendSucceed()
+            .sendFail(authException) // send 1 fails immediately
+            .callbackSucceed()       // send 0 ok
+            // Sending record 1 failed with AuthError, sending records 2, 3, and 4 was skipped
+            // All 4 are retried:
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .callbackSucceed()
+            .callbackSucceed()
+            .callbackSucceed()
+            .callbackSucceed()
+          for {
+            results <- runTest(expectations, recordsToSend, Schedule.recurs(1))
+          } yield {
+            val history = expectations.history
+            assertTrue(
               results.length == recordsToSend.length,
-              results(0).isRight,
-              results(1).isRight,
-              results(2).left.forall(_.getMessage == testAuthenticationExceptionMessage),
-              results(3) == Left(Producer.PublishOmittedException),
-              results(4) == Left(Producer.PublishOmittedException)
+              results.forall(_.isRight),
+              history.size == 6
             )
           }
         },
-        test(
-          "omits sending further records in chunk and provides correct results in case second publication to broker fails along with middle send call failure"
-        ) {
-          withProducer(autoCompleteProducerRequests = false) { (mockJavaProducer, producer) =>
-            val recordsToSend = Chunk(
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord(),
-              makeProducerRecord()
+        test("retries send after an AuthenticationException from callback") {
+          val expectations = AsyncProducerTestSupport
+            .expectations[Array[Byte], Array[Byte]]()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .callbackSucceed()
+            .callbackFail(authException)
+            .callbackSucceed()
+            .callbackFail(authException)
+            .callbackSucceed()
+            // Sending record 0, 2 and 4 -> okay
+            // Sending record 1 and 3 failed with AuthError
+            // Only 1 and 3 are retried:
+            .sendSucceed()
+            .sendSucceed()
+            .callbackSucceed()
+            .callbackSucceed()
+          for {
+            results <- runTest(expectations, recordsToSend, Schedule.recurs(1))
+          } yield {
+            val history = expectations.history
+            assertTrue(
+              results.length == recordsToSend.length,
+              results.forall(_.isRight),
+              history.size == 7
             )
-            val testAuthenticationExceptionMessage = "test authentication exception"
-            val testKafkaExceptionMessage          = "unexpected broker exception"
-            val mockJavaProducerBehaviour = ZIO.succeed {
-              // Send calls behaviours
-              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
-              mockJavaProducer.allowNextSendAndAwaitSendCompletion()
-              mockJavaProducer.sendException = new AuthenticationException(testAuthenticationExceptionMessage)
-              mockJavaProducer.allowNextSend()
-              // Send callbacks behaviours
-              mockJavaProducer.completeNext()
-              mockJavaProducer.errorNext(new KafkaException(testKafkaExceptionMessage))
-            }
-            for {
-              _       <- mockJavaProducerBehaviour.forkScoped
-              results <- producer.produceChunkAsyncWithFailures(recordsToSend).flatten
-            } yield assertTrue(
+          }
+        },
+        test("does not retry send after another Exception from send") {
+          val expectations = AsyncProducerTestSupport
+            .expectations[Array[Byte], Array[Byte]]()
+            .sendSucceed()
+            .sendFail(new RuntimeException())
+            .callbackSucceed()
+          for {
+            results <- runTest(expectations, recordsToSend, Schedule.recurs(1))
+          } yield {
+            val history = expectations.history
+            assertTrue(
+              results.length == recordsToSend.length,
+              results.head.isRight,
+              results.tail.forall(_.isLeft),
+              history.size == 2
+            )
+          }
+        },
+        test("does not retry send after another Exception from callback, even when there is also an AuthException") {
+          val expectations = AsyncProducerTestSupport
+            .expectations[Array[Byte], Array[Byte]]()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .callbackSucceed()
+            .callbackFail(authException)
+            .callbackSucceed()
+            .callbackFail(new RuntimeException())
+            .callbackSucceed()
+          for {
+            results <- runTest(expectations, recordsToSend, Schedule.recurs(1))
+          } yield {
+            val history = expectations.history
+            assertTrue(
               results.length == recordsToSend.length,
               results(0).isRight,
               results(1).isLeft,
-              results(1).left.forall(_.getMessage == testKafkaExceptionMessage),
-              results(2).left.forall(_.getMessage == testAuthenticationExceptionMessage),
-              results(3) == Left(Producer.PublishOmittedException),
-              results(4) == Left(Producer.PublishOmittedException)
+              results(2).isRight,
+              results(3).isLeft,
+              results(4).isRight,
+              history.size == 5
+            )
+          }
+        },
+        test("does multiple send retries after an AuthenticationException") {
+          val expectations = AsyncProducerTestSupport
+            .expectations[Array[Byte], Array[Byte]]()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .sendSucceed()
+            .callbackSucceed()
+            .callbackFail(authException)
+            .callbackSucceed()
+            .callbackFail(authException)
+            .callbackSucceed()
+            // Sending record 0, 2 and 4 -> okay
+            // Sending record 1 and 3 failed with AuthError
+            // Only 1 and 3 are retried:
+            .sendSucceed()
+            .sendSucceed()
+            .callbackFail(authException)
+            .callbackFail(authException)
+            // Retried again
+            .sendSucceed()
+            .sendSucceed()
+            .callbackFail(authException)
+            .callbackSucceed()
+            // Retried again
+            .sendSucceed()
+            .callbackSucceed()
+          for {
+            results <- runTest(expectations, recordsToSend, Schedule.forever)
+          } yield {
+            val history = expectations.history
+            assertTrue(
+              results.length == recordsToSend.length,
+              results.forall(_.isRight),
+              history.size == 10
             )
           }
         }
       )
     ) @@ withLiveClock
 
-  private def withProducer(autoCompleteProducerRequests: Boolean = true)(
-    producerTest: (BinaryMockProducer, Producer) => ZIO[Scope, Throwable, TestResult]
-  ): ZIO[Scope, Throwable, TestResult] =
+  private def withProducer[A](
+    mockJavaProducer: KafkaProducer[Array[Byte], Array[Byte]],
+    authErrorRetrySchedule: Schedule[Any, Throwable, Any]
+  )(
+    producerTest: Producer => ZIO[Scope, Throwable, A]
+  ): ZIO[Any, Throwable, A] =
     ZIO.scoped {
-      val mockJavaProducer = new BinaryMockProducer(autoCompleteProducerRequests)
+      val producerSettings = ProducerSettings()
+        .withAuthErrorRetrySchedule(authErrorRetrySchedule)
 
       Producer
-        .fromJavaProducer(mockJavaProducer, ProducerSettings())
-        .flatMap(producerTest(mockJavaProducer, _))
+        .fromJavaProducer(mockJavaProducer, producerSettings)
+        .flatMap(producerTest(_))
+    }
+
+  private def runTest(
+    expectations: AsyncProducerTestSupport.AsyncMockProducerExpectations[Array[Byte], Array[Byte]],
+    recordsToSend: Chunk[ProducerRecord[Array[Byte], Array[Byte]]],
+    authErrorRetrySchedule: Schedule[Any, Throwable, Any] = Schedule.stop
+  ): ZIO[Any, Throwable, Chunk[Either[Throwable, RecordMetadata]]] =
+    expectations.run { mockProducer =>
+      withProducer(mockProducer, authErrorRetrySchedule) { producer =>
+        producer.produceChunkAsyncWithFailures(recordsToSend).flatten
+      }
     }
 
   private def makeProducerRecord(

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -617,6 +617,8 @@ private[producer] final class ProducerLive(
             }
           }
 
+          // Must be volatile so that reads in this thread always see the latest value, even when the callback sets it
+          // from another thread.
           @volatile var previousSendCallsSucceed = true
 
           recordsIterator.foreach { case (record: ByteRecord, recordIndex: Int) =>

--- a/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
@@ -17,8 +17,8 @@ import zio.kafka.security.KafkaCredentialStore
 final case class ProducerSettings(
   closeTimeout: Duration = 30.seconds,
   sendBufferSize: Int = 4096,
-  properties: Map[String, AnyRef] = Map.empty,
-  authErrorRetrySchedule: Schedule[Any, Throwable, Any] = Schedule.stop
+  authErrorRetrySchedule: Schedule[Any, Throwable, Any] = Schedule.stop,
+  properties: Map[String, AnyRef] = Map.empty
 ) {
   def driverSettings: Map[String, AnyRef] = properties
 

--- a/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
@@ -4,10 +4,21 @@ import org.apache.kafka.clients.producer.ProducerConfig
 import zio._
 import zio.kafka.security.KafkaCredentialStore
 
+/**
+ * Settings for the Producer.
+ *
+ * To stay source compatible with future releases, you are recommended to construct the settings as follows:
+ * {{{
+ *   ProducerSettings(bootstrapServers)
+ *     .withCloseTimeout(30.seconds)
+ *     .... etc.
+ * }}}
+ */
 final case class ProducerSettings(
   closeTimeout: Duration = 30.seconds,
   sendBufferSize: Int = 4096,
-  properties: Map[String, AnyRef] = Map.empty
+  properties: Map[String, AnyRef] = Map.empty,
+  authErrorRetrySchedule: Schedule[Any, Throwable, Any] = Schedule.stop
 ) {
   def driverSettings: Map[String, AnyRef] = properties
 
@@ -32,7 +43,33 @@ final case class ProducerSettings(
   def withCredentials(credentialsStore: KafkaCredentialStore): ProducerSettings =
     withProperties(credentialsStore.properties)
 
-  def withSendBufferSize(sendBufferSize: Int) = copy(sendBufferSize = sendBufferSize)
+  /**
+   * @param sendBufferSize
+   *   The maximum number of record chunks that can queue up while waiting for the underlying producer to become
+   *   available.
+   */
+  def withSendBufferSize(sendBufferSize: Int): ProducerSettings =
+    copy(sendBufferSize = sendBufferSize)
+
+  /**
+   * @param authErrorRetrySchedule
+   *   The schedule at which the producer will retry producing, even when producing fails with an
+   *   [[org.apache.kafka.common.errors.AuthorizationException]] or
+   *   [[org.apache.kafka.common.errors.AuthenticationException]].
+   *
+   * This setting helps with failed producing due to too slow authorization or authentication in the broker.
+   *
+   * For example, to retry 5 times, spaced by 500ms, you can set this to
+   * {{{Schedule.recurs(5) && Schedule.spaced(500.millis)}}}
+   *
+   * The default is `Schedule.stop` which is, to fail the producer on the first auth error.
+   *
+   * ⚠️ Retrying can cause records to be produced in a different order than the order in which they were given to
+   * zio-kafka.
+   */
+  def withAuthErrorRetrySchedule(authErrorRetrySchedule: Schedule[Any, Throwable, Any]): ProducerSettings =
+    copy(authErrorRetrySchedule = authErrorRetrySchedule)
+
 }
 
 object ProducerSettings {

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -97,7 +97,7 @@ object TransactionalProducer {
       semaphore <- Semaphore.make(1)
       runtime   <- ZIO.runtime[Any]
       sendQueue <-
-        Queue.bounded[(Chunk[ByteRecord], Promise[Nothing, Chunk[Either[Throwable, RecordMetadata]]])](
+        Queue.bounded[(Chunk[ByteRecord], Chunk[Either[Throwable, RecordMetadata]] => UIO[Unit])](
           settings.producerSettings.sendBufferSize
         )
       live = new ProducerLive(settings.producerSettings, rawProducer, runtime, sendQueue)

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -100,7 +100,7 @@ object TransactionalProducer {
         Queue.bounded[(Chunk[ByteRecord], Promise[Nothing, Chunk[Either[Throwable, RecordMetadata]]])](
           settings.producerSettings.sendBufferSize
         )
-      live = new ProducerLive(rawProducer, runtime, sendQueue)
+      live = new ProducerLive(settings.producerSettings, rawProducer, runtime, sendQueue)
       _ <- ZIO.blocking(live.sendFromQueue).forkScoped
     } yield new LiveTransactionalProducer(live, semaphore)
 }

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
@@ -13,11 +13,8 @@ object TransactionalProducerSettings {
 
   def apply(bootstrapServers: List[String], transactionalId: String): TransactionalProducerSettings =
     TransactionalProducerSettings(
-      ProducerSettings(
-        30.seconds,
-        4096,
-        Map(ProducerConfig.TRANSACTIONAL_ID_CONFIG -> transactionalId)
-      ).withBootstrapServers(bootstrapServers)
+      ProducerSettings(bootstrapServers)
+        .withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
     )
 
   def apply(
@@ -28,10 +25,10 @@ object TransactionalProducerSettings {
     sendBufferSize: Int
   ): TransactionalProducerSettings =
     TransactionalProducerSettings(
-      ProducerSettings(
-        closeTimeout,
-        sendBufferSize,
-        properties.updated(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
-      ).withBootstrapServers(bootstrapServers)
+      ProducerSettings(bootstrapServers)
+        .withCloseTimeout(closeTimeout)
+        .withSendBufferSize(sendBufferSize)
+        .withProperties(properties)
+        .withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
     )
 }


### PR DESCRIPTION
1. When the producer fails to send a message from a batch of messages, it stops sending after the first error. This behavior is extended by also stopping after a failure from Kafka's callback.

2. Introduce producer setting `authErrorRetrySchedule` on which sending after auth errors (`AuthorizationException` and `AuthenticationException`) can be retried. Auth error occur on some slow brokers.

Both changes have been made possible by a new test framework in which we have precise control over the order of callbacks.

This change is not binary compatible due to changes in `ProducerSettings`.

Also:
 - cleanup `Producer` scaladocs
 - add more producer tests