### PR TITLE
Improve `withSendBufferSize` docs

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
@@ -66,6 +66,8 @@ final case class ProducerSettings(
    * @param sendBufferSize
    *   The maximum number of record chunks that can queue up while waiting for the underlying producer to become
    *   available.
+   *   Performance critical users that publish a lot of records one by one (instead of in chunks), should consider
+   *   increasing this value, for example to `10240`.
    */
   def withSendBufferSize(sendBufferSize: Int): ProducerSettings =
     copy(sendBufferSize = sendBufferSize)


### PR DESCRIPTION
Performance research from @lukestephenson suggests that a higher send buffer size is good for performance in some use cases. (See #531.)