### PR TITLE
Deprecate `restartStreamOnRebalancing`

### DIFF
--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -128,6 +128,10 @@ object KafkaTestUtils {
     clientInstanceId: Option[String] = None,
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest),
+    // @deprecated
+    // starting zio-kafka 3.0.0 `restartStreamOnRebalancing` is no longer available. As far as the zio-kafka
+    // contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs it for
+    // that.
     restartStreamOnRebalancing: Boolean = false,
     rebalanceSafeCommits: Boolean = false,
     maxRebalanceDuration: Duration = 3.minutes,

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -13,6 +13,7 @@ import zio.stream.ZStream
 
 import java.io.File
 import java.nio.file.{ Files, StandardCopyOption }
+import scala.annotation.nowarn
 
 object KafkaTestUtils {
 
@@ -136,6 +137,7 @@ object KafkaTestUtils {
     properties: Map[String, String] = Map.empty
   ): URIO[Kafka, ConsumerSettings] =
     ZIO.serviceWith[Kafka] { (kafka: Kafka) =>
+      @nowarn("msg=deprecated")
       val settings = ConsumerSettings(kafka.bootstrapServers)
         .withClientId(clientId)
         .withCloseTimeout(5.seconds)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -206,7 +206,7 @@ final case class ConsumerSettings(
    *
    * @deprecated
    *   starting zio-kafka 3.0.0 `restartStreamOnRebalancing` is no longer available. As far as the zio-kafka
-   *   contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs if for
+   *   contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs it for
    *   that.
    */
   @deprecated("`restartStreamOnRebalancing` will be removed in zio-kafka 3.0", "2.10.0")

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -203,7 +203,13 @@ final case class ConsumerSettings(
    * @param value
    *   When `true` _all_ streams are restarted during a rebalance, including those streams that are not revoked. The
    *   default is `false`.
+   *
+   * @deprecated
+   *   starting zio-kafka 3.0.0 `restartStreamOnRebalancing` is no longer available. As far as the zio-kafka
+   *   contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs if for
+   *   that.
    */
+  @deprecated("`restartStreamOnRebalancing` will be removed in zio-kafka 3.0", "2.10.0")
   def withRestartStreamOnRebalancing(value: Boolean): ConsumerSettings =
     copy(restartStreamOnRebalancing = value)
 


### PR DESCRIPTION
The feature `restartStreamOnRebalancing` is no longer needed in zio-kafka 3.x as transactional producing will work without it.