### PR TITLE
Explore event sourced rebalance listener (alt)

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -366,6 +366,9 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           } yield assertTrue(recordChunk.map(_.value).last == 0)
         },
         test("serialize concurrent transactions") {
+          // Warning: on fast machines this test is flaky.
+          // The problem is that when the consumer is reading from the topic, sometimes it only sees
+          // one of the 2 produced records since the second is still in transit.
           import Subscription._
 
           for {


### PR DESCRIPTION
In this experiment we remove even more logic from the rebalance listener; it now reports which callbacks happened and no longer collapses that information. This gives the runloop a full picture of what happened during the rebalance.

For now, the logic stays exactly the same, it just moved to the runloop.

This an alternative implementation to #1467 that requires less code to achieve the same goal.