### PR TITLE
Explore event sourced rebalance listener

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -366,6 +366,9 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           } yield assertTrue(recordChunk.map(_.value).last == 0)
         },
         test("serialize concurrent transactions") {
+          // Warning: on fast machines this test is flaky.
+          // The problem is that when the consumer is reading from the topic, sometimes it only sees
+          // one of the 2 produced records since the second is still in transit.
           import Subscription._
 
           for {

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -59,19 +59,19 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
         event.rebalanceCallbacks.size == 4,
         event.rebalanceCallbacks(0) match {
           case AssignedRebalanceCallback(a, _) if a == Set(tp) => true
-          case _ => false
+          case _                                               => false
         },
         event.rebalanceCallbacks(1) match {
           case AssignedRebalanceCallback(a, _) if a == Set(tp4) => true
-          case _ => false
+          case _                                                => false
         },
         event.rebalanceCallbacks(2) match {
           case RevokedRebalanceCallback(r, _) if r == Set(tp2) => true
-          case _ => false
+          case _                                               => false
         },
         event.rebalanceCallbacks(3) match {
           case LostRebalanceCallback(l, _) if l == Set(tp3) => true
-          case _ => false
+          case _                                            => false
         }
       )
     },


### PR DESCRIPTION
In this experiment we remove even more logic from the rebalance listener; it now reports which callbacks happened and no longer collapses that information. This gives the runloop a full picture of what happened during the rebalance.

The logic stays exactly the same, it just moved to the runloop. This does however allow more complex logic if it becomes necessary.

This is a draft because I am not sure yet if this PR is an improvement.