### PR TITLE
Remove accessor methods from docs

### DIFF
--- a/docs/consuming-kafka-topics-using-zio-streams.md
+++ b/docs/consuming-kafka-topics-using-zio-streams.md
@@ -3,64 +3,69 @@ id: consuming-kafka-topics-using-zio-streams
 title: "Consuming Kafka topics using ZIO Streams"
 ---
 
-First, create a consumer using the ConsumerSettings instance:
-
-```scala
-import zio.*
-import zio.kafka.consumer.{ Consumer, ConsumerSettings }
-
-val consumerSettings: ConsumerSettings = ConsumerSettings(List("localhost:9092")).withGroupId("group")
-val consumerScoped: ZIO[Scope, Throwable, Consumer] =
-  Consumer.make(consumerSettings)
-val consumer: ZLayer[Any, Throwable, Consumer] =
-  ZLayer.scoped(consumerScoped)
-```
-
-The consumer returned from `Consumer.make` is wrapped in a `ZLayer`
-to allow for easy composition with other ZIO environment components.
-You may provide that layer to effects that require a consumer. Here's
-an example:
-
-```scala
-import zio._
-import zio.kafka.consumer._
-import zio.kafka.serde._
-
-val data: Task[Chunk[CommittableRecord[String, String]]] =
-  Consumer.plainStream(Subscription.topics("topic"), Serde.string, Serde.string).take(50).runCollect
-    .provideSomeLayer(consumer)
-```
-
-You may stream data from Kafka using the `plainStream` method:
+You can stream data from Kafka using the `plainStream` method:
 
 ```scala
 import zio.Console.printLine
 import zio.kafka.consumer._
 
-Consumer.plainStream(Subscription.topics("topic150"), Serde.string, Serde.string)
-  .tap(cr => printLine(s"key: ${cr.record.key}, value: ${cr.record.value}"))
-  .map(_.offset)
-  .aggregateAsync(Consumer.offsetBatches)
-  .mapZIO(_.commit)
+consumer
+  .plainStream(Subscription.topics("topic150"), Serde.string, Serde.string) // (1)
+  .tap(cr => printLine(s"key: ${cr.record.key}, value: ${cr.record.value}")) // (2)
+  .map(_.offset) // (3)
+  .aggregateAsync(Consumer.offsetBatches) // (4)
+  .mapZIO(_.commit) // (5)
   .runDrain
 ```
 
-To process partitions assigned to the consumer in parallel, you may use the `Consumer#partitionedStream` method, which creates a nested stream of partitions:
+(1) There are several types of subscriptions: a set of topics, a topic name pattern, or fully specified set of
+topic-partitions (see [subscriptions](partition-assignment-and-offset-retrieval.md)).
+
+(2) The `plainStream` method returns a stream of `CommittableRecord` objects. In this line, we access the key
+and value from the `CommittableRecord` and print them to the console.
+
+(3) Here we get the offset of the record, so we now have a stream of offsets.
+
+(4) The offsets are aggregated into an `OffsetBatch`. The offset batch keeps the highest seen offset per partition.
+
+(5) All offsets in the `OffsetBatch` are committed. As soon as the commit is done, the next offset batch is pulled
+from the stream. Because the aggregation in (4) is asynchronous, this application is continuously committing while
+concurrently processing records.
+
+## Consuming with more parallelism
+
+To process partitions (assigned to the consumer) in parallel, you may use the `partitionedStream` method, which creates
+a nested stream of partitions:
 
 ```scala
 import zio.Console.printLine
 import zio.kafka.consumer._
 
-Consumer.partitionedStream(Subscription.topics("topic150"), Serde.string, Serde.string)
-  .flatMapPar(Int.MaxValue) { case (topicPartition, partitionStream) =>
-    ZStream.fromZIO(printLine(s"Starting stream for topic '${topicPartition.topic}' partition ${topicPartition.partition}")) *>
+consumer
+  .partitionedStream(Subscription.topics("topic150"), Serde.string, Serde.string)
+  .flatMapPar(Int.MaxValue) { case (topicPartition, partitionStream) => // (1)
+    ZStream.fromZIO(
+      printLine(s"Starting stream for topic '${topicPartition.topic}' partition ${topicPartition.partition}")
+    ) *>
       partitionStream
-        .tap(record => printLine(s"key: ${record.key}, value: ${record.value}")) // Replace with a custom message handling effect
-        .map(_.offset)
+        .tap(record => printLine(s"key: ${record.key}, value: ${record.value}")) // (2)
+        .map(_.offset) // (3)
   }
-  .aggregateAsync(Consumer.offsetBatches)
+  .aggregateAsync(Consumer.offsetBatches) // (4)
   .mapZIO(_.commit)
   .runDrain
 ```
 
-When using partitionedStream with `flatMapPar(n)`, it is recommended to set n to `Int.MaxValue`. N must be equal or greater than the number of partitions your consumer subscribes to otherwise there'll be unhandled partitions and Kafka will eventually evict your consumer.
+(1) When using partitionedStream with `flatMapPar(n)`, it is recommended to set n to `Int.MaxValue`. N must be equal to
+or greater than the number of partitions your consumer subscribes to otherwise there will be unhandled partitions and
+Kafka eventually evicts your consumer.
+
+Each time a new partition is assigned to the consumer, a new partition stream is created and the body of the
+`flatMapPar` is executed.
+
+(2) As before, here we process the received `CommittableRecord`.
+
+(3) and (4) Note how the offsets from all the sub-streams are merged into a single stream of `OffsetBatch`es. This
+ensures only a single stream is doing commits.
+
+In this example, each partition is processed in parallel, on separate fibers, while a single fiber is doing commits.

--- a/docs/creating-a-consumer.md
+++ b/docs/creating-a-consumer.md
@@ -1,0 +1,73 @@
+---
+id: creating-a-consumer
+title: "Creating a zio-kafka Consumer"
+---
+
+Create a consumer with `Consumer.make`, passing some `ConsumerSettings`:
+
+```scala
+import zio.*
+import zio.kafka.consumer.{ Consumer, ConsumerSettings }
+
+val consumerSettings: ConsumerSettings =
+  ConsumerSettings(List("localhost:9092")).withGroupId("group")
+val consumer: ZIO[Scope, Throwable, Consumer] =
+  Consumer.make(consumerSettings)
+```
+
+The consumer settings are not only used for passing properties to the underlying Kafka consumer. You can also configure
+zio-kafka features such as `rebalanceSafeCommits` (see [preventing duplicates](preventing-duplicates.md)), manual offset
+retrieval (see [offset retrieval](partition-assignment-and-offset-retrieval.md)), and the pre-fetch strategy (see
+[consumer tuning](consumer-tuning.md)).
+
+Notice that the consumer requires a `Scope` in the environment. When this scope closes, the consumer closes its
+connection with the Kafka cluster. A scope can be created with the `ZIO.scoped` method:
+
+```scala
+ZIO.scoped {
+  // make the consumer
+  // use the consumer
+}
+// end of scope, consumer has closed connection to Kafka cluster.
+```
+
+If the consumer is provided as a layer, you can use a scoped layer (see below).
+
+:::caution
+If no explicit `Scope` is provided, the consumer uses the application's scope, and it will only close the connection
+with the Kafka cluster when the application exits.
+:::
+
+## Providing a consumer as a layer
+
+If your application uses the [ZIO service pattern](https://zio.dev/reference/service-pattern/), the consumer can
+be provided as a layer. Here's an example of how to construct a consumer layer:
+
+```scala
+import zio.*
+import zio.kafka.consumer.{ Consumer, ConsumerSettings }
+
+val consumerLayer: Layer[Any, Throwable, Consumer] =
+  ZLayer.scoped { // (1)
+    val consumerSettings: ConsumerSettings =
+      ConsumerSettings(List("localhost:9092")).withGroupId("group")
+    Consumer.make(consumerSettings)
+  }
+```
+
+(1) By using `ZLayer.scoped`, the consumer is closed when the layer is no longer needed.
+
+## Consumer settings from a layer
+
+If you wish to create the `ConsumerSettings` and the `Consumer` from a layer, you can use `Consumer.live`. It takes
+the consumer settings and diagnostics settings as a layer and produces a consumer.
+
+The `provide` section of the main program could look like this:
+
+```scala
+.provide(
+  consumerSettingsLayer,
+  ZLayer.succeed(Diagnostics.NoOp),
+  Consumer.live
+)
+```

--- a/docs/example-of-consuming-producing-and-committing-offsets.md
+++ b/docs/example-of-consuming-producing-and-committing-offsets.md
@@ -3,7 +3,14 @@ id: example-of-consuming-producing-and-committing-offsets
 title: "Example of Consuming, Producing and Committing Offsets"
 ---
 
-This example shows how to consume messages from topic `topic_a` and produce transformed messages to `topic_b`, after which consumer offsets are committed. Processing is done in chunks using `ZStreamChunk` for more efficiency. Please note: ZIO consumer does not support automatic offset committing. As a result, it ignores the Kafka consumer setting `enable.auto.commit=true`. Developers should manually commit offsets using the provided commit methods, typically after processing messages or at appropriate points in their application logic.
+This example shows how to consume messages from topic `topic_a` and produce transformed messages to `topic_b`, after
+which consumer offsets are committed.
+
+Processing is done in chunks using `mapChunksZIO` for more efficiency.
+
+Please note: the ZIO consumer does not support automatic offset committing. As a result, it ignores the Kafka consumer
+setting `enable.auto.commit=true`. Developers should manually commit offsets using the provided commit methods,
+typically after processing messages or at appropriate points in their application logic.
 
 ```scala
 import zio.ZLayer
@@ -12,29 +19,33 @@ import zio.kafka.producer._
 import zio.kafka.serde._
 import org.apache.kafka.clients.producer.ProducerRecord
 
-val consumerSettings: ConsumerSettings = ConsumerSettings(List("localhost:9092")).withGroupId("group")
-val producerSettings: ProducerSettings = ProducerSettings(List("localhost:9092"))
+val consumerSettings: ConsumerSettings =
+  ConsumerSettings(List("localhost:9092")).withGroupId("group")
+val producerSettings: ProducerSettings =
+  ProducerSettings(List("localhost:9092"))
 
-val consumerAndProducer = 
-  ZLayer.scoped(Consumer.make(consumerSettings)) ++
-    ZLayer.scoped(Producer.make(producerSettings, Serde.int, Serde.string))
+for {
+  consumer <- Consumer.make(consumerSettings)
+  producer <- Producer.make(producerSettings, Serde.int, Serde.string)
+  _ <-
+    consumer
+      .plainStream(Subscription.topics("my-input-topic"), Serde.int, Serde.long)
+      .map { record =>
+        val key: Int = record.record.key()
+        val value: Long = record.record.value()
+        val newValue: String = value.toString
 
-val consumeProduceStream = Consumer
-  .plainStream(Subscription.topics("my-input-topic"), Serde.int, Serde.long)
-  .map { record =>
-    val key: Int    = record.record.key()
-    val value: Long = record.record.value()
-    val newValue: String = value.toString
+        val producerRecord: ProducerRecord[Int, String] =
+          new ProducerRecord("my-output-topic", key, newValue)
+        (producerRecord, record.offset)
+      }
+      .mapChunksZIO { chunk =>
+        val records = chunk.map(_._1)
+        val offsetBatch = OffsetBatch(chunk.map(_._2).toSeq)
 
-    val producerRecord: ProducerRecord[Int, String] = new ProducerRecord("my-output-topic", key, newValue)
-    (producerRecord, record.offset)
-  }
-  .mapChunksZIO { chunk =>
-    val records     = chunk.map(_._1)
-    val offsetBatch = OffsetBatch(chunk.map(_._2).toSeq)
-
-    Producer.produceChunk[Any, Int, String](records) *> offsetBatch.commit.as(Chunk(()))
-  }
-  .runDrain
-  .provideSomeLayer(consumerAndProducer)
+        producer.produceChunk[Any, Int, String](records) *>
+          offsetBatch.commit.as(Chunk(()))
+      }
+      .runDrain
+} yield ()
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,53 +69,55 @@ Now, we can run our ZIO Kafka Streaming application:
 ```scala
 import zio._
 import zio.kafka.consumer._
-import zio.kafka.producer.{Producer, ProducerSettings}
+import zio.kafka.producer.{ Producer, ProducerSettings }
 import zio.kafka.serde._
 import zio.stream.ZStream
 
-object MainApp extends ZIOAppDefault {
-  val producer: ZStream[Producer, Throwable, Nothing] =
-    ZStream
-      .repeatZIO(Random.nextIntBetween(0, Int.MaxValue))
-      .schedule(Schedule.fixed(2.seconds))
-      .mapZIO { random =>
-        Producer.produce[Any, Long, String](
-          topic = "random",
-          key = random % 4,
-          value = random.toString,
-          keySerializer = Serde.long,
-          valueSerializer = Serde.string
-        )
-      }
-      .drain
+object ReadmeExample extends ZIOAppDefault {
 
-  val consumer: ZStream[Consumer, Throwable, Nothing] =
-    Consumer
-      .plainStream(Subscription.topics("random"), Serde.long, Serde.string)
-      .tap(r => Console.printLine(r.value))
-      .map(_.offset)
-      .aggregateAsync(Consumer.offsetBatches)
-      .mapZIO(_.commit)
-      .drain
+  private val producerRun: ZIO[Any, Throwable, Unit] =
+    ZIO.scoped {
+      for {
+        producer <-
+          Producer.make(
+            ProducerSettings(List("localhost:29092"))
+          )
+        _ <- ZStream
+          .fromSchedule(Schedule.fixed(2.seconds))
+          .mapZIO(_ => Random.nextIntBetween(0, Int.MaxValue))
+          .mapZIO { random =>
+            producer.produce[Any, Long, String](
+              topic = "random-topic",
+              key = (random % 4).toLong,
+              value = random.toString,
+              keySerializer = Serde.long,
+              valueSerializer = Serde.string
+            )
+          }
+          .runDrain
+      } yield ()
+    }
 
-  def producerLayer =
-    ZLayer.scoped(
-      Producer.make(
-        settings = ProducerSettings(List("localhost:29092"))
-      )
-    )
+  private val consumerRun: ZIO[Any, Throwable, Unit] =
+    ZIO.scoped {
+      for {
+        consumer <-
+          Consumer.make(
+            ConsumerSettings(List("localhost:29092"))
+              .withGroupId("group")
+          )
+        _ <- consumer
+          .plainStream(Subscription.topics("random"), Serde.long, Serde.string)
+          .tap(r => Console.printLine(r.value))
+          .map(_.offset)
+          .aggregateAsync(Consumer.offsetBatches)
+          .mapZIO(_.commit)
+          .runDrain
+      } yield ()
+    }
 
-  def consumerLayer =
-    ZLayer.scoped(
-      Consumer.make(
-        ConsumerSettings(List("localhost:29092")).withGroupId("group")
-      )
-    )
-
-  override def run =
-    producer.merge(consumer)
-      .runDrain
-      .provide(producerLayer, consumerLayer)
+  override def run: ZIO[Any, Throwable, Unit] =
+    ZIO.raceFirst(producerRun, List(consumerRun))
 }
 ```
 

--- a/docs/partition-assignment-and-offset-retrieval.md
+++ b/docs/partition-assignment-and-offset-retrieval.md
@@ -11,7 +11,7 @@ title: "Partition Assignment And Offset Retrieval"
 | Topics matching a pattern                          | `Subscription.pattern("topic.*")`                       |
 | Manual partition assignment                        | `Subscription.manual("my_topic" -> 1, "my_topic" -> 2)` |
 
-By default `zio-kafka` will start streaming a partition from the last committed offset for the consumer group, or the latest message on the topic if no offset has yet been committed. You can also choose to store offsets outside of Kafka. This can be useful in cases where consistency between data stores and consumer offset is required.
+By default `zio-kafka` starts streaming a partition from the last committed offset for the consumer group, or the latest message on the topic if no offset has yet been committed. You can also choose to store offsets outside of Kafka. This can be useful in cases where consistency between data stores and consumer offset is required.
 
 | Use case                                                           | Method                                                                       |
 |--------------------------------------------------------------------|------------------------------------------------------------------------------|
@@ -19,4 +19,4 @@ By default `zio-kafka` will start streaming a partition from the last committed 
 | Offsets in Kafka, start at earliest message if no offset committed | `OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest)`                          |
 | Manual/external offset storage                                     | `Manual(getOffsets: Set[TopicPartition] => Task[Map[TopicPartition, Long]])` |
 
-For manual offset retrieval, the `getOffsets` function will be called for each topic-partition that is assigned to the consumer, either via Kafka's rebalancing or via a manual assignment.
+For manual offset retrieval, the `getOffsets` function is called for each topic-partition that is assigned to the consumer, either via Kafka's rebalancing or via a manual assignment.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -6,6 +6,7 @@ const sidebars = {
       collapsed: false,
       link: { type: "doc", id: "index" },
       items: [
+        "creating-a-consumer",
         "consuming-kafka-topics-using-zio-streams",
         "example-of-consuming-producing-and-committing-offsets",
         "partition-assignment-and-offset-retrieval",

--- a/zio-kafka-example/src/main/scala/zio/kafka/example/ReadmeExample.scala
+++ b/zio-kafka-example/src/main/scala/zio/kafka/example/ReadmeExample.scala
@@ -1,0 +1,56 @@
+// format: off
+// Manually formatted for the small width of readme
+package zio.kafka.example
+
+import zio._
+import zio.kafka.consumer._
+import zio.kafka.producer.{ Producer, ProducerSettings }
+import zio.kafka.serde._
+import zio.stream.ZStream
+
+object ReadmeExample extends ZIOAppDefault {
+
+  private val producerRun: ZIO[Any, Throwable, Unit] =
+    ZIO.scoped {
+      for {
+        producer <-
+          Producer.make(
+            ProducerSettings(List("localhost:29092"))
+          )
+        _ <- ZStream
+          .fromSchedule(Schedule.fixed(2.seconds))
+          .mapZIO(_ => Random.nextIntBetween(0, Int.MaxValue))
+          .mapZIO { random =>
+            producer.produce[Any, Long, String](
+              topic = "random-topic",
+              key = (random % 4).toLong,
+              value = random.toString,
+              keySerializer = Serde.long,
+              valueSerializer = Serde.string
+            )
+          }
+          .runDrain
+      } yield ()
+    }
+
+  private val consumerRun: ZIO[Any, Throwable, Unit] =
+    ZIO.scoped {
+      for {
+        consumer <-
+          Consumer.make(
+            ConsumerSettings(List("localhost:29092"))
+              .withGroupId("group")
+          )
+        _ <- consumer
+          .plainStream(Subscription.topics("random"), Serde.long, Serde.string)
+          .tap(r => Console.printLine(r.value))
+          .map(_.offset)
+          .aggregateAsync(Consumer.offsetBatches)
+          .mapZIO(_.commit)
+          .runDrain
+      } yield ()
+    }
+
+  override def run: ZIO[Any, Throwable, Unit] =
+    ZIO.raceFirst(producerRun, List(consumerRun))
+}


### PR DESCRIPTION
In preparation of removing the accessor method in zio-kafka 3.0.0, this change already removes them from the user documentation.

The diff looks a bit large because how to create a consumer was split to a different file.

File `writing-tests.md` is updated in a separate PR (#1449) as it involves code changes as well.