### PR TITLE
Deprecate accessor methods

### DIFF
--- a/docs/migrating-to-2.11.md
+++ b/docs/migrating-to-2.11.md
@@ -1,0 +1,141 @@
+---
+id: migrating-to-2.11
+title: "Migrating to zio-kafka 2.11"
+---
+
+Zio-kafka 2.11 paves the way for zio-kafka 3.0 by deprecating things that will be removed in zio-kafka 3.0.
+
+If you encounter deprecated methods in your code, follow this guide.
+
+# Renamed methods
+
+Some methods have just been renamed. Read the deprecation message and try the new method name. If it compiles, you're
+done. Otherwise, read on.
+
+# Consumer, Producer and TransactionalProducer accessor methods
+
+Accessor methods are little helper methods that look up a service from the environment, and then forward your call to
+that service. Accessor methods have not been recommended for some time and are now deprecated. The
+[ZIO service pattern](https://zio.dev/reference/service-pattern/) provides a much cleaner approach for accessing
+services.
+
+All accessor methods provided by zio-kafka are deprecated in zio-kafka 2.11 and will be removed in zio-kafka 3.0. If
+you use these accessor methods follow one of these approaches:
+
+## Use the ZIO Service pattern
+
+This is the best option. For established codebases it may be a lot of work to get here. If you are already follow
+this pattern, using it for zio-kafka services as well will be easy.
+
+Here is an example with a `Consumer`, but it works the same with `Producer` and `TransactionalProducer`. We get the
+`Consumer` from the environment in the layer with the `ZIO.service` method, and then inject it into the service class.
+The service now uses the consumer directly: with `consumer` instead of `Consumer`.
+
+```scala
+import zio.kafka.consumer.Consumer
+
+trait Service {
+    def someMethod: ZIO[Any, Throwable, String]
+}
+
+object Service {
+  
+  def layer: ZLayer[Consumer, Throwable, Service] = ZLayer {
+      for {
+        consumer <- ZIO.service[Consumer]
+      } yield ServiceLive(consumer)
+  }
+  
+}
+
+case class ServiceLive(consumer: Consumer) extends Service {
+
+  override def someMethod: ZIO[Any, Throwable, String] = {
+    // use `consumer`, not `Consumer`:
+    consumer.plainStream(/*...*/).runHead
+  }
+}
+```
+
+## YOLO, use `ZIO.service` everywhere
+
+The other option is to replace all accessor methods of `Consumer`, `Producer` and `TransactionalProducer` as follows:
+
+- `Consumer.method(...)` => `ZIO.serviceWithZIO[Consumer](_.method(...))`
+- `Producer.method(...)` => `ZIO.serviceWithZIO[Producer](_.method(...))`
+- `TransactionalProducer.method(...)` => `ZIO.serviceWithZIO[TransactionalProducer](_.method(...))`
+
+Or, alternatively, use `ZIO.service`: `Consumer.method(...)` is transformed to:
+```scala
+for {
+  consumer <- ZIO.service[Consumer]
+  _        <- consumer.method(...)
+} yield () 
+```
+
+# Zio-test-kit
+
+Zio-kafka provides a `zio-kafka-testkit` library to help you test your code using zio-kafka. Several methods in the
+`KafkaTestUtils` class have been replaced:
+
+- The `produce*` and `scheduledProduce*` methods, which get a producer from the environment, have been deprecated.
+  Each of these methods now has a variant with an explicit producer parameter.
+- All methods that produce a layer (e.g. `consumer`, `producer`) have _not_ been deprecated, but they have been given a
+  more convenient alternative: `makeConsumer`, `makeProducer`, etc.
+- The `withAdmin`, `withSaslAdmin`, `withSslAdmin` methods are deprecated and are replaced by `makeAdminClient`,
+  `makeSaslAdminClient` and `makeSslAdminClient`.
+
+Here is a typical example and the new version:
+
+```scala
+// Old
+override def spec: Spec[TestEnvironment, Any] =
+  suite("old example suite")(
+    test("uses a producer") {
+      for {
+        _ <- KafkaTestUtils.produceOne("topic", "key", "message")
+      } yield assertCompletes
+    }
+  )
+    .provideSome[Kafka](KafkaTestUtils.producer)
+
+// New
+// Added `Scope`:
+override def spec: Spec[TestEnvironment & Scope, Any] =
+  suite("new example suite")(
+    test("uses a producer") {
+      for {
+        // Make a producer explicitly (instead of via a layer):
+        producer <- KafkaTestUtils.makeProducer
+        // Notice explicit producer parameter:
+        _ <- KafkaTestUtils.produceOne(producer, "topic", "key", "message")
+      } yield assertCompletes
+    }
+    // No more layer magic!
+  )
+```
+
+`KafkaTestUtils.makeProducer` and the other `make*` methods require a `Scope` in the environment. This scope is
+normally provided by the test framework (notice how `Scope` was added to the type parameter of `Spec`). If needed, a
+smaller scope can be given with the `ZIO.scoped` method. See also [writing tests](writing-tests.md) for details on how
+to provide more layers.
+
+Here is an example of how to rewrite code that uses one of the deprecated `with*Admin` methods:
+
+```scala
+// Old
+KafkaTestUtils.withAdmin { adminClient =>
+  adminClient.method() // Use the admin client...
+}
+
+// New
+for {
+  adminClient <- KafkaTestUtils.makeAdminClient
+  _           <- adminClient.method() // Use the admin client...
+} yield ()
+```
+
+# Other changes?
+
+If you find a change that is not documented here then please let us know via a
+[new issue](https://github.com/zio/zio-kafka/issues/new).

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -14,7 +14,8 @@ const sidebars = {
         "preventing-duplicates",
         "sharing-consumer",
         "serialization-and-deserialization",
-        "writing-tests"
+        "writing-tests",
+        "migrating-to-2.11"
       ]
     }
   ]

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -3,25 +3,26 @@ id: writing-tests
 title: "Writing Tests with the `zio-kafka-testkit` library"
 ---
 
-zio-kafka provides a `zio-kafka-testkit` library to help you test your code using zio-kafka.
+Zio-kafka provides a `zio-kafka-testkit` library to help you test your code using zio-kafka.
 
 To add it in your project, add the following dependency in your `build.sbt`:
+
 ```scala
 libraryDependencies += "dev.zio" %% "zio-kafka-testkit" % "<latest-version>" % Test
 ```
 
-Let's study some examples of tests you can write with the `zio-kafka-testkit` and `zio-test` and let's see what this library provides you.
+Let's study some examples of tests you can write with the `zio-kafka-testkit` and `zio-test` and let's see what this
+library provides you.
 
 ## Testing a producer
 
 ```scala mdoc:compile-only
 import org.apache.kafka.clients.producer.ProducerRecord
 import zio._
-import zio.kafka.producer.Producer
 import zio.kafka.serde.Serde
-import zio.kafka.testkit.KafkaTestUtils._ // An object containing several utilities to simplify writing your tests
-import zio.kafka.testkit.Kafka // A trait representing a Kafka instance in your tests
-import zio.test.TestAspect.{ sequential, timeout }
+import zio.kafka.testkit.Kafka
+import zio.kafka.testkit.KafkaTestUtils
+import zio.test.TestAspect.{timeout, withLiveClock}
 import zio.test._
 
 object ProducerSpec extends ZIOSpecDefault {
@@ -30,134 +31,182 @@ object ProducerSpec extends ZIOSpecDefault {
       suite("Producer test suite")(
         test("minimal example") {
           for {
-            _ <- Producer.produce(new ProducerRecord("topic", "boo", "baa"), Serde.string, Serde.string)
-          } yield assertCompletes
+            producer <- KafkaTestUtils.makeProducer // (1)
+            _ <- producer.produce(new ProducerRecord("topic", "boo", "baa"), Serde.string, Serde.string) // (3)
+          } yield assertCompletes // (3)
         }
         // ... more tests ...
       )
-        .provideSome[Kafka](producer)             // Here, we provide a new instance of Producer per test
-        .provideSomeShared[Scope](Kafka.embedded) // Here, we provide an instance of Kafka for the entire suite
-    ) @@ timeout(2.minutes) @@ sequential
+        .provideSomeShared[Scope](Kafka.embedded) // (4) Provide an embedded Kafka instance, shared in the entire suite
+      ) @@ withLiveClock @@ timeout(2.minutes) // (5)
 }
 ```
 
-This test is a very minimal example.    
-It uses the `Producer.produce` method from zio-kafka to produce a record to the Kafka cluster.    
-The `assertCompletes` assertion from zio-test is used to check that the effect completes successfully.    
+The main entry points for zio-kafka test kit are the classes `KafkaTestUtils` and `Kafka`.
 
-In this example, we decided to instantiate a new `Producer` for each test, with the `.provideSome[Kafka](producer)`.      
-We could have decided to share one instance of `Producer` between all the tests of this suite by moving the `producer` layer to the `provideSomeShared`, which would have
-looked like this:
+(1) A producer is created with lots of default settings. It knows how to connect to the Kafka broker by getting a
+`Kafka` instance from the environment (see (4)).
+
+(2) The producer is used to produce a record.
+
+Take a look at the `produce*` methods in `KafkaTestUtils` when you need to produce a lot of records.
+
+(3) The `assertCompletes` assertion from zio-test is used to check that the effect completes without errors.
+
+(4) Provide a `Kafka` instance as a layer shared between all the tests. In this test we provide an **Embedded Kafka**,
+meaning that a complete Kafka cluster is started and stopped inside the current JVM.
+
+See further below for more options, such as connecting to an external Kafka cluster.
+
+Note that any services that are _not_ provided at this line, must be given as type parameter to `provideSomeShared`. In
+this case we are not providing a `Scope` (it is provided by the test framework).
+
+(5) Zio-kafka requires a live clock.
+
+### Producer layer
+
+In this example above, we decided to make a new `Producer` in each test. We could have decided to share one instance of
+`Producer` between all the tests of this suite. For this purpose we can get a Producer layer using
+`KafkaTestUtils.producer`. The result is:
+
 ```scala
 suite("producer test suite")(
   // ... tests ...
-).provideSomeShared[Scope](Kafka.embedded, producer)
+).provideSomeShared[Scope](Kafka.embedded, KafkaTestUtils.producer)
 ```
-This `producer` layer comes from the `KafkaTestUtils` object in zio-kafka-testkit. It is a layer that bootstraps a `Producer` instance.
 
-In this example, we decided to share an instance of Kafka for the entire suite, with the `.provideSomeShared[Scope](Kafka.embedded)`.     
-Kafka is slow to start, so it is better to only start it once and share it between all tests of the suite.     
+### More Kafka sharing options
 
-We could have decided to instantiate a new instance of Kafka for each test by moving the `Kafka.embedded` layer to the `provideSome`, which would have
-looked like this:
+Kafka is slow to start, so it is better to only start it once and share it between all tests of the suite.
+
+However, if we insist on a separate embedded Kafka _per test_, we can provide the `Kafka.embedded` layer with
+`provideSome` (instead of `provideSomeShared`), which looks like this:
+
 ```scala
 suite("producer test suite")(
   // ... tests ...
-).provideSome[Scope](Kafka.embedded, producer)
+).provideSome[Scope](Kafka.embedded)
 ```
 
-We could also have decided to share one instance of `Kafka` between different test suites (i.e. between different test files) by mixing the `ZIOSpecWithKafka` trait,
-which would have looked like this:
+We can also share one embedded `Kafka` instance between different test suites (i.e. between different test files) by
+mixing in the `ZIOSpecWithKafka` trait, this looks like this:
+
 ```scala
-object ProducerSpec extends ZIOSpecWithKafka { // Note the `ZIOSpecWithKafka` trait usage here instead of `ZIOSpecDefault`
-  override def spec: Spec[TestEnvironment & Kafka, Any] =
+object ProducerSpec extends ZIOSpecWithKafka { // (1)
+  override def spec: Spec[TestEnvironment & Scope & Kafka, Any] =
     (
       suite("Producer test suite")(
         // ... tests ...
       )
-        .provideSome[Kafka](producer)             // No need here to provide a Kafka instance, it is already provided by the `ZIOSpecWithKafka` trait
-    ) @@ timeout(2.minutes) @@ sequential
+        .provideSome[Scope & Kafka](/* ...other layers... */) // (2)
+      )
 }
 ```
+
+(1) Note the `ZIOSpecWithKafka` trait usage here instead of `ZIOSpecDefault`.
+
+(2) When we need to provide additional layers with `provideSome` or `provideSomeShared`, both `Scope` and `Kafka` are
+now provided by the test framework. Therefore, we need to include both in the type parameter.
+
 More details about this `ZIOSpecWithKafka` trait [below](#ziospecwithkafka-trait).
 
-Finally, we annotate the suite with the `timeout` and `sequential` aspects.   
-The `timeout` aspect from zio-test is used to specify a timeout for the entire suite. If the suite takes more than 5 minutes to run, it will fail.    
-The `sequential` aspect from zio-test is used to specify that the tests in the suite must be run sequentially. This is necessary because Kafka is a shared resource.
-We don't want tests to interfere with each other.
+## Considerations for sharing Kafka between tests
+
+Zio tests by default all run concurrently. Tests may interfere with each other through the shared Kafka resource. The
+best way to prevent interference is by making sure each test uses a different topic. If this is not feasible, we can use
+the `sequential` aspect from zio-test to run the tests one by one.
+
+```scala
+import zio.test.TestAspect.sequential
+
+suite("test suite")(
+ // ... tests ...
+) @@ sequential
+```
 
 ## Testing a consumer
 
 ```scala mdoc:compile-only
 import zio._
-import zio.kafka.consumer.{ Consumer, Subscription }
+import zio.kafka.consumer.Subscription
 import zio.kafka.serde.Serde
-import zio.kafka.testkit.KafkaTestUtils.{ consumer, produceMany, producer }
+import zio.kafka.testkit.KafkaTestUtils
 import zio.kafka.testkit._
 import zio.test.Assertion.hasSameElements
-import zio.test.TestAspect.{ sequential, timeout }
+import zio.test.TestAspect.{timeout, withLiveClock}
 import zio.test._
 
-object ConsumerSpec extends ZIOSpecDefault with KafkaRandom {
-  override def kafkaPrefix: String = "consumer-spec"
+object ConsumerSpec extends ZIOSpecDefault {
 
   override def spec: Spec[TestEnvironment & Scope, Any] =
     (
       suite("Consumer test suite")(
         test("minimal example") {
+          // Records (as key/value pairs) to produce and consume
           val kvs: List[(String, String)] = (1 to 5).toList.map(i => (s"key-$i", s"msg-$i"))
           for {
-            topic  <- randomTopic
-            client <- randomClient
-            group  <- randomGroup
+            topic <- Random.nextUUID.map("topic-" + _.toString) // (1)
+            client <- Random.nextUUID.map("client-" + _.toString)
+            group <- Random.nextUUID.map("group-" + _.toString)
 
-            _ <- produceMany(topic, kvs) // Comes from `KafkaTestUtils`. Produces messages to the topic.
+            _ <- KafkaTestUtils.createCustomTopic(topic, partitionCount = 3) // (2)
 
-            records <- Consumer
-                         .plainStream(Subscription.Topics(Set(topic)), Serde.string, Serde.string)
-                         .take(5)
-                         .runCollect
-                         .provideSome[Kafka](
-                           // Comes from `KafkaTestUtils`
-                           consumer(clientId = client, groupId = Some(group))
-                         )
+            producer <- KafkaTestUtils.makeProducer
+            _ <- KafkaTestUtils.produceMany(producer, topic, kvs) // (3)
+
+            consumer <- KafkaTestUtils.makeConsumer(clientId = client, groupId = Some(group)) // (4)
+            records <- consumer
+              .plainStream(Subscription.topics(topic), Serde.string, Serde.string)
+              .take(5)
+              .runCollect // (5)
             consumed = records.map(r => (r.record.key, r.record.value)).toList
           } yield assert(consumed)(hasSameElements(kvs))
-        },
-        // ... more tests ...
+        }
       )
-        .provideSome[Kafka](producer)             // Here, we provide a new instance of Producer per test
-        .provideSomeShared[Scope](Kafka.embedded) // Here, we provide an instance of Kafka for the entire suite
-    ) @@ timeout(2.minutes) @@ sequential
+        .provideSomeShared[Scope](Kafka.embedded) // (6)
+      ) @@ withLiveClock @@ timeout(2.minutes)
 }
 ```
 
-This test is also a quite minimal example.    
-We produce 5 messages thanks to the `KafkaTestUtils.produceMany` method from zio-kafka-testkit, then we consume them with the `Consumer.plainStream` method from zio-kafka.     
-Finally, we use the `hasSameElements` assertion from zio-test to check that the consumed records are the same as the ones we produced.
+(1) Using random values for these parameters is important to avoid conflicts between tests as we share one Kafka
+instance between all the tests of the suite.
 
-In this example, we're reusing the `producer` and the `Kafka.embedded` layers we've seen in the [Producer test example](#testing-a-producer).    
-We're also using the `KafkaTestUtils.consumer` layer from zio-kafka-testkit to instantiate a new `Consumer`.    
+(2) Here we create a topic with 3 partitions. Note that by default Kafka auto-creates topics. Therefore, creating
+a topic explicitly is only needed when we want to control the number of partitions, or when your Kafka cluster does
+not allow auto-created topics.
 
-Finally, we use the `KafkaRandom` trait from zio-kafka-testkit and its methods to generate random values for the Consumer client ID, the Consumer group ID and the topic name.     
-More details about this `KafkaRandom` trait [later in this page](#kafkarandom-trait).    
-Using random values for these parameters is important to avoid conflicts between tests as we share one Kafka instance between all the tests of the suite.
+(3) A producer is constructed and 5 records are produced with `KafkaTestUtils.produceMany`.
+
+(4) A consumer is constructed with `KafkaTestUtils.makeConsumer`.
+
+(5) The consumer reads 5 records from the topic.
+
+Be careful with the `take` method, due to pre-fetching, the consumer may have fetched more from the topic than expected.
+
+(6) Similarly as in the producer test above, we provide the `Kafka.embedded` layer.
+
+## More consumer options
+
+If we want to share a consumer between tests, we can use the `KafkaTestUtils.consumer` layer and provide it with the
+`provideSomeShared` method (see the producer example above for more details).
 
 ## Utilities provided by the `zio-kafka-testkit` library
 
 ### `Kafka` service
 
-This trait represents a Kafka instance in your tests.    
-It is used to provide the bootstrap servers to the `Producer` and `Consumer` layers.
+This trait represents a Kafka instance in your tests. It is used to provide the bootstrap servers to the constructor
+methods in `KafkaTestUtils`.
 
 ```scala
 trait Kafka {
   def bootstrapServers: List[String]
+
   def stop(): UIO[Unit]
 }
 ```
 
 The companion object provides a few layers to provide a Kafka instance in your tests:
+
 ```scala
 object Kafka {
   /**
@@ -186,10 +235,13 @@ The in-memory Kafka instances are created using [embedded-kafka](https://github.
 
 ### `KafkaTestUtils` utilities
 
-This object provides several utilities to simplify writing your tests, like layers to boot a `Producer`, a `Consumer`, or an `AdminClient`.     
-It also provides several functions to produce records, and more.     
+This object provides several utilities to simplify writing your tests, like constructing a `Producer`, a `Consumer`,
+or an `AdminClient`.
+
+It also provides several functions to produce records, and more.
+
 Each utility function is documented in the source code. Please have a look at the source code for more details.     
-You can also look at `zio-katka` tests in the `zio-kafka-test` module to have examples on how to use these utilities.    
+You can also look at `zio-kafka` tests in the `zio-kafka-test` module to have examples on how to use these utilities.
 
 ### `ZIOSpecWithKafka` trait
 
@@ -197,27 +249,22 @@ This trait can be used if you want to share one Kafka instance between different
 This allows you to speed up your tests by booting a Kafka instance only once for all your test suites using this trait.
 
 Usage example:
+
 ```scala
 // In `src/test/scala/io/example/producer/ProducerSpec.scala`
-object ProducerSpec extends ZIOSpecWithKafka { // Note the `ZIOSpecWithKafka` trait usage here instead of `ZIOSpecDefault`
-  override def spec: Spec[TestEnvironment & Kafka, Any] =
-    (
-      suite("Producer test suite")(
-        // ... tests ...
-      )
-        .provideSome[Kafka](producer)             // No need here to provide a Kafka instance, it is already provided by the `ZIOSpecWithKafka` trait
-    ) @@ timeout(2.minutes) @@ sequential
+object ProducerSpec extends ZIOSpecWithKafka { // Note `ZIOSpecWithKafka`
+  override def spec: Spec[TestEnvironment & Scope & Kafka, Any] =
+    suite("Producer test suite")(
+      // ... tests ...
+    ) @@ timeout(2.minutes)
 }
 
 // In `src/test/scala/io/example/consumer/ConsumerSpec.scala`
-object ConsumerSpec extends ZIOSpecWithKafka { // Note the `ZIOSpecWithKafka` trait usage here instead of `ZIOSpecDefault`
-  override def spec: Spec[TestEnvironment & Kafka, Any] =
-    (
-      suite("Consumer test suite")(
-        // ... tests ...
-      )
-        .provideSome[Kafka](producer)             // No need here to provide a Kafka instance, it is already provided by the `ZIOSpecWithKafka` trait
-    ) @@ timeout(2.minutes) @@ sequential
+object ConsumerSpec extends ZIOSpecWithKafka { // Note `ZIOSpecWithKafka`
+  override def spec: Spec[TestEnvironment & Scope & Kafka, Any] =
+    suite("Consumer test suite")(
+      // ... tests ...
+    ) @@ timeout(2.minutes)
 }
 ```
 
@@ -228,31 +275,28 @@ See related zio-test documentation: https://zio.dev/reference/test/sharing-layer
 
 The `KafkaRandom` trait provides a few methods to generate random values.
 To use it, you need to mix it in your test suite, like this:
+
 ```scala mdoc:compile-only
-import zio.kafka.consumer.Consumer
-import zio.kafka.testkit.KafkaRandom
 import zio.kafka.testkit.Kafka
-import zio.kafka.testkit.KafkaTestUtils.consumer
-import zio.test.{ assertTrue, Spec, TestEnvironment, ZIOSpecDefault }
+import zio.kafka.testkit.KafkaRandom
+import zio.kafka.testkit.KafkaTestUtils
+import zio.test._
 import zio._
 
 object MyServiceSpec extends ZIOSpecDefault with KafkaRandom {
   // Required when mixing in the `KafkaRandom` trait
   // The best is to use a different prefix for each test suite
-  override def kafkaPrefix: String = "my-service" 
+  override def kafkaPrefix: String = "my-service"
 
   override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("MyService")(
       test("minimal example") {
         for {
-          group    <- randomGroup // Comes from `KafkaRandom`
+          topic    <- randomTopic  // Comes from `KafkaRandom`
           clientId <- randomClient // Comes from `KafkaRandom`
-          metrics  <- Consumer.metrics
-                        .provideSome[Kafka](
-                          // Comes from `KafkaTestUtils`
-                          consumer(clientId = clientId, groupId = Some(group))
-                        )
-        } yield assertTrue(metrics.nonEmpty)
+          groupId  <- randomGroup  // Comes from `KafkaRandom`
+          // ... 
+        } yield assertCompletes
       }
     ).provideSomeShared[Scope](Kafka.embedded)
 }

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaProducerBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaProducerBenchmark.scala
@@ -1,14 +1,14 @@
 package zio.kafka.bench
 
-import io.github.embeddedkafka.EmbeddedKafka
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.openjdk.jmh.annotations._
+import zio.kafka.admin.AdminClient.NewTopic
 import zio.kafka.producer.Producer
 import zio.kafka.serde.Serde
 import zio.kafka.testkit.Kafka
-import zio.kafka.testkit.KafkaTestUtils.producer
+import zio.kafka.testkit.KafkaTestUtils
 import zio.stream.ZStream
-import zio.{ Chunk, ZIO, ZLayer }
+import zio.{ Scope => _, _ }
 
 import java.util.concurrent.TimeUnit
 
@@ -20,30 +20,40 @@ class ZioKafkaProducerBenchmark extends ProducerZioBenchmark[Kafka with Producer
   })
 
   override protected def bootstrap: ZLayer[Any, Nothing, Kafka with Producer] =
-    ZLayer.make[Kafka with Producer](Kafka.embedded, producer).orDie
+    ZLayer.make[Kafka with Producer](Kafka.embedded, KafkaTestUtils.producer).orDie
 
-  override def initialize: ZIO[Kafka with Producer, Throwable, Any] = for {
-    _ <- ZIO.succeed(EmbeddedKafka.deleteTopics(List(topic1))).ignore
-    _ <- ZIO.succeed(EmbeddedKafka.createCustomTopic(topic1, partitions = partitionCount))
-  } yield ()
+  override def initialize: ZIO[Kafka & Producer, Throwable, Any] =
+    ZIO.scoped {
+      for {
+        adminClient <- KafkaTestUtils.makeAdminClient
+        _           <- adminClient.deleteTopic(topic1).ignore
+        _           <- adminClient.createTopic(NewTopic(topic1, partitionCount, replicationFactor = 1))
+      } yield ()
+    }
 
   @Benchmark
   @BenchmarkMode(Array(Mode.AverageTime))
   def produceChunkSeq(): Any = runZIO {
     // Produce 30 chunks sequentially
-    Producer.produceChunk(records, Serde.string, Serde.string).repeatN(29)
+    for {
+      producer <- ZIO.service[Producer]
+      _        <- producer.produceChunk(records, Serde.string, Serde.string).repeatN(29)
+    } yield ()
   }
 
   @Benchmark
   @BenchmarkMode(Array(Mode.AverageTime))
   def produceChunkPar(): Any = runZIO {
     // Produce 30 chunks of which 4 run in parallel
-    ZStream
-      .range(0, 30, 1)
-      .mapZIOParUnordered(4) { _ =>
-        Producer.produceChunk(records, Serde.string, Serde.string)
-      }
-      .runDrain
+    for {
+      producer <- ZIO.service[Producer]
+      _ <- ZStream
+             .range(0, 30, 1)
+             .mapZIOParUnordered(4) { _ =>
+               producer.produceChunk(records, Serde.string, Serde.string)
+             }
+             .runDrain
+    } yield ()
   }
 
   @Benchmark
@@ -51,7 +61,10 @@ class ZioKafkaProducerBenchmark extends ProducerZioBenchmark[Kafka with Producer
   @OutputTimeUnit(TimeUnit.SECONDS)
   def produceSingleRecordSeq(): Any = runZIO {
     // Produce 100 records sequentially
-    Producer.produce(topic1, "key", "value", Serde.string, Serde.string).repeatN(99)
+    for {
+      producer <- ZIO.service[Producer]
+      _        <- producer.produce(topic1, "key", "value", Serde.string, Serde.string).repeatN(99)
+    } yield ()
   }
 
   @Benchmark
@@ -59,11 +72,14 @@ class ZioKafkaProducerBenchmark extends ProducerZioBenchmark[Kafka with Producer
   @OutputTimeUnit(TimeUnit.SECONDS)
   def produceSingleRecordPar(): Any = runZIO {
     // Produce 100 records of which 4 run in parallel
-    ZStream
-      .range(0, 100, 1)
-      .mapZIOParUnordered(4) { _ =>
-        Producer.produce(topic1, "key", "value", Serde.string, Serde.string)
-      }
-      .runDrain
+    for {
+      producer <- ZIO.service[Producer]
+      _ <- ZStream
+             .range(0, 100, 1)
+             .mapZIOParUnordered(4) { _ =>
+               producer.produce(topic1, "key", "value", Serde.string, Serde.string)
+             }
+             .runDrain
+    } yield ()
   }
 }

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ComparisonBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ComparisonBenchmark.scala
@@ -1,17 +1,14 @@
 package zio.kafka.bench.comparison
 
-import io.github.embeddedkafka.EmbeddedKafka
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
-import zio.kafka.admin.AdminClient.TopicPartition
+import zio.kafka.admin.AdminClient.{ NewTopic, TopicPartition }
 import zio.kafka.bench.ConsumerZioBenchmark
 import zio.kafka.bench.ZioBenchmark.randomThing
 import zio.kafka.bench.comparison.ComparisonBenchmark._
 import zio.kafka.consumer.{ Consumer, ConsumerSettings }
-import zio.kafka.producer.Producer
-import zio.kafka.testkit.Kafka
-import zio.kafka.testkit.KafkaTestUtils.{ consumerSettings, minimalConsumer, produceMany, producer }
-import zio.{ ULayer, ZIO, ZLayer }
+import zio.kafka.testkit.{ Kafka, KafkaTestUtils }
+import zio.{ Scope => _, _ }
 
 import scala.jdk.CollectionConverters._
 
@@ -37,38 +34,43 @@ trait ComparisonBenchmark extends ConsumerZioBenchmark[Env] {
 
   protected def settings: ZLayer[Kafka, Nothing, ConsumerSettings] =
     ZLayer.fromZIO(
-      consumerSettings(
-        clientId = randomThing("client"),
-        groupId = Some(randomThing("client")),
-        // A more production worthy value:
-        `max.poll.records` = 1000
-      ).map(_.withPartitionPreFetchBufferLimit(8192))
+      KafkaTestUtils
+        .consumerSettings(
+          clientId = randomThing("client"),
+          groupId = Some(randomThing("client")),
+          // A more production worthy value:
+          `max.poll.records` = 1000
+        )
+        .map(_.withPartitionPreFetchBufferLimit(8192))
     )
 
   override final def bootstrap: ULayer[Env] =
     ZLayer
       .make[Env](
         Kafka.embedded,
-        producer,
         settings,
         javaKafkaConsumer,
-        minimalConsumer()
+        KafkaTestUtils.minimalConsumer()
       )
       .orDie
 
   override final def initialize: ZIO[Env, Throwable, Any] =
-    for {
-      _ <- ZIO.succeed(EmbeddedKafka.deleteTopics(List(topic1))).ignore
-      _ <- ZIO.succeed(EmbeddedKafka.createCustomTopic(topic1, partitions = partitionCount))
-      _ <- produceMany(topic1, kvs)
-    } yield ()
+    ZIO.scoped {
+      for {
+        adminClient <- KafkaTestUtils.makeAdminClient
+        _           <- adminClient.deleteTopic(topic1).ignore
+        _           <- adminClient.createTopic(NewTopic(topic1, partitionCount, replicationFactor = 1))
+        producer    <- KafkaTestUtils.makeProducer
+        _           <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+      } yield ()
+    }
 
 }
 
 object ComparisonBenchmark {
   type LowLevelKafka = KafkaConsumer[Array[Byte], Array[Byte]]
 
-  type Env = Kafka with Consumer with Producer with LowLevelKafka with ConsumerSettings
+  type Env = Kafka with Consumer with LowLevelKafka with ConsumerSettings
 
   def zAssert(p: => Boolean, message: => String): ZIO[Any, AssertionError, Unit] =
     ZIO.when(!p)(ZIO.fail(new AssertionError(s"Assertion failed: $message"))).unit

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ZioKafkaBenchmarks.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ZioKafkaBenchmarks.scala
@@ -1,6 +1,7 @@
 package zio.kafka.bench.comparison
 
 import org.openjdk.jmh.annotations._
+import zio.ZIO
 import zio.kafka.bench.comparison.ComparisonBenchmark.zAssert
 import zio.kafka.consumer.{ Consumer, Subscription }
 import zio.kafka.serde.Serde
@@ -15,26 +16,29 @@ class ZioKafkaBenchmarks extends ComparisonBenchmark {
   @BenchmarkMode(Array(Mode.AverageTime))
   def zioKafka(): Any =
     runZIO {
-      Consumer
-        .plainStream(Subscription.topics(topic1), Serde.byteArray, Serde.byteArray)
-        .take(recordCount.toLong)
-        .runCount
-        .flatMap(r => zAssert(r == recordCount, s"Consumed $r records instead of $recordCount"))
+      ZIO.serviceWithZIO[Consumer] {
+        _.plainStream(Subscription.topics(topic1), Serde.byteArray, Serde.byteArray)
+          .take(recordCount.toLong)
+          .runCount
+          .flatMap(r => zAssert(r == recordCount, s"Consumed $r records instead of $recordCount"))
+      }
     }
 
   @Benchmark
   @BenchmarkMode(Array(Mode.AverageTime))
   def manualZioKafka(): Any =
     runZIO {
-      Consumer
-        .plainStream(
-          Subscription.manual(topicPartitions.map(tp => tp.name -> tp.partition): _*),
-          Serde.byteArray,
-          Serde.byteArray
-        )
-        .take(recordCount.toLong)
-        .runCount
-        .flatMap(r => zAssert(r == recordCount, s"Consumed $r records instead of $recordCount"))
+      ZIO.serviceWithZIO[Consumer] { consumer =>
+        consumer
+          .plainStream(
+            Subscription.manual(topicPartitions.map(tp => tp.name -> tp.partition): _*),
+            Serde.byteArray,
+            Serde.byteArray
+          )
+          .take(recordCount.toLong)
+          .runCount
+          .flatMap(r => zAssert(r == recordCount, s"Consumed $r records instead of $recordCount"))
+      }
     }
 
 }

--- a/zio-kafka-example/src/main/scala/zio/kafka/example/Main.scala
+++ b/zio-kafka-example/src/main/scala/zio/kafka/example/Main.scala
@@ -51,8 +51,9 @@ object Main extends ZIOAppDefault {
 
   private val runConsumerStream: ZIO[Consumer, Throwable, Unit] =
     for {
-      _ <- ZIO.logInfo("Consuming messages...")
-      consumed <- Consumer
+      _        <- ZIO.logInfo("Consuming messages...")
+      consumer <- ZIO.service[Consumer]
+      consumed <- consumer
                     .plainStream(Subscription.topics(topic), Serde.string, Serde.string)
                     .take(1000)
                     .tap(r => ZIO.logInfo(s"Consumed record $r"))

--- a/zio-kafka-example/src/test/scala/zio/kafka/example/MyServiceSpec.scala
+++ b/zio-kafka-example/src/test/scala/zio/kafka/example/MyServiceSpec.scala
@@ -1,10 +1,10 @@
 package zio.kafka.example
 
-import zio.kafka.consumer.Consumer
-import zio.kafka.testkit.KafkaTestUtils.consumer
+import zio.kafka.testkit.KafkaTestUtils
 import zio.kafka.testkit.{ Kafka, KafkaRandom }
 import zio.test.{ assertTrue, Spec, TestEnvironment, ZIOSpecDefault }
-import zio.{ &, Scope }
+import zio._
+import zio.test.TestAspect.withLiveClock
 
 /**
  * Used to write documentation
@@ -18,11 +18,11 @@ object MyServiceSpec extends ZIOSpecDefault with KafkaRandom {
         for {
           group    <- randomGroup
           clientId <- randomClient
-          metrics <- Consumer.metrics
-                       .provideSome[Kafka](
-                         consumer(clientId = clientId, groupId = Some(group)) // Comes from KafkaTestUtils
-                       )
+          consumer <- KafkaTestUtils.makeConsumer(clientId = clientId, groupId = Some(group))
+          metrics  <- consumer.metrics
+
         } yield assertTrue(metrics.nonEmpty)
       }
-    ).provideSomeShared[Scope](Kafka.embedded)
+    )
+      .provideSomeShared[Scope](Kafka.embedded) @@ withLiveClock
 }

--- a/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -7,9 +7,8 @@ import zio._
 import zio.kafka.admin.AdminClient.NewTopic
 import zio.kafka.consumer._
 import zio.kafka.producer.TransactionalProducer.{ TransactionLeaked, UserInitiatedAbort }
-import zio.kafka.producer.{ ByteRecord, Producer, Transaction, TransactionalProducer }
+import zio.kafka.producer.{ ByteRecord, Transaction }
 import zio.kafka.serde.Serde
-import zio.kafka.testkit.KafkaTestUtils._
 import zio.kafka.testkit._
 import zio.stream.Take
 import zio.test.Assertion._
@@ -27,7 +26,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
   private def withConsumerInt(
     subscription: Subscription,
     settings: ConsumerSettings
-  ): ZIO[Any with Scope, Throwable, Dequeue[Take[Throwable, CommittableRecord[String, Int]]]] =
+  ): ZIO[Scope, Throwable, Dequeue[Take[Throwable, CommittableRecord[String, Int]]]] =
     Consumer.make(settings).flatMap { c =>
       c.plainStream(subscription, Serde.string, Serde.int).toQueue()
     }
@@ -36,17 +35,19 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
     suite("::produce(record: ProducerRecord[Array[Byte], Array[Byte]])")(
       test("produces messages") {
         for {
-          topic <- randomTopic
+          consumer <- KafkaTestUtils.makeConsumer(clientId = "producer-spec-consumer", groupId = Some("group-0"))
+          producer <- KafkaTestUtils.makeProducer
+          topic    <- randomTopic
           firstMessage  = "toto"
           secondMessage = "tata"
           consume = (n: Int) =>
-                      Consumer
+                      consumer
                         .plainStream(Subscription.topics(topic), Serde.byteArray, Serde.byteArray)
                         .take(n.toLong)
                         .runCollect
-          _ <- Producer.produce(new ProducerRecord(topic, firstMessage.getBytes(StandardCharsets.UTF_8)): ByteRecord)
+          _ <- producer.produce(new ProducerRecord(topic, firstMessage.getBytes(StandardCharsets.UTF_8)): ByteRecord)
           first <- consume(1)
-          _ <- Producer.produce(new ProducerRecord(topic, secondMessage.getBytes(StandardCharsets.UTF_8)): ByteRecord)
+          _ <- producer.produce(new ProducerRecord(topic, secondMessage.getBytes(StandardCharsets.UTF_8)): ByteRecord)
           second <- consume(2)
         } yield assertTrue(
           first.size == 1,
@@ -62,19 +63,21 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
     suite("::produceAsync(record: ProducerRecord[Array[Byte], Array[Byte]])")(
       test("produces messages") {
         for {
-          topic <- randomTopic
+          consumer <- KafkaTestUtils.makeConsumer(clientId = "producer-spec-consumer", groupId = Some("group-0"))
+          producer <- KafkaTestUtils.makeProducer
+          topic    <- randomTopic
           firstMessage  = "toto"
           secondMessage = "tata"
           consume = (n: Int) =>
-                      Consumer
+                      consumer
                         .plainStream(Subscription.topics(topic), Serde.byteArray, Serde.byteArray)
                         .take(n.toLong)
                         .runCollect
-          _ <- Producer
+          _ <- producer
                  .produceAsync(new ProducerRecord(topic, firstMessage.getBytes(StandardCharsets.UTF_8)): ByteRecord)
                  .flatten
           first <- consume(1)
-          _ <- Producer
+          _ <- producer
                  .produceAsync(new ProducerRecord(topic, secondMessage.getBytes(StandardCharsets.UTF_8)): ByteRecord)
                  .flatten
           second <- consume(2)
@@ -92,19 +95,21 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
     suite("::produceChunkAsync(records: Chunk[ProducerRecord[Array[Byte], Array[Byte]]])")(
       test("produces messages") {
         for {
-          topic <- randomTopic
+          consumer <- KafkaTestUtils.makeConsumer(clientId = "producer-spec-consumer", groupId = Some("group-0"))
+          producer <- KafkaTestUtils.makeProducer
+          topic    <- randomTopic
           firstMessage  = "toto"
           secondMessage = "tata"
           consume = (n: Int) =>
-                      Consumer
+                      consumer
                         .plainStream(Subscription.topics(topic), Serde.byteArray, Serde.byteArray)
                         .take(n.toLong)
                         .runCollect
-          _ <- Producer
+          _ <- producer
                  .produceChunkAsync(Chunk(new ProducerRecord(topic, firstMessage.getBytes(StandardCharsets.UTF_8))))
                  .flatten
           first <- consume(1)
-          _ <- Producer
+          _ <- producer
                  .produceChunkAsync(
                    Chunk(
                      new ProducerRecord(topic, firstMessage.getBytes(StandardCharsets.UTF_8)),
@@ -128,18 +133,20 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
     suite("::produceChunk(records: Chunk[ProducerRecord[Array[Byte], Array[Byte]]])")(
       test("produces messages") {
         for {
-          topic <- randomTopic
+          consumer <- KafkaTestUtils.makeConsumer(clientId = "producer-spec-consumer", groupId = Some("group-0"))
+          producer <- KafkaTestUtils.makeProducer
+          topic    <- randomTopic
           firstMessage  = "toto"
           secondMessage = "tata"
           consume = (n: Int) =>
-                      Consumer
+                      consumer
                         .plainStream(Subscription.topics(topic), Serde.byteArray, Serde.byteArray)
                         .take(n.toLong)
                         .runCollect
-          _ <- Producer
+          _ <- producer
                  .produceChunk(Chunk(new ProducerRecord(topic, firstMessage.getBytes(StandardCharsets.UTF_8))))
           first <- consume(1)
-          _ <- Producer
+          _ <- producer
                  .produceChunk(
                    Chunk(
                      new ProducerRecord(topic, firstMessage.getBytes(StandardCharsets.UTF_8)),
@@ -162,8 +169,9 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
     suite("producer test suite")(
       test("one record") {
         for {
-          topic <- randomTopic
-          _     <- Producer.produce(new ProducerRecord(topic, "boo", "baa"), Serde.string, Serde.string)
+          producer <- KafkaTestUtils.makeProducer
+          topic    <- randomTopic
+          _        <- producer.produce(new ProducerRecord(topic, "boo", "baa"), Serde.string, Serde.string)
         } yield assertCompletes
       },
       test("a non-empty chunk of records") {
@@ -187,8 +195,9 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                      List(new ProducerRecord(topic1, key1, value1), new ProducerRecord(topic2, key2, value2))
                    )
 
-          outcome  <- Producer.produceChunk(chunks, Serde.string, Serde.string)
-          settings <- consumerSettings(client, Some(group))
+          producer <- KafkaTestUtils.makeProducer
+          outcome  <- producer.produceChunk(chunks, Serde.string, Serde.string)
+          settings <- KafkaTestUtils.consumerSettings(client, Some(group))
           record1 <- ZIO.scoped {
                        withConsumer(Topics(Set(topic1)), settings).flatMap { consumer =>
                          for {
@@ -206,9 +215,11 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                          } yield record
                        }
                      }
-        } yield assertTrue(outcome.length == 2) &&
-          assertTrue(record1.nonEmpty) &&
-          assertTrue(record2.nonEmpty)
+        } yield assertTrue(
+          outcome.length == 2,
+          record1.nonEmpty,
+          record2.nonEmpty
+        )
       },
       test("a non-empty chunk of records with partial failure") {
         import Subscription._
@@ -234,14 +245,15 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         for {
           compactedTopic <- randomTopic
           standardTopic  <- randomTopic
-          _ <- withAdmin(
-                 _.createTopic(NewTopic(compactedTopic, 1, 1, Map(TopicConfig.CLEANUP_POLICY_CONFIG -> "compact")))
-               )
+          adminClient    <- KafkaTestUtils.makeAdminClient
+          _ <- adminClient
+                 .createTopic(NewTopic(compactedTopic, 1, 1, Map(TopicConfig.CLEANUP_POLICY_CONFIG -> "compact")))
           group  <- randomGroup
           client <- randomClient
           chunk = makeChunk(standardTopic, compactedTopic)
-          outcome  <- Producer.produceChunkAsyncWithFailures(chunk).flatten
-          settings <- consumerSettings(client, Some(group))
+          producer <- KafkaTestUtils.makeProducer
+          outcome  <- producer.produceChunkAsyncWithFailures(chunk).flatten
+          settings <- KafkaTestUtils.consumerSettings(client, Some(group))
           recordsConsumed <- ZIO.scoped {
                                withConsumer(Topics(Set(standardTopic)), settings).flatMap { consumer =>
                                  consumer.take.flatMap(_.exit).mapError(_.getOrElse(new NoSuchElementException))
@@ -258,19 +270,22 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
       test("an empty chunk of records") {
         val chunks = Chunk.fromIterable(List.empty)
         for {
-          outcome <- Producer.produceChunk(chunks, Serde.string, Serde.string)
+          producer <- KafkaTestUtils.makeProducer
+          outcome  <- producer.produceChunk(chunks, Serde.string, Serde.string)
         } yield assertTrue(outcome.isEmpty)
       },
       test("export metrics") {
         for {
-          metrics <- Producer.metrics
+          producer <- KafkaTestUtils.makeProducer
+          metrics  <- producer.metrics
         } yield assertTrue(metrics.nonEmpty)
       },
       test("partitionsFor") {
         for {
-          topic <- randomTopic
-          info  <- Producer.partitionsFor(topic).debug
-        } yield assertTrue(info.headOption.map(_.topic()) == Some(topic))
+          producer <- KafkaTestUtils.makeProducer
+          topic    <- randomTopic
+          info     <- producer.partitionsFor(topic).debug
+        } yield assertTrue(info.headOption.map(_.topic()).contains(topic))
       },
       suite("transactions")(
         test("a simple transaction") {
@@ -283,13 +298,17 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             initialAliceAccount = new ProducerRecord(topic, "alice", 20)
             initialBobAccount   = new ProducerRecord(topic, "bob", 0)
 
+            transactionalProducer <- KafkaTestUtils.makeTransactionalProducer(UUID.randomUUID().toString)
+
             _ <- ZIO.scoped {
-                   TransactionalProducer.createTransaction.flatMap { t =>
-                     t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
-                       t.produce(initialAliceAccount, Serde.string, Serde.int, None)
-                   }
+                   for {
+                     tx <- transactionalProducer.createTransaction
+                     _  <- tx.produce(initialBobAccount, Serde.string, Serde.int, None)
+                     _  <- tx.produce(initialAliceAccount, Serde.string, Serde.int, None)
+                   } yield ()
                  }
-            settings <- transactionalConsumerSettings(group, client)
+
+            settings <- KafkaTestUtils.transactionalConsumerSettings(group, client)
             recordChunk <- ZIO.scoped {
                              withConsumerInt(Topics(Set(topic)), settings).flatMap { consumer =>
                                for {
@@ -314,22 +333,26 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             aliceGives20        = new ProducerRecord(topic, "alice", 0)
             bobReceives20       = new ProducerRecord(topic, "bob", 20)
 
+            transactionalProducer <- KafkaTestUtils.makeTransactionalProducer(UUID.randomUUID().toString)
+
             _ <- ZIO.scoped {
-                   TransactionalProducer.createTransaction.flatMap { t =>
-                     t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
-                       t.produce(initialAliceAccount, Serde.string, Serde.int, None)
-                   }
+                   for {
+                     tx <- transactionalProducer.createTransaction
+                     _  <- tx.produce(initialBobAccount, Serde.string, Serde.int, None)
+                     _  <- tx.produce(initialAliceAccount, Serde.string, Serde.int, None)
+                   } yield ()
                  }
             _ <- ZIO.scoped {
-                   TransactionalProducer.createTransaction.flatMap { t =>
-                     t.produce(aliceGives20, Serde.string, Serde.int, None) *>
-                       t.produce(bobReceives20, Serde.string, Serde.int, None) *>
-                       t.abort
-                   }
+                   (for {
+                     tx <- transactionalProducer.createTransaction
+                     _  <- tx.produce(aliceGives20, Serde.string, Serde.int, None)
+                     _  <- tx.produce(bobReceives20, Serde.string, Serde.int, None)
+                   } yield tx).flatMap(_.abort)
                  }.catchSome { case UserInitiatedAbort =>
                    ZIO.unit // silences the abort
                  }
-            settings <- transactionalConsumerSettings(group, client)
+
+            settings <- KafkaTestUtils.transactionalConsumerSettings(group, client)
             recordChunk <- ZIO.scoped {
                              withConsumerInt(Topics(Set(topic)), settings).flatMap { consumer =>
                                for {
@@ -352,19 +375,23 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             initialAliceAccount = new ProducerRecord(topic, "alice", 20)
             initialBobAccount   = new ProducerRecord(topic, "bob", 0)
 
+            transactionalProducer <- KafkaTestUtils.makeTransactionalProducer(UUID.randomUUID().toString)
+
             transaction1 = ZIO.scoped {
-                             TransactionalProducer.createTransaction.flatMap { t =>
-                               t.produce(initialAliceAccount, Serde.string, Serde.int, None)
-                             }
+                             for {
+                               tx <- transactionalProducer.createTransaction
+                               _  <- tx.produce(initialAliceAccount, Serde.string, Serde.int, None)
+                             } yield ()
                            }
             transaction2 = ZIO.scoped {
-                             TransactionalProducer.createTransaction.flatMap { t =>
-                               t.produce(initialBobAccount, Serde.string, Serde.int, None)
-                             }
+                             for {
+                               tx <- transactionalProducer.createTransaction
+                               _  <- tx.produce(initialBobAccount, Serde.string, Serde.int, None)
+                             } yield ()
                            }
+            _ <- transaction1 <&> transaction2
 
-            _        <- transaction1 <&> transaction2
-            settings <- transactionalConsumerSettings(group, client)
+            settings <- KafkaTestUtils.transactionalConsumerSettings(group, client)
             recordChunk <- ZIO.scoped {
                              withConsumerInt(Topics(Set(topic)), settings).flatMap { consumer =>
                                for {
@@ -381,8 +408,10 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             topic <- randomTopic
             initialBobAccount = new ProducerRecord(topic, "bob", 0)
 
+            transactionalProducer <- KafkaTestUtils.makeTransactionalProducer(UUID.randomUUID().toString)
+
             result <- ZIO.scoped {
-                        TransactionalProducer.createTransaction.flatMap { t =>
+                        transactionalProducer.createTransaction.flatMap { t =>
                           t.produce(
                             initialBobAccount,
                             Serde.string,
@@ -406,31 +435,33 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             nonTransactional    = new ProducerRecord(topic, "no one", -1)
             aliceGives20        = new ProducerRecord(topic, "alice", 0)
 
+            transactionalProducer <- KafkaTestUtils.makeTransactionalProducer(UUID.randomUUID().toString)
+
             _ <- ZIO.scoped {
-                   TransactionalProducer.createTransaction.flatMap { t =>
-                     t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
-                       t.produce(initialAliceAccount, Serde.string, Serde.int, None)
-                   }
+                   for {
+                     tx <- transactionalProducer.createTransaction
+                     _  <- tx.produce(initialBobAccount, Serde.string, Serde.int, None)
+                     _  <- tx.produce(initialAliceAccount, Serde.string, Serde.int, None)
+                   } yield ()
                  }
             assertion <- ZIO.scoped {
-                           TransactionalProducer.createTransaction.flatMap { t =>
-                             for {
-                               _        <- t.produce(aliceGives20, Serde.string, Serde.int, None)
-                               _        <- Producer.produce(nonTransactional, Serde.string, Serde.int)
-                               settings <- consumerSettings(client, Some(group))
-                               recordChunk <- ZIO.scoped {
-                                                withConsumerInt(Topics(Set(topic)), settings).flatMap { consumer =>
-                                                  for {
-                                                    messages <- consumer.take
-                                                                  .flatMap(_.exit)
-                                                                  .mapError(_.getOrElse(new NoSuchElementException))
-                                                    record = messages.filter(rec => rec.record.key == "no one")
-                                                  } yield record
-
-                                                }
+                           for {
+                             tx       <- transactionalProducer.createTransaction
+                             _        <- tx.produce(aliceGives20, Serde.string, Serde.int, None)
+                             producer <- KafkaTestUtils.makeProducer
+                             _        <- producer.produce(nonTransactional, Serde.string, Serde.int)
+                             settings <- KafkaTestUtils.consumerSettings(client, Some(group))
+                             recordChunk <- ZIO.scoped {
+                                              withConsumerInt(Topics(Set(topic)), settings).flatMap { consumer =>
+                                                for {
+                                                  messages <- consumer.take
+                                                                .flatMap(_.exit)
+                                                                .mapError(_.getOrElse(new NoSuchElementException))
+                                                  record = messages.filter(rec => rec.record.key == "no one")
+                                                } yield record
                                               }
-                             } yield assertTrue(recordChunk.nonEmpty)
-                           }
+                                            }
+                           } yield assertTrue(recordChunk.nonEmpty)
                          }
           } yield assertion
         },
@@ -447,30 +478,33 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             nonTransactional    = new ProducerRecord(topic, "no one", -1)
             aliceGives20        = new ProducerRecord(topic, "alice", 0)
 
+            transactionalProducer <- KafkaTestUtils.makeTransactionalProducer(UUID.randomUUID().toString)
+
             _ <- ZIO.scoped {
-                   TransactionalProducer.createTransaction.flatMap { t =>
-                     t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
-                       t.produce(initialAliceAccount, Serde.string, Serde.int, None)
-                   }
+                   for {
+                     tx <- transactionalProducer.createTransaction
+                     _  <- tx.produce(initialBobAccount, Serde.string, Serde.int, None)
+                     _  <- tx.produce(initialAliceAccount, Serde.string, Serde.int, None)
+                   } yield ()
                  }
             assertion <- ZIO.scoped {
-                           TransactionalProducer.createTransaction.flatMap { t =>
-                             for {
-                               _        <- t.produce(aliceGives20, Serde.string, Serde.int, None)
-                               _        <- Producer.produce(nonTransactional, Serde.string, Serde.int)
-                               settings <- transactionalConsumerSettings(group, client)
-                               recordChunk <- ZIO.scoped {
-                                                withConsumerInt(Topics(Set(topic)), settings).flatMap { consumer =>
-                                                  for {
-                                                    messages <- consumer.take
-                                                                  .flatMap(_.exit)
-                                                                  .mapError(_.getOrElse(new NoSuchElementException))
-                                                    record = messages.filter(rec => rec.record.key == "no one")
-                                                  } yield record
-                                                }
+                           for {
+                             tx       <- transactionalProducer.createTransaction
+                             _        <- tx.produce(aliceGives20, Serde.string, Serde.int, None)
+                             producer <- KafkaTestUtils.makeProducer
+                             _        <- producer.produce(nonTransactional, Serde.string, Serde.int)
+                             settings <- KafkaTestUtils.transactionalConsumerSettings(group, client)
+                             recordChunk <- ZIO.scoped {
+                                              withConsumerInt(Topics(Set(topic)), settings).flatMap { consumer =>
+                                                for {
+                                                  messages <- consumer.take
+                                                                .flatMap(_.exit)
+                                                                .mapError(_.getOrElse(new NoSuchElementException))
+                                                  record = messages.filter(rec => rec.record.key == "no one")
+                                                } yield record
                                               }
-                             } yield assertTrue(recordChunk.isEmpty)
-                           }
+                                            }
+                           } yield assertTrue(recordChunk.isEmpty)
                          }
           } yield assertion
         },
@@ -488,23 +522,28 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             nonTransactional    = new ProducerRecord(topic, "no one", -1)
             bobReceives20       = new ProducerRecord(topic, "bob", 20)
 
+            transactionalProducer <- KafkaTestUtils.makeTransactionalProducer(UUID.randomUUID().toString)
+            producer              <- KafkaTestUtils.makeProducer
+
             _ <- ZIO.scoped {
-                   TransactionalProducer.createTransaction.flatMap { t =>
-                     t.produce(initialBobAccount, Serde.string, Serde.int, None) *>
-                       t.produce(initialAliceAccount, Serde.string, Serde.int, None)
-                   }
+                   for {
+                     tx <- transactionalProducer.createTransaction
+                     _  <- tx.produce(initialBobAccount, Serde.string, Serde.int, None)
+                     _  <- tx.produce(initialAliceAccount, Serde.string, Serde.int, None)
+                   } yield ()
                  }
             _ <- ZIO.scoped {
-                   TransactionalProducer.createTransaction.flatMap { t =>
-                     t.produce(aliceGives20, Serde.string, Serde.int, None) *>
-                       Producer.produce(nonTransactional, Serde.string, Serde.int) *>
-                       t.produce(bobReceives20, Serde.string, Serde.int, None) *>
-                       t.abort
-                   }
+                   (for {
+                     tx <- transactionalProducer.createTransaction
+                     _  <- tx.produce(aliceGives20, Serde.string, Serde.int, None)
+                     _  <- producer.produce(nonTransactional, Serde.string, Serde.int)
+                     _  <- tx.produce(bobReceives20, Serde.string, Serde.int, None)
+                   } yield tx).flatMap(_.abort)
                  }.catchSome { case UserInitiatedAbort =>
                    ZIO.unit // silences the abort
                  }
-            settings <- transactionalConsumerSettings(group, client)
+
+            settings <- KafkaTestUtils.transactionalConsumerSettings(group, client)
             recordChunk <- ZIO.scoped {
                              withConsumerInt(Topics(Set(topic)), settings).flatMap { consumer =>
                                for {
@@ -528,8 +567,12 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             initialAliceAccount  = new ProducerRecord(topic, "alice", 20)
             aliceAccountFeesPaid = new ProducerRecord(topic, "alice", 0)
 
-            _        <- Producer.produce(initialAliceAccount, Serde.string, Serde.int)
-            settings <- transactionalConsumerSettings(group, client)
+            producer <- KafkaTestUtils.makeProducer
+            _        <- producer.produce(initialAliceAccount, Serde.string, Serde.int)
+
+            transactionalProducer <- KafkaTestUtils.makeTransactionalProducer(UUID.randomUUID().toString)
+
+            settings <- KafkaTestUtils.transactionalConsumerSettings(group, client)
             committedOffset <-
               ZIO.scoped {
                 Consumer.make(settings).flatMap { c =>
@@ -546,14 +589,15 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                         for {
                           aliceHadMoneyCommittableMessage <- readAliceAccount
                           _ <- ZIO.scoped {
-                                 TransactionalProducer.createTransaction.flatMap { t =>
-                                   t.produce(
-                                     aliceAccountFeesPaid,
-                                     Serde.string,
-                                     Serde.int,
-                                     Some(aliceHadMoneyCommittableMessage.offset)
-                                   )
-                                 }
+                                 for {
+                                   tx <- transactionalProducer.createTransaction
+                                   _ <- tx.produce(
+                                          aliceAccountFeesPaid,
+                                          Serde.string,
+                                          Serde.int,
+                                          Some(aliceHadMoneyCommittableMessage.offset)
+                                        )
+                                 } yield ()
                                }
                           aliceTopicPartition =
                             new TopicPartition(topic, aliceHadMoneyCommittableMessage.partition)
@@ -577,8 +621,12 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             initialAliceAccount  = new ProducerRecord(topic, "alice", 20)
             aliceAccountFeesPaid = new ProducerRecord(topic, "alice", 0)
 
-            _        <- Producer.produce(initialAliceAccount, Serde.string, Serde.int)
-            settings <- transactionalConsumerSettings(group, client)
+            producer <- KafkaTestUtils.makeProducer
+            _        <- producer.produce(initialAliceAccount, Serde.string, Serde.int)
+
+            transactionalProducer <- KafkaTestUtils.makeTransactionalProducer(UUID.randomUUID().toString)
+
+            settings <- KafkaTestUtils.transactionalConsumerSettings(group, client)
             committedOffset <- ZIO.scoped {
                                  Consumer.make(settings).flatMap { c =>
                                    c
@@ -593,14 +641,14 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                                        for {
                                          aliceHadMoneyCommittableMessage <- readAliceAccount
                                          _ <- ZIO.scoped {
-                                                TransactionalProducer.createTransaction.flatMap { t =>
-                                                  t.produce(
+                                                transactionalProducer.createTransaction.flatMap { tx =>
+                                                  tx.produce(
                                                     aliceAccountFeesPaid,
                                                     Serde.string,
                                                     Serde.int,
                                                     Some(aliceHadMoneyCommittableMessage.offset)
                                                   ) *>
-                                                    t.abort
+                                                    tx.abort
                                                 }
                                               }.catchSome { case UserInitiatedAbort =>
                                                 ZIO.unit // silences the abort
@@ -618,13 +666,15 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           val test = for {
             topic            <- randomTopic
             transactionThief <- Ref.make(Option.empty[Transaction])
+
+            transactionalProducer <- KafkaTestUtils.makeTransactionalProducer(UUID.randomUUID().toString)
             _ <- ZIO.scoped {
-                   TransactionalProducer.createTransaction.flatMap { t =>
-                     transactionThief.set(Some(t))
+                   transactionalProducer.createTransaction.flatMap { tx =>
+                     transactionThief.set(Some(tx))
                    }
                  }
-            t <- transactionThief.get
-            _ <- t.get.produce(topic, 0, 0, Serde.int, Serde.int, None)
+            stolenTx <- transactionThief.get
+            _        <- stolenTx.get.produce(topic, 0, 0, Serde.int, Serde.int, None)
           } yield ()
           assertZIO(test.exit)(failsCause(containsCause(Cause.fail(TransactionLeaked(OffsetBatch.empty)))))
         },
@@ -632,16 +682,18 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           val test = for {
             topic            <- randomTopic
             transactionThief <- Ref.make(Option.empty[Transaction])
+
+            transactionalProducer <- KafkaTestUtils.makeTransactionalProducer(UUID.randomUUID().toString)
+
             _ <- ZIO.scoped {
-                   TransactionalProducer.createTransaction.flatMap { t =>
-                     transactionThief.set(Some(t))
+                   transactionalProducer.createTransaction.flatMap { tx =>
+                     transactionThief.set(Some(tx))
                    }
                  }
-            t <- transactionThief.get
+            stolenTx <- transactionThief.get
             _ <- ZIO.scoped {
-                   TransactionalProducer.createTransaction.flatMap { _ =>
-                     t.get.produce(topic, 0, 0, Serde.int, Serde.int, None)
-                   }
+                   transactionalProducer.createTransaction *>
+                     stolenTx.get.produce(topic, 0, 0, Serde.int, Serde.int, None)
                  }
           } yield ()
           assertZIO(test.exit)(failsCause(containsCause(Cause.fail(TransactionLeaked(OffsetBatch.empty)))))
@@ -652,11 +704,6 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
       produceChunkAsyncSpec,
       produceChunkSpec
     )
-      .provideSome[Kafka](
-        (KafkaTestUtils.producer ++ transactionalProducer(UUID.randomUUID().toString))
-          .mapError(TestFailure.fail),
-        KafkaTestUtils.consumer(clientId = "producer-spec-consumer", groupId = Some("group-0"))
-      )
       .provideSomeShared[Scope](
         Kafka.embedded
       ) @@ withLiveClock @@ timeout(3.minutes)

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/SubscriptionsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/SubscriptionsSpec.scala
@@ -3,10 +3,9 @@ package zio.kafka.consumer
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import zio._
 import zio.kafka.ZIOSpecDefaultSlf4j
-import zio.kafka.producer.Producer
 import zio.kafka.serde.Serde
-import zio.kafka.testkit.KafkaTestUtils._
-import zio.kafka.testkit.{ Kafka, KafkaRandom, KafkaTestUtils }
+import zio.kafka.testkit.KafkaTestUtils
+import zio.kafka.testkit.{ Kafka, KafkaRandom }
 import zio.stream.{ ZSink, ZStream }
 import zio.test.Assertion._
 import zio.test.TestAspect._
@@ -27,19 +26,20 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         client <- randomClient
         group  <- randomGroup
 
-        _ <- produceMany(topic1, kvs)
-        _ <- produceMany(topic2, kvs)
+        producer <- KafkaTestUtils.makeProducer
+        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+        _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
 
+        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
         records <-
-          (Consumer
+          consumer
             .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
             .take(5)
-            .runCollect zipPar
-            Consumer
+            .runCollect <&>
+            consumer
               .plainStream(Subscription.topics(topic2), Serde.string, Serde.string)
               .take(5)
-              .runCollect)
-            .provideSomeLayer[Kafka with Scope](consumer(client, Some(group)))
+              .runCollect
         (records1, records2) = records
         kvOut1               = records1.map(r => (r.record.key, r.record.value)).toList
         kvOut2               = records2.map(r => (r.record.key, r.record.value)).toList
@@ -56,19 +56,20 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         client <- randomClient
         group  <- randomGroup
 
-        _ <- produceMany(topic1, kvs)
-        _ <- produceMany(topic2, kvs)
+        producer <- KafkaTestUtils.makeProducer
+        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+        _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
 
+        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
         records <-
-          (Consumer
+          consumer
             .plainStream(Subscription.Pattern(s"$topic1".r), Serde.string, Serde.string)
             .take(5)
-            .runCollect zipPar
-            Consumer
+            .runCollect <&>
+            consumer
               .plainStream(Subscription.Pattern(s"$topic2".r), Serde.string, Serde.string)
               .take(5)
-              .runCollect)
-            .provideSomeLayer[Kafka with Scope](consumer(client, Some(group)))
+              .runCollect
         (records1, records2) = records
         kvOut1               = records1.map(r => (r.record.key, r.record.value)).toList
         kvOut2               = records2.map(r => (r.record.key, r.record.value)).toList
@@ -87,16 +88,18 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         client <- randomClient
         group  <- randomGroup
 
-        _ <- produceMany(topic1, kvs)
-        _ <- produceMany(topic2, kvs)
+        producer <- KafkaTestUtils.makeProducer
+        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+        _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
 
+        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
         consumer0 =
-          Consumer
+          consumer
             .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
             .runCollect
 
         consumer1 =
-          Consumer
+          consumer
             .plainStream(
               Subscription.manual(topic2, 1), // invalid with the previous subscription
               Serde.string,
@@ -104,10 +107,7 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             )
             .runCollect
 
-        result <- (consumer0 zipPar consumer1)
-                    .provideSomeLayer[Kafka & Scope](consumer(client, Some(group)))
-                    .unit
-                    .exit
+        result <- (consumer0 <&> consumer1).unit.exit
       } yield assert(result)(fails(isSubtype[InvalidSubscriptionUnion](anything)))
     },
     test(
@@ -120,60 +120,57 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         client <- randomClient
         group  <- randomGroup
 
-        _ <- produceMany(topic1, kvs)
+        producer <- KafkaTestUtils.makeProducer
+        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
 
         counter = new AtomicInteger(1)
 
         firstMessagesRef <- Ref.make(("", ""))
         finalizersRef    <- Ref.make(Chunk.empty[String])
 
-        consumer0 =
-          Consumer
-            .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-            // Here we delay each message to be sure that `consumer1` will fail while `consumer0` is still running
-            .mapZIO { r =>
-              firstMessagesRef.updateSome { case ("", v) =>
-                ("First consumer0 message", v)
-              } *>
-                ZIO
-                  .logDebug(s"Consumed ${counter.getAndIncrement()} records")
-                  .delay(10.millis)
-                  .as(r)
-            }
-            .take(numberOfMessages.toLong)
-            .runCollect
-            .exit
-            .zipLeft(finalizersRef.update(_ :+ "consumer0 finalized"))
+        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
 
-        consumer1 =
-          Consumer
-            .plainStream(
-              Subscription.manual(topic1, 1), // invalid with the previous subscription
-              Serde.string,
-              Serde.string
-            )
-            .tapError { _ =>
-              firstMessagesRef.updateSome { case (v, "") =>
-                (v, "consumer1 error")
-              }
-            }
-            .runCollect
-            .exit
-            .zipLeft(finalizersRef.update(_ :+ "consumer1 finalized"))
+        c1Fib <- consumer
+                   .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
+                   // Here we delay each message to be sure that `consumer1` will fail while `consumer0` is still running
+                   .mapZIO { r =>
+                     firstMessagesRef.updateSome { case ("", v) => ("First consumer0 message", v) } *>
+                       ZIO
+                         .logDebug(s"Consumed ${counter.getAndIncrement()} records")
+                         .delay(10.millis)
+                         .as(r)
+                   }
+                   .take(numberOfMessages.toLong)
+                   .runCollect
+                   .exit
+                   .zipLeft(finalizersRef.update(_ :+ "consumer0 finalized"))
+                   .fork
 
-        consumerInstance <- consumer(client, Some(group)).build
+        _ <- ZIO.sleep(100.millis) // Wait to be sure that `consumer0` is running
 
-        fiber0 <- consumer0.provideEnvironment(consumerInstance).fork
-        _      <- ZIO.unit.delay(100.millis) // Wait to be sure that `consumer0` is running
-        fiber1 <- consumer1.provideEnvironment(consumerInstance).fork
+        c2Fib <- consumer
+                   .plainStream(
+                     Subscription.manual(topic1, 1), // invalid with the previous subscription
+                     Serde.string,
+                     Serde.string
+                   )
+                   .tapError { _ =>
+                     firstMessagesRef.updateSome { case (v, "") =>
+                       (v, "consumer1 error")
+                     }
+                   }
+                   .runCollect
+                   .exit
+                   .zipLeft(finalizersRef.update(_ :+ "consumer1 finalized"))
+                   .fork
 
-        result0 <- fiber0.join
-        result1 <- fiber1.join
+        result1 <- c1Fib.join
+        result2 <- c2Fib.join
 
         finalizingOrder <- finalizersRef.get
         firstMessages   <- firstMessagesRef.get
-      } yield assert(result0)(succeeds(hasSize(equalTo(numberOfMessages)))) &&
-        assert(result1)(fails(isSubtype[InvalidSubscriptionUnion](anything))) &&
+      } yield assert(result1)(succeeds(hasSize(equalTo(numberOfMessages)))) &&
+        assert(result2)(fails(isSubtype[InvalidSubscriptionUnion](anything))) &&
         // Here we check that `consumer0` was running when `consumer1` failed
         assert(firstMessages)(equalTo(("First consumer0 message", "consumer1 error"))) &&
         assert(finalizingOrder)(equalTo(Chunk("consumer1 finalized", "consumer0 finalized")))
@@ -185,24 +182,26 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         client <- randomClient
         group  <- randomGroup
 
-        _ <- produceMany(topic1, kvs)
+        producer <- KafkaTestUtils.makeProducer
+        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
 
         consumer1GotMessage <- Promise.make[Nothing, Unit]
         consumer2GotMessage <- Promise.make[Nothing, Unit]
-        _ <-
-          (Consumer
-            .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-            .tap(_ => consumer1GotMessage.succeed(()))
-            .merge(
-              Consumer
-                .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-                .tap(_ => consumer2GotMessage.succeed(()))
-            )
-            .interruptWhen(consumer1GotMessage.await *> consumer2GotMessage.await)
-            .runCollect)
-            .provideSomeLayer[Kafka & Scope](
-              consumer(client, Some(group), properties = Map(ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> "10"))
-            )
+        consumer <- KafkaTestUtils.makeConsumer(
+                      client,
+                      Some(group),
+                      properties = Map(ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> "10")
+                    )
+        _ <- consumer
+               .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
+               .tap(_ => consumer1GotMessage.succeed(()))
+               .merge(
+                 consumer
+                   .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
+                   .tap(_ => consumer2GotMessage.succeed(()))
+               )
+               .interruptWhen(consumer1GotMessage.await *> consumer2GotMessage.await)
+               .runCollect
       } yield assertCompletes
     } @@ TestAspect.nonFlaky(5),
     test("can handle unsubscribing during the lifetime of other streams") {
@@ -213,20 +212,21 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         client <- randomClient
         group  <- randomGroup
 
-        _ <- produceMany(topic1, kvs)
-        _ <- produceMany(topic2, kvs)
+        producer <- KafkaTestUtils.makeProducer
+        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+        _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
 
+        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
         _ <-
-          (Consumer
+          consumer
             .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
             .take(100)
             .merge(
-              Consumer
+              consumer
                 .plainStream(Subscription.topics(topic2), Serde.string, Serde.string)
-                .take(50) *> ZStream.fromZIO(produceMany(topic1, kvs))
+                .take(50) *> ZStream.fromZIO(KafkaTestUtils.produceMany(producer, topic1, kvs))
             )
-            .runCollect)
-            .provideSomeLayer[Kafka with Scope with Producer](consumer(client, Some(group)))
+            .runCollect
       } yield assertCompletes
     },
     test("can restart a stream for the same subscription") {
@@ -236,17 +236,17 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         client <- randomClient
         group  <- randomGroup
 
-        _ <- produceMany(topic1, kvs)
+        producer <- KafkaTestUtils.makeProducer
+        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
 
-        errored <- Ref.make(false)
-        _ <-
-          Consumer
-            .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-            .take(5)
-            .tap(_ => ZIO.unlessZIO(errored.getAndSet(true))(ZIO.fail(new RuntimeException("Stream failure 1"))))
-            .runCollect
-            .retryN(1)
-            .provideSomeLayer[Kafka with Scope](consumer(client, Some(group)))
+        errored  <- Ref.make(false)
+        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+        _ <- consumer
+               .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
+               .take(5)
+               .tap(_ => ZIO.unlessZIO(errored.getAndSet(true))(ZIO.fail(new RuntimeException("Stream failure 1"))))
+               .runCollect
+               .retryN(1)
       } yield assertCompletes
     },
     test("can resume a stream for the same subscription") {
@@ -258,28 +258,29 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
 
         _ <- KafkaTestUtils.createCustomTopic(topic1, partitionCount = 48) // Large number of partitions
 
-        _ <- produceMany(topic1, kvs)
+        producer <- KafkaTestUtils.makeProducer
+        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
 
         recordsConsumed <- Ref.make(Chunk.empty[CommittableRecord[String, String]])
-        _ <-
-          Consumer
-            .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-            .take(40)
-            .transduce(
-              Consumer.offsetBatches.contramap[CommittableRecord[String, String]](_.offset) <&>
-                ZSink.collectAll[CommittableRecord[String, String]]
-            )
-            .mapZIO { case (offsetBatch, records) => offsetBatch.commit.as(records) }
-            .flattenChunks
-            .runCollect
-            .tap(records => recordsConsumed.update(_ ++ records))
-            .repeatN(24)
-            .provideSomeLayer[Kafka with Scope](consumer(client, Some(group)))
+        consumer        <- KafkaTestUtils.makeConsumer(client, Some(group))
+        _ <- ZIO.scoped {
+               consumer
+                 .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
+                 .take(40)
+                 .transduce(
+                   Consumer.offsetBatches.contramap[CommittableRecord[String, String]](_.offset) <&>
+                     ZSink.collectAll[CommittableRecord[String, String]]
+                 )
+                 .mapZIO { case (offsetBatch, records) => offsetBatch.commit.as(records) }
+                 .flattenChunks
+                 .runCollect
+                 .tap(records => recordsConsumed.update(_ ++ records))
+             }
+               .repeatN(24)
         consumed <- recordsConsumed.get
       } yield assert(consumed.map(r => r.value))(hasSameElements(Chunk.fromIterable(kvs.map(_._2))))
     } @@ TestAspect.nonFlaky(2)
   )
-    .provideSome[Scope & Kafka](producer)
     .provideSomeShared[Scope](
       Kafka.embedded
     ) @@ withLiveClock @@ TestAspect.sequential @@ timeout(2.minutes)

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/fetch/ManyPartitionsQueueSizeBasedFetchStrategySpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/fetch/ManyPartitionsQueueSizeBasedFetchStrategySpec.scala
@@ -4,7 +4,7 @@ import org.apache.kafka.common.TopicPartition
 import zio.kafka.ZIOSpecDefaultSlf4j
 import zio.kafka.consumer.internal.PartitionStream
 import zio.test.{ assertTrue, Spec, TestEnvironment }
-import zio.{ Chunk, Scope, UIO, ZIO }
+import zio._
 
 object ManyPartitionsQueueSizeBasedFetchStrategySpec extends ZIOSpecDefaultSlf4j {
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/fetch/QueueSizeBasedFetchStrategySpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/fetch/QueueSizeBasedFetchStrategySpec.scala
@@ -4,7 +4,7 @@ import org.apache.kafka.common.TopicPartition
 import zio.kafka.ZIOSpecDefaultSlf4j
 import zio.kafka.consumer.internal.PartitionStream
 import zio.test.{ assertTrue, Spec, TestEnvironment }
-import zio.{ Chunk, Scope, UIO, ZIO }
+import zio._
 
 object QueueSizeBasedFetchStrategySpec extends ZIOSpecDefaultSlf4j {
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/CommitterSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/CommitterSpec.scala
@@ -5,7 +5,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.RebalanceInProgressException
 import zio.kafka.consumer.diagnostics.Diagnostics
 import zio.test._
-import zio.{ durationInt, Promise, Queue, Ref, Task, Unsafe, ZIO }
+import zio._
 
 import java.util.{ Map => JavaMap }
 import scala.jdk.CollectionConverters.{ MapHasAsJava, MapHasAsScala }

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/DummyMetrics.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/DummyMetrics.scala
@@ -1,5 +1,5 @@
 package zio.kafka.consumer.internal
-import zio.{ UIO, ZIO }
+import zio._
 
 private[internal] class DummyMetrics extends ConsumerMetrics {
   override def observePoll(resumedCount: Int, pausedCount: Int, latency: zio.Duration, pollSize: Int): UIO[Unit] =

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -11,7 +11,7 @@ import zio.kafka.consumer.internal.RebalanceCoordinator.RebalanceEvent
 import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.kafka.consumer.{ CommittableRecord, ConsumerSettings }
 import zio.test._
-import zio.{ durationInt, Chunk, Promise, Ref, Scope, Semaphore, Task, UIO, ZIO }
+import zio._
 
 import java.util
 

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaRandom.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaRandom.scala
@@ -1,6 +1,6 @@
 package zio.kafka.testkit
 
-import zio.{ Task, ZIO }
+import zio._
 
 import java.util.UUID
 

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -17,8 +17,14 @@ import scala.annotation.nowarn
 
 object KafkaTestUtils {
 
+  // -----------------------------------------------------------------------------------------
+  //
+  // Producer construction
+  //
+  // -----------------------------------------------------------------------------------------
+
   /**
-   * Default Producer settings you can use in your tests
+   * Makes `ProducerSettings` for use in tests.
    */
   val producerSettings: ZIO[Kafka, Nothing, ProducerSettings] =
     ZIO
@@ -26,16 +32,37 @@ object KafkaTestUtils {
       .map(ProducerSettings(_))
 
   /**
-   * Producer instance you can use in your tests. It uses the default Producer settings.
+   * Makes a `Producer` for use in tests.
    */
-  val producer: ZLayer[Kafka, Throwable, Producer] =
-    ZLayer.makeSome[Kafka, Producer](
-      ZLayer(producerSettings),
-      Producer.live
-    )
+  val makeProducer: ZIO[Scope & Kafka, Throwable, Producer] =
+    producerSettings.flatMap(settings => Producer.make(settings))
 
   /**
-   * Default transactional producer settings you can use in your tests.
+   * `Producer` layer for use in tests.
+   *
+   * ℹ️ Instead of using a layer, consider using [[KafkaTestUtils.makeProducer]] to directly get a producer.
+   */
+  val producer: ZLayer[Kafka, Throwable, Producer] =
+    ZLayer.scoped(makeProducer)
+
+  // -----------------------------------------------------------------------------------------
+  //
+  // Transactional producer construction
+  //
+  // -----------------------------------------------------------------------------------------
+
+  /**
+   * Makes `TransactionalProducerSettings` for use in tests.
+   *
+   * Note: to run multiple tests in parallel, each producer needs a different transactional id.
+   */
+  def transactionalProducerSettings(transactionalId: String): ZIO[Kafka, Nothing, TransactionalProducerSettings] =
+    ZIO
+      .serviceWith[Kafka](_.bootstrapServers)
+      .map(TransactionalProducerSettings(_, transactionalId))
+
+  /**
+   * Makes `TransactionalProducerSettings` for use in tests.
    *
    * Note: to run multiple tests in parallel, you need to use different transactional ids via
    * `transactionalProducerSettings(transactionalId)`.
@@ -43,84 +70,169 @@ object KafkaTestUtils {
   val transactionalProducerSettings: ZIO[Kafka, Nothing, TransactionalProducerSettings] =
     transactionalProducerSettings("test-transaction")
 
-  def transactionalProducerSettings(transactionalId: String): ZIO[Kafka, Nothing, TransactionalProducerSettings] =
-    ZIO
-      .serviceWith[Kafka](_.bootstrapServers)
-      .map(TransactionalProducerSettings(_, transactionalId))
+  /**
+   * Makes a `TransactionalProducer` for use in tests.
+   *
+   * Note: to run multiple tests in parallel, every test needs a different transactional id.
+   */
+  def makeTransactionalProducer(transactionalId: String): ZIO[Scope & Kafka, Throwable, TransactionalProducer] =
+    transactionalProducerSettings(transactionalId).flatMap(TransactionalProducer.make)
 
   /**
-   * Transactional producer instance you can use in your tests. It uses the default transactional producer settings.
+   * `TransactionalProducer` layer for use in tests.
    *
    * Note: to run multiple tests in parallel, you need to use different transactional ids via
    * `transactionalProducer(transactionalId)`.
+   *
+   * ℹ️ Instead of using a layer, consider using [[KafkaTestUtils.makeTransactionalProducer]] to directly get a
+   * producer.
    */
   val transactionalProducer: ZLayer[Kafka, Throwable, TransactionalProducer] =
     transactionalProducer("test-transaction")
 
+  /**
+   * `TransactionalProducer` layer for use in tests.
+   *
+   * ℹ️ Instead of using a layer, consider using [[KafkaTestUtils.makeTransactionalProducer]] to directly get a
+   * producer.
+   */
   def transactionalProducer(transactionalId: String): ZLayer[Kafka, Throwable, TransactionalProducer] =
-    ZLayer.makeSome[Kafka, TransactionalProducer](
-      ZLayer(transactionalProducerSettings(transactionalId)),
-      TransactionalProducer.live
-    )
+    ZLayer.scoped(makeTransactionalProducer(transactionalId))
+
+  // -----------------------------------------------------------------------------------------
+  //
+  // Producer helpers
+  //
+  // -----------------------------------------------------------------------------------------
 
   /**
-   * Utility function to produce a single message in a Topic.
+   * Produce a single message to a topic.
    */
+  def produceOne(
+    producer: Producer,
+    topic: String,
+    key: String,
+    message: String
+  ): ZIO[Any, Throwable, RecordMetadata] =
+    producer.produce[Any, String, String](new ProducerRecord(topic, key, message), Serde.string, Serde.string)
+
+  /**
+   * Produce a single message to a topic.
+   *
+   * @deprecated
+   *   instead of using layers, use [[KafkaTestUtils.makeProducer]] to directly get a producer OR use
+   *   `ZIO.service[Producer]` to get the producer from the environment. Then use the [[KafkaTestUtils.produceOne]]
+   *   variant that accepts the `Producer` as a parameter.
+   */
+  @deprecated("Use method variant that accepts the Producer as parameter", since = "2.11.0")
   def produceOne(
     topic: String,
     key: String,
     message: String
   ): ZIO[Producer, Throwable, RecordMetadata] =
-    Producer.produce[Any, String, String](new ProducerRecord(topic, key, message), Serde.string, Serde.string)
+    ZIO.serviceWithZIO[Producer](produceOne(_, topic, key, message))
 
   /**
-   * Utility function to produce many messages in give Partition of a Topic.
+   * Produce many messages to the given partition of a topic.
    */
+  def produceMany(
+    producer: Producer,
+    topic: String,
+    partition: Int,
+    kvs: Iterable[(String, String)]
+  ): ZIO[Any, Throwable, Chunk[RecordMetadata]] =
+    producer.produceChunk[Any, String, String](
+      Chunk.fromIterable(kvs.map { case (k, v) =>
+        new ProducerRecord(topic, partition, null, k, v)
+      }),
+      Serde.string,
+      Serde.string
+    )
+
+  /**
+   * Produce many messages to the given partition of a topic.
+   *
+   * @deprecated
+   *   instead of using layers, use [[KafkaTestUtils.makeProducer]] to directly get a producer OR use
+   *   `ZIO.service[Producer]` to get the producer from the environment. Then use the [[KafkaTestUtils.produceMany]]
+   *   variant that accepts the `Producer` as a parameter.
+   */
+  @deprecated("Use method variant that accepts the Producer as parameter", since = "2.11.0")
   def produceMany(
     topic: String,
     partition: Int,
     kvs: Iterable[(String, String)]
   ): ZIO[Producer, Throwable, Chunk[RecordMetadata]] =
-    Producer
-      .produceChunk[Any, String, String](
-        Chunk.fromIterable(kvs.map { case (k, v) =>
-          new ProducerRecord(topic, partition, null, k, v)
-        }),
-        Serde.string,
-        Serde.string
-      )
+    ZIO.serviceWithZIO[Producer](produceMany(_, topic, partition, kvs))
 
   /**
-   * Utility function to produce many messages in a Topic.
+   * Produce many messages to a topic.
    */
+  def produceMany(
+    producer: Producer,
+    topic: String,
+    kvs: Iterable[(String, String)]
+  ): ZIO[Any, Throwable, Chunk[RecordMetadata]] =
+    producer.produceChunk[Any, String, String](
+      Chunk.fromIterable(kvs.map { case (k, v) =>
+        new ProducerRecord(topic, k, v)
+      }),
+      Serde.string,
+      Serde.string
+    )
+
+  /**
+   * Produce many messages to a topic.
+   *
+   * @deprecated
+   *   instead of using layers, use [[KafkaTestUtils.makeProducer]] to directly get a producer OR use
+   *   `ZIO.service[Producer]` to get the producer from the environment. Then use the [[KafkaTestUtils.produceMany]]
+   *   variant that accepts the `Producer` as a parameter.
+   */
+  @deprecated("Use method variant that accepts the Producer as parameter", since = "2.11.0")
   def produceMany(
     topic: String,
     kvs: Iterable[(String, String)]
   ): ZIO[Producer, Throwable, Chunk[RecordMetadata]] =
-    Producer
-      .produceChunk[Any, String, String](
-        Chunk.fromIterable(kvs.map { case (k, v) =>
-          new ProducerRecord(topic, k, v)
-        }),
-        Serde.string,
-        Serde.string
-      )
+    ZIO.serviceWithZIO[Producer](produceMany(_, topic, kvs))
 
   /**
-   * A stream that produces messages to a Topic on a schedule for as long as it is running.
+   * A stream that produces messages to a topic on a schedule for as long as it is running.
    */
+  def scheduledProduce[R](
+    producer: Producer,
+    topic: String,
+    schedule: Schedule[R, Any, Long]
+  ): ZStream[R, Throwable, RecordMetadata] =
+    ZStream
+      .fromSchedule(schedule)
+      .mapZIO { i =>
+        produceOne(producer, topic, s"key$i", s"msg$i")
+      }
+
+  /**
+   * A stream that produces messages to a topic on a schedule for as long as it is running.
+   *
+   * @deprecated
+   *   instead of using layers, use [[KafkaTestUtils.makeProducer]] to directly get a producer OR use
+   *   `ZIO.service[Producer]` to get the producer from the environment. Then use the
+   *   [[KafkaTestUtils.scheduledProduce]] variant that accepts the `Producer` as a parameter.
+   */
+  @deprecated("Use method variant that accepts the Producer as parameter", since = "2.11.0")
   def scheduledProduce[R](
     topic: String,
     schedule: Schedule[R, Any, Long]
   ): ZStream[R with Producer, Throwable, RecordMetadata] =
-    ZStream
-      .fromSchedule(schedule)
-      .mapZIO { i =>
-        produceOne(topic, s"key$i", s"msg$i")
-      }
+    ZStream.serviceWithStream[Producer](scheduledProduce(_, topic, schedule))
+
+  // -----------------------------------------------------------------------------------------
+  //
+  // Consumer construction
+  //
+  // -----------------------------------------------------------------------------------------
 
   /**
-   * Utility function to make a Consumer settings set.
+   * Makes `ConsumerSettings` for use in tests.
    */
   def consumerSettings(
     clientId: String,
@@ -166,7 +278,104 @@ object KafkaTestUtils {
     }
 
   /**
-   * Utility function to make a transactional Consumer settings set.
+   * Makes a `Consumer` for use in tests.
+   */
+  def makeConsumer(
+    clientId: String,
+    groupId: Option[String] = None,
+    clientInstanceId: Option[String] = None,
+    offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest),
+    allowAutoCreateTopics: Boolean = true,
+    diagnostics: Diagnostics = Diagnostics.NoOp,
+    // @deprecated
+    // starting zio-kafka 3.0.0 `restartStreamOnRebalancing` is no longer available. As far as the zio-kafka
+    // contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs it for
+    // that.
+    restartStreamOnRebalancing: Boolean = false,
+    rebalanceSafeCommits: Boolean = false,
+    maxRebalanceDuration: Duration = 3.minutes,
+    commitTimeout: Duration = ConsumerSettings.defaultCommitTimeout,
+    properties: Map[String, String] = Map.empty
+  ): ZIO[Scope & Kafka, Throwable, Consumer] =
+    for {
+      settings <- consumerSettings(
+                    clientId = clientId,
+                    groupId = groupId,
+                    clientInstanceId = clientInstanceId,
+                    allowAutoCreateTopics = allowAutoCreateTopics,
+                    offsetRetrieval = offsetRetrieval,
+                    restartStreamOnRebalancing = restartStreamOnRebalancing,
+                    rebalanceSafeCommits = rebalanceSafeCommits,
+                    maxRebalanceDuration = maxRebalanceDuration,
+                    properties = properties,
+                    commitTimeout = commitTimeout
+                  )
+      c <- Consumer.make(settings, diagnostics)
+    } yield c
+
+  /**
+   * `Consumer` layer for use in tests, requires a `ConsumerSettings` layer.
+   *
+   * "minimal" because, unlike the other functions returning a `ZLayer[..., ..., Consumer]` of this file, you need to
+   * provide the `ConsumerSettings` layer yourself.
+   *
+   * ℹ️ Instead of using a layer, consider using [[KafkaTestUtils.makeConsumer]] to directly get a consumer.
+   */
+  def minimalConsumer(diagnostics: Diagnostics = Diagnostics.NoOp): ZLayer[ConsumerSettings, Throwable, Consumer] =
+    ZLayer.makeSome[ConsumerSettings, Consumer](
+      ZLayer.succeed(diagnostics) >>> Consumer.live
+    )
+
+  @deprecated("Use [[KafkaTestUtils.minimalConsumer]] instead", "2.3.1")
+  def simpleConsumer(diagnostics: Diagnostics = Diagnostics.NoOp): ZLayer[ConsumerSettings, Throwable, Consumer] =
+    minimalConsumer(diagnostics)
+
+  /**
+   * `Consumer` layer for use in tests.
+   *
+   * ℹ️ Instead of using a layer, consider using [[makeConsumer]] to directly get a consumer.
+   */
+  def consumer(
+    clientId: String,
+    groupId: Option[String] = None,
+    clientInstanceId: Option[String] = None,
+    offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest),
+    allowAutoCreateTopics: Boolean = true,
+    diagnostics: Diagnostics = Diagnostics.NoOp,
+    // @deprecated
+    // starting zio-kafka 3.0.0 `restartStreamOnRebalancing` is no longer available. As far as the zio-kafka
+    // contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs it for
+    // that.
+    restartStreamOnRebalancing: Boolean = false,
+    rebalanceSafeCommits: Boolean = false,
+    maxRebalanceDuration: Duration = 3.minutes,
+    commitTimeout: Duration = ConsumerSettings.defaultCommitTimeout,
+    properties: Map[String, String] = Map.empty
+  ): ZLayer[Kafka, Throwable, Consumer] =
+    ZLayer.scoped {
+      makeConsumer(
+        clientId,
+        groupId,
+        clientInstanceId,
+        offsetRetrieval,
+        allowAutoCreateTopics,
+        diagnostics,
+        restartStreamOnRebalancing,
+        rebalanceSafeCommits,
+        maxRebalanceDuration,
+        commitTimeout,
+        properties
+      )
+    }
+
+  // -----------------------------------------------------------------------------------------
+  //
+  // Transactional consumer construction
+  //
+  // -----------------------------------------------------------------------------------------
+
+  /**
+   * Makes `ConsumerSettings` for a transactional consumer, use in tests.
    */
   def transactionalConsumerSettings(
     groupId: String,
@@ -174,6 +383,10 @@ object KafkaTestUtils {
     clientInstanceId: Option[String] = None,
     allowAutoCreateTopics: Boolean = true,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest),
+    // @deprecated
+    // starting zio-kafka 3.0.0 `restartStreamOnRebalancing` is no longer available. As far as the zio-kafka
+    // contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs it for
+    // that.
     restartStreamOnRebalancing: Boolean = false,
     rebalanceSafeCommits: Boolean = false,
     properties: Map[String, String] = Map.empty
@@ -188,65 +401,46 @@ object KafkaTestUtils {
       rebalanceSafeCommits = rebalanceSafeCommits,
       properties = properties
     )
-      .map(
-        _.withProperties(
-          ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed"
-        )
-      )
+      .map(_.withProperties(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed"))
 
   /**
-   * Utility function to make a Consumer. It requires a ConsumerSettings layer.
+   * Makes a transactional `Consumer` for use in tests.
    */
-  @deprecated("Use [[KafkaTestUtils.minimalConsumer]] instead", "2.3.1")
-  def simpleConsumer(diagnostics: Diagnostics = Diagnostics.NoOp): ZLayer[ConsumerSettings, Throwable, Consumer] =
-    ZLayer.makeSome[ConsumerSettings, Consumer](
-      ZLayer.succeed(diagnostics) >>> Consumer.live
-    )
-
-  /**
-   * Utility function to make a Consumer. It requires a ConsumerSettings layer.
-   *
-   * "minimal" because, unlike the other functions returning a `ZLayer[..., ..., Consumer]` of this file, you need to
-   * provide the `ConsumerSettings` layer yourself.
-   */
-  def minimalConsumer(diagnostics: Diagnostics = Diagnostics.NoOp): ZLayer[ConsumerSettings, Throwable, Consumer] =
-    ZLayer.makeSome[ConsumerSettings, Consumer](
-      ZLayer.succeed(diagnostics) >>> Consumer.live
-    )
-
-  /**
-   * Utility function to make a Consumer.
-   */
-  def consumer(
+  def makeTransactionalConsumer(
     clientId: String,
-    groupId: Option[String] = None,
+    groupId: String,
     clientInstanceId: Option[String] = None,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest),
     allowAutoCreateTopics: Boolean = true,
     diagnostics: Diagnostics = Diagnostics.NoOp,
+    // @deprecated
+    // starting zio-kafka 3.0.0 `restartStreamOnRebalancing` is no longer available. As far as the zio-kafka
+    // contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs it for
+    // that.
     restartStreamOnRebalancing: Boolean = false,
     rebalanceSafeCommits: Boolean = false,
-    maxRebalanceDuration: Duration = 3.minutes,
-    commitTimeout: Duration = ConsumerSettings.defaultCommitTimeout,
-    properties: Map[String, String] = Map.empty
-  ): ZLayer[Kafka, Throwable, Consumer] =
-    (ZLayer(
-      consumerSettings(
-        clientId = clientId,
-        groupId = groupId,
-        clientInstanceId = clientInstanceId,
-        allowAutoCreateTopics = allowAutoCreateTopics,
-        offsetRetrieval = offsetRetrieval,
-        restartStreamOnRebalancing = restartStreamOnRebalancing,
-        rebalanceSafeCommits = rebalanceSafeCommits,
-        maxRebalanceDuration = maxRebalanceDuration,
-        properties = properties,
-        commitTimeout = commitTimeout
-      )
-    ) ++ ZLayer.succeed(diagnostics)) >>> Consumer.live
+    properties: Map[String, String] = Map.empty,
+    rebalanceListener: RebalanceListener = RebalanceListener.noop
+  ): ZIO[Scope & Kafka, Throwable, Consumer] =
+    for {
+      settings <- transactionalConsumerSettings(
+                    groupId = groupId,
+                    clientId = clientId,
+                    clientInstanceId = clientInstanceId,
+                    allowAutoCreateTopics = allowAutoCreateTopics,
+                    offsetRetrieval = offsetRetrieval,
+                    restartStreamOnRebalancing = restartStreamOnRebalancing,
+                    rebalanceSafeCommits = rebalanceSafeCommits,
+                    properties = properties
+                  ).map(_.withRebalanceListener(rebalanceListener))
+      consumer <- Consumer.make(settings, diagnostics)
+    } yield consumer
 
   /**
-   * Utility function to make a transactional Consumer.
+   * A transactional `Consumer` layer for use in tests.
+   *
+   * ℹ️ Instead of using a layer, consider using [[KafkaTestUtils.makeTransactionalConsumer]] to directly get a
+   * consumer.
    */
   def transactionalConsumer(
     clientId: String,
@@ -255,26 +449,38 @@ object KafkaTestUtils {
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest),
     allowAutoCreateTopics: Boolean = true,
     diagnostics: Diagnostics = Diagnostics.NoOp,
+    // @deprecated
+    // starting zio-kafka 3.0.0 `restartStreamOnRebalancing` is no longer available. As far as the zio-kafka
+    // contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs it for
+    // that.
     restartStreamOnRebalancing: Boolean = false,
     rebalanceSafeCommits: Boolean = false,
     properties: Map[String, String] = Map.empty,
     rebalanceListener: RebalanceListener = RebalanceListener.noop
   ): ZLayer[Kafka, Throwable, Consumer] =
-    (ZLayer(
-      transactionalConsumerSettings(
-        groupId = groupId,
-        clientId = clientId,
-        clientInstanceId = clientInstanceId,
-        allowAutoCreateTopics = allowAutoCreateTopics,
-        offsetRetrieval = offsetRetrieval,
-        restartStreamOnRebalancing = restartStreamOnRebalancing,
-        rebalanceSafeCommits = rebalanceSafeCommits,
-        properties = properties
-      ).map(_.withRebalanceListener(rebalanceListener))
-    ) ++ ZLayer.succeed(diagnostics)) >>> Consumer.live
+    ZLayer.scoped {
+      makeTransactionalConsumer(
+        clientId,
+        groupId,
+        clientInstanceId,
+        offsetRetrieval,
+        allowAutoCreateTopics,
+        diagnostics,
+        restartStreamOnRebalancing,
+        rebalanceSafeCommits,
+        properties,
+        rebalanceListener
+      )
+    }
+
+  // -----------------------------------------------------------------------------------------
+  //
+  // Consumer helpers
+  //
+  // -----------------------------------------------------------------------------------------
 
   /**
-   * Utility function consume a stream of ConsumerRecords.
+   * Consumes a stream of `ConsumerRecord`s for topics that have `String` keys and `String` values.
    *
    * For each consumed record, the provided `r` function will be called.
    */
@@ -290,34 +496,40 @@ object KafkaTestUtils {
       )(r)
     }
 
-  /**
-   * Default AdminClient settings.
-   */
-  val adminSettings: ZIO[Kafka, Nothing, AdminClientSettings] =
-    ZIO.serviceWith[Kafka](_.bootstrapServers).map(AdminClientSettings(_))
+  // -----------------------------------------------------------------------------------------
+  //
+  // Admin client construction
+  //
+  // -----------------------------------------------------------------------------------------
 
   /**
-   * Utility function to make an AdminClient settings set using SASL_PLAINTEXT security protocol.
+   * Makes `AdminClientSettings` for use in tests.
+   */
+  val adminSettings: ZIO[Kafka, Nothing, AdminClientSettings] =
+    ZIO.serviceWith[Kafka](_.bootstrapServers).map(bootstrapServers => AdminClientSettings(bootstrapServers))
+
+  /**
+   * Makes `AdminClientSettings` for use in tests, using SASL_PLAINTEXT security protocol.
    */
   def saslAdminSettings(username: String, password: String): ZIO[Kafka.Sasl, Nothing, AdminClientSettings] =
     ZIO
       .serviceWith[Kafka.Sasl](_.value.bootstrapServers)
-      .map(
-        AdminClientSettings(_).withProperties(
+      .map { bootstrapServers =>
+        AdminClientSettings(bootstrapServers).withProperties(
           "sasl.mechanism"    -> "PLAIN",
           "security.protocol" -> "SASL_PLAINTEXT",
           "sasl.jaas.config" -> s"""org.apache.kafka.common.security.plain.PlainLoginModule required username="$username" password="$password";"""
         )
-      )
+      }
 
   /**
-   * Default AdminClient settings using SSL security protocol.
+   * Makes `AdminClientSettings` for use in tests, using SSL security protocol.
    */
   val sslAdminSettings: ZIO[Kafka, Nothing, AdminClientSettings] =
     ZIO
       .serviceWith[Kafka](_.bootstrapServers)
-      .map(bootstrap =>
-        AdminClientSettings(bootstrap).withProperties(
+      .map { bootstrapServers =>
+        AdminClientSettings(bootstrapServers).withProperties(
           "security.protocol"       -> "SSL",
           "ssl.truststore.location" -> trustStoreFile.getAbsolutePath,
           "ssl.truststore.password" -> "123456",
@@ -328,45 +540,95 @@ object KafkaTestUtils {
           "ssl.truststore.type"     -> "JKS",
           "ssl.keystore.type"       -> "JKS"
         )
-      )
+      }
 
   /**
-   * Utility function to execute something with an `AdminClient` instance configure with the default settings.
+   * Makes a `AdminClient` for use in tests.
    */
-  def withAdmin[T](f: AdminClient => RIO[Kafka, T]): ZIO[Kafka, Throwable, T] =
-    for {
-      settings <- adminSettings
-      fRes     <- withAdminClient(settings)(f)
-    } yield fRes
+  def makeAdminClient: ZIO[Scope & Kafka, Throwable, AdminClient] =
+    adminSettings.flatMap(AdminClient.make)
 
   /**
-   * Utility function to execute something with an `AdminClient` instance configured to use the SASL_PLAINTEXT security
-   * protocol.
+   * Makes a `AdminClient` for use in tests, using the `SASL_PLAINTEXT` security protocol.
    */
-  def withSaslAdmin[T](
+  def makeSaslAdminClient(
     username: String = "admin",
     password: String = "admin-secret"
-  )(f: AdminClient => RIO[Kafka.Sasl, T]): ZIO[Kafka.Sasl, Throwable, T] =
-    for {
-      settings <- saslAdminSettings(username, password)
-      fRes     <- withAdminClient(settings)(f)
-    } yield fRes
+  ): ZIO[Scope & Kafka.Sasl, Throwable, AdminClient] =
+    saslAdminSettings(username, password).flatMap(AdminClient.make)
 
   /**
-   * Utility function to execute something with an `AdminClient` instance configured to use the SSL security protocol.
+   * Makes a `AdminClient` for use in tests, using the `SSL` security protocol.
    */
-  def withSslAdmin[T](f: AdminClient => RIO[Kafka, T]): ZIO[Kafka, Throwable, T] =
-    for {
-      settings <- sslAdminSettings
-      fRes     <- withAdminClient(settings)(f)
-    } yield fRes
+  def makeSslAdminClient: ZIO[Scope & Kafka, Throwable, AdminClient] =
+    sslAdminSettings.flatMap(AdminClient.make)
 
+  /**
+   * Run `f` with an `AdminClient`.
+   *
+   * @deprecated
+   *   use [[KafkaTestUtils.makeAdminClient]] directly, for example:
+   *   {{{
+   *   for {
+   *     adminClient <- KafkaTestUtils.makeAdminClient
+   *     _           <- adminClient.createTopic(topic1, 1, 1)
+   *   } yield ()
+   *   }}}
+   */
+  @deprecated("Use KafkaTestUtils.makeAdminClient instead", since = "2.11.0")
+  def withAdmin[A](f: AdminClient => UIO[A]): ZIO[Scope & Kafka, Throwable, A] =
+    makeAdminClient.flatMap(f)
+
+  /**
+   * Run `f` with an `AdminClient`, using the SASL_PLAINTEXT security protocol.
+   *
+   * @deprecated
+   *   use [[KafkaTestUtils.makeSaslAdminClient]] directly, for example:
+   *   {{{
+   *   for {
+   *     adminClient <- KafkaTestUtils.makeSaslAdminClient
+   *     _           <- adminClient.createTopic(topic1, 1, 1)
+   *   } yield ()
+   *   }}}
+   */
+  @deprecated("Use KafkaTestUtils.makeSaslAdminClient instead", since = "2.11.0")
+  def withSaslAdmin[A](
+    username: String = "admin",
+    password: String = "admin-secret"
+  )(f: AdminClient => UIO[A]): ZIO[Scope & Kafka.Sasl, Throwable, A] =
+    makeSaslAdminClient(username, password).flatMap(f)
+
+  /**
+   * Run `f` with an `AdminClient`, using the `SSL` security protocol.
+   *
+   * @deprecated
+   *   use [[KafkaTestUtils.makeSslAdminClient]] directly, for example:
+   *   {{{
+   *   for {
+   *     adminClient <- KafkaTestUtils.makeSslAdminClient
+   *     _           <- adminClient.createTopic(topic1, 1, 1)
+   *   } yield ()
+   *   }}}
+   */
+  @deprecated("Use KafkaTestUtils.makeSslAdminClient instead", since = "2.11.0")
+  def withSslAdmin[A](f: AdminClient => UIO[A]): ZIO[Scope & Kafka, Throwable, A] =
+    makeSslAdminClient.flatMap(f)
+
+  // -----------------------------------------------------------------------------------------
+  //
+  // Admin client helpers
+  //
+  // -----------------------------------------------------------------------------------------
+
+  /**
+   * Create a topic.
+   */
   def createCustomTopic(topic: String, partitionCount: Int = 1): ZIO[Kafka, Throwable, Unit] =
-    withAdmin(_.createTopic(AdminClient.NewTopic(topic, partitionCount, 1)))
-
-  private def withAdminClient[R, T](settings: AdminClientSettings)(f: AdminClient => RIO[R, T]): ZIO[R, Throwable, T] =
-    ZIO.scoped[R] {
-      AdminClient.make(settings).flatMap(f)
+    ZIO.scoped {
+      for {
+        adminClient <- makeAdminClient
+        _           <- adminClient.createTopic(AdminClient.NewTopic(topic, partitionCount, replicationFactor = 1))
+      } yield ()
     }
 
   private def readResourceFile(file: String, tmpFileName: String, tmpFileSuffix: String): File =

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -59,6 +59,9 @@ import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success, Try }
 
+/**
+ * Admin client, can be used to create, list, delete topics, consumer groups, etc.
+ */
 trait AdminClient {
 
   import AdminClient._

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -263,12 +263,20 @@ object Consumer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def assignment: RIO[Consumer, Set[TopicPartition]] =
     ZIO.serviceWithZIO(_.assignment)
 
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def beginningOffsets(
     partitions: Set[TopicPartition],
     timeout: Duration = Duration.Infinity
@@ -278,6 +286,10 @@ object Consumer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def committed(
     partitions: Set[TopicPartition],
     timeout: Duration = Duration.Infinity
@@ -287,6 +299,10 @@ object Consumer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def endOffsets(
     partitions: Set[TopicPartition],
     timeout: Duration = Duration.Infinity
@@ -296,6 +312,10 @@ object Consumer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def listTopics(
     timeout: Duration = Duration.Infinity
   ): RIO[Consumer, Map[String, List[PartitionInfo]]] =
@@ -304,6 +324,10 @@ object Consumer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def partitionedAssignmentStream[R, K, V](
     subscription: Subscription,
     keyDeserializer: Deserializer[R, K],
@@ -314,6 +338,10 @@ object Consumer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def partitionedStream[R, K, V](
     subscription: Subscription,
     keyDeserializer: Deserializer[R, K],
@@ -328,6 +356,10 @@ object Consumer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def plainStream[R, K, V](
     subscription: Subscription,
     keyDeserializer: Deserializer[R, K],
@@ -341,6 +373,10 @@ object Consumer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def stopConsumption: RIO[Consumer, Unit] =
     ZIO.serviceWithZIO(_.stopConsumption)
 
@@ -414,6 +450,10 @@ object Consumer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def offsetsForTimes(
     timestamps: Map[TopicPartition, Long],
     timeout: Duration = Duration.Infinity
@@ -423,6 +463,10 @@ object Consumer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def partitionsFor(
     topic: String,
     timeout: Duration = Duration.Infinity
@@ -432,6 +476,10 @@ object Consumer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def position(
     partition: TopicPartition,
     timeout: Duration = Duration.Infinity
@@ -441,12 +489,20 @@ object Consumer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def subscription: RIO[Consumer, Set[String]] =
     ZIO.serviceWithZIO(_.subscription)
 
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def metrics: RIO[Consumer, Map[MetricName, Metric]] =
     ZIO.serviceWithZIO(_.metrics)
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
@@ -2,7 +2,7 @@ package zio.kafka.consumer
 
 import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, OffsetAndMetadata, RetriableCommitFailedException }
 import org.apache.kafka.common.TopicPartition
-import zio.{ RIO, Schedule, Task }
+import zio._
 
 sealed trait Offset {
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
@@ -2,7 +2,7 @@ package zio.kafka.consumer
 
 import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, OffsetAndMetadata }
 import org.apache.kafka.common.TopicPartition
-import zio.{ RIO, Schedule, Task, ZIO }
+import zio._
 
 sealed trait OffsetBatch {
   def offsets: Map[TopicPartition, OffsetAndMetadata]

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
@@ -2,7 +2,7 @@ package zio.kafka.consumer
 
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
 import org.apache.kafka.common.TopicPartition
-import zio.{ Executor, Runtime, Task, Unsafe, ZIO }
+import zio._
 
 import scala.jdk.CollectionConverters._
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Subscription.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Subscription.scala
@@ -1,6 +1,6 @@
 package zio.kafka.consumer
 
-import zio.{ NonEmptyChunk, Task, ZIO }
+import zio._
 
 import scala.util.matching.Regex
 import java.util.regex.{ Pattern => JPattern }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/LiveCommitter.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/LiveCommitter.scala
@@ -7,7 +7,7 @@ import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
 import zio.kafka.consumer.internal.Committer.CommitOffsets
 import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
 import zio.kafka.consumer.internal.LiveCommitter.Commit
-import zio.{ durationLong, Cause, Chunk, Duration, Exit, Promise, Queue, Ref, Scope, Task, UIO, Unsafe, ZIO }
+import zio._
 
 import java.util.{ Map => JavaMap }
 import scala.collection.mutable

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -6,7 +6,7 @@ import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
 import zio.kafka.consumer.internal.PartitionStreamControl.QueueInfo
 import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.stream.{ Take, ZStream }
-import zio.{ Chunk, Clock, Duration, LogAnnotation, Promise, Queue, Ref, UIO, ZIO }
+import zio._
 
 import java.util.concurrent.TimeoutException
 import scala.util.control.NoStackTrace

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RebalanceCoordinator.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RebalanceCoordinator.scala
@@ -4,7 +4,7 @@ import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
 import zio.kafka.consumer.internal.RebalanceCoordinator._
 import zio.kafka.consumer.{ ConsumerSettings, RebalanceListener }
 import zio.stream.ZStream
-import zio.{ durationInt, Chunk, Duration, Ref, Task, UIO, ZIO }
+import zio._
 
 /**
  * The Runloop's RebalanceListener gets notified of partitions that are assigned, revoked and lost

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopExecutor.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopExecutor.scala
@@ -1,6 +1,6 @@
 package zio.kafka.consumer.internal
 
-import zio.{ Executor, Scope, URIO, ZIO }
+import zio._
 
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -257,6 +257,10 @@ object Producer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def produce(
     record: ProducerRecord[Array[Byte], Array[Byte]]
   ): RIO[Producer, RecordMetadata] =
@@ -265,6 +269,10 @@ object Producer {
   /**
    * Accessor method for [[Producer!.produce[R,K,V](record*]]
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def produce[R, K, V](
     record: ProducerRecord[K, V],
     keySerializer: Serializer[R, K],
@@ -275,6 +283,10 @@ object Producer {
   /**
    * Accessor method for [[Producer!.produce[R,K,V](topic*]]
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def produce[R, K, V](
     topic: String,
     key: K,
@@ -287,6 +299,10 @@ object Producer {
   /**
    * A stream pipeline that produces all records from the stream.
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def produceAll[R, K, V](
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V]
@@ -296,6 +312,10 @@ object Producer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def produceAsync(
     record: ProducerRecord[Array[Byte], Array[Byte]]
   ): RIO[Producer, Task[RecordMetadata]] =
@@ -304,6 +324,10 @@ object Producer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def produceAsync[R, K, V](
     record: ProducerRecord[K, V],
     keySerializer: Serializer[R, K],
@@ -314,6 +338,10 @@ object Producer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def produceAsync[R, K, V](
     topic: String,
     key: K,
@@ -326,6 +354,10 @@ object Producer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def produceChunkAsync(
     records: Chunk[ProducerRecord[Array[Byte], Array[Byte]]]
   ): RIO[Producer, Task[Chunk[RecordMetadata]]] =
@@ -334,6 +366,10 @@ object Producer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def produceChunkAsync[R, K, V](
     records: Chunk[ProducerRecord[K, V]],
     keySerializer: Serializer[R, K],
@@ -344,6 +380,10 @@ object Producer {
   /**
    * Accessor method for [[Producer.produceChunkAsyncWithFailures]]]
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def produceChunkAsyncWithFailures(
     records: Chunk[ProducerRecord[Array[Byte], Array[Byte]]]
   ): RIO[Producer, UIO[Chunk[Either[Throwable, RecordMetadata]]]] =
@@ -352,6 +392,10 @@ object Producer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def produceChunk(
     records: Chunk[ProducerRecord[Array[Byte], Array[Byte]]]
   ): RIO[Producer, Chunk[RecordMetadata]] =
@@ -360,6 +404,10 @@ object Producer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def produceChunk[R, K, V](
     records: Chunk[ProducerRecord[K, V]],
     keySerializer: Serializer[R, K],
@@ -370,17 +418,29 @@ object Producer {
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def partitionsFor(topic: String): RIO[Producer, Chunk[PartitionInfo]] =
     ZIO.serviceWithZIO(_.partitionsFor(topic))
 
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   val flush: RIO[Producer, Unit] = ZIO.serviceWithZIO(_.flush)
 
   /**
    * Accessor method
    */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   val metrics: RIO[Producer, Map[MetricName, Metric]] = ZIO.serviceWithZIO(_.metrics)
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Transaction.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Transaction.scala
@@ -4,7 +4,7 @@ import org.apache.kafka.clients.producer.{ ProducerRecord, RecordMetadata }
 import zio.kafka.consumer.{ Offset, OffsetBatch }
 import zio.kafka.producer.TransactionalProducer.{ TransactionLeaked, UserInitiatedAbort }
 import zio.kafka.serde.Serializer
-import zio.{ Chunk, IO, RIO, Ref, UIO, ZIO }
+import zio._
 
 trait Transaction {
   def produce[R, K, V](

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -12,6 +12,9 @@ import zio.kafka.consumer.OffsetBatch
 import java.util
 import scala.jdk.CollectionConverters._
 
+/**
+ * A producer that produces records transactionally.
+ */
 trait TransactionalProducer {
   def createTransaction: ZIO[Scope, Throwable, Transaction]
 }
@@ -71,6 +74,13 @@ object TransactionalProducer {
         } { case (transaction: TransactionImpl, exit) => transaction.markAsClosed *> commitOrAbort(transaction, exit) }
   }
 
+  /**
+   * Accessor method
+   */
+  @deprecated(
+    "Use zio service pattern instead (https://zio.dev/reference/service-pattern/), will be removed in zio-kafka 3.0.0",
+    since = "2.11.0"
+  )
   def createTransaction: ZIO[TransactionalProducer & Scope, Throwable, Transaction] =
     ZIO.service[TransactionalProducer].flatMap(_.createTransaction)
 

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
@@ -3,6 +3,18 @@ package zio.kafka.producer
 import org.apache.kafka.clients.producer.ProducerConfig
 import zio._
 
+/**
+ * Settings for a transactional producer.
+ *
+ * To stay source compatible with future releases, you are recommended to construct the settings as follows:
+ * {{{
+ *   val producerSettings = ProducerSettings(bootstrapServers)
+ *     .withLinger(500.millis)
+ *     .withCompression(ProducerCompression.Zstd(3))
+ *     .... etc.
+ *   TransactionalProducerSettings(producerSettings, transactionalId)
+ * }}}
+ */
 final case class TransactionalProducerSettings private (producerSettings: ProducerSettings)
 
 object TransactionalProducerSettings {

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
@@ -2,7 +2,7 @@ package zio.kafka.serde
 
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.{ Deserializer => KafkaDeserializer }
-import zio.{ RIO, Task, ZIO }
+import zio._
 
 import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success, Try }

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
@@ -2,7 +2,7 @@ package zio.kafka.serde
 
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.{ Serde => KafkaSerde }
-import zio.{ RIO, Task, ZIO }
+import zio._
 
 import scala.jdk.CollectionConverters._
 import scala.util.Try

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -2,7 +2,7 @@ package zio.kafka.serde
 
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.{ Serializer => KafkaSerializer }
-import zio.{ RIO, Task, ZIO }
+import zio._
 
 import scala.jdk.CollectionConverters._
 

--- a/zio-kafka/src/main/scala/zio/kafka/utils/SslHelper.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/SslHelper.scala
@@ -5,7 +5,7 @@ import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.network.TransferableChannel
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.{ ApiVersionsRequest, RequestHeader }
-import zio.{ durationInt, durationLong, BuildFrom, Duration, IO, Task, Trace, URIO, ZIO }
+import zio._
 
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer


### PR DESCRIPTION
Accessor methods are [deprecated by the ZIO community](https://zio.dev/reference/service-pattern/accessor-methods). Therefore, all accessor methods for `Consumer`, `Producer` and `TransactionalProducer` have been deprecated so that they can be removed in zio-kafka 3.0.0.

Accessor methods were heavily used in the zio-kafka unit tests. Therefore, all tests and benchmarks have been rewritten to use services directly. `KafkaTestUtils` has been extended with several methods to make this easier. To nudge users of the zio-kafka-test-kit, anything that promotes accessor methods is also deprecated.

The unit tests now have less layer trickery and are easier to understand.

The documentation has been extended with a migration guide: https://github.com/zio/zio-kafka/blob/accessors/docs/migrating-to-2.11.md

Hint for the reviewer: enable "hide whitespace" for smaller diffs.