### PR TITLE
Enable `rebalanceSafeCommits` by default

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/admin/AdminSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/admin/AdminSpec.scala
@@ -288,7 +288,7 @@ object AdminSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         def consumeAndCommit(count: Long, topic: String, groupId: String) =
           ZIO.scoped {
             for {
-              consumer <- KafkaTestUtils.makeConsumer(topic, Some(groupId))
+              consumer <- KafkaTestUtils.makeConsumer(topic, Some(groupId), rebalanceSafeCommits = false)
               _ <- consumer
                      .plainStream[Kafka, String, String](Subscription.Topics(Set(topic)), Serde.string, Serde.string)
                      .take(count)
@@ -335,7 +335,7 @@ object AdminSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         def consumeAndCommit(count: Long, topic: String, groupId: String) =
           ZIO.scoped {
             for {
-              consumer <- KafkaTestUtils.makeConsumer(topic, Some(groupId))
+              consumer <- KafkaTestUtils.makeConsumer(topic, Some(groupId), rebalanceSafeCommits = false)
               _ <- consumer
                      .plainStream[Kafka, String, String](Subscription.Topics(Set(topic)), Serde.string, Serde.string)
                      .take(count)

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/SubscriptionsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/SubscriptionsSpec.scala
@@ -30,7 +30,7 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
         _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
 
-        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+        consumer <- KafkaTestUtils.makeConsumer(client, Some(group), rebalanceSafeCommits = false)
         records <-
           consumer
             .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
@@ -60,7 +60,7 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
         _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
 
-        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+        consumer <- KafkaTestUtils.makeConsumer(client, Some(group), rebalanceSafeCommits = false)
         records <-
           consumer
             .plainStream(Subscription.Pattern(s"$topic1".r), Serde.string, Serde.string)
@@ -92,7 +92,7 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
         _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
 
-        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+        consumer <- KafkaTestUtils.makeConsumer(client, Some(group), rebalanceSafeCommits = false)
         consumer0 =
           consumer
             .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
@@ -128,7 +128,7 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         firstMessagesRef <- Ref.make(("", ""))
         finalizersRef    <- Ref.make(Chunk.empty[String])
 
-        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+        consumer <- KafkaTestUtils.makeConsumer(client, Some(group), rebalanceSafeCommits = false)
 
         c1Fib <- consumer
                    .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
@@ -190,6 +190,7 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         consumer <- KafkaTestUtils.makeConsumer(
                       client,
                       Some(group),
+                      rebalanceSafeCommits = false,
                       properties = Map(ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> "10")
                     )
         _ <- consumer
@@ -216,7 +217,7 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
         _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
 
-        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+        consumer <- KafkaTestUtils.makeConsumer(client, Some(group), rebalanceSafeCommits = false)
         _ <-
           consumer
             .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
@@ -240,7 +241,7 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
 
         errored  <- Ref.make(false)
-        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+        consumer <- KafkaTestUtils.makeConsumer(client, Some(group), rebalanceSafeCommits = false)
         _ <- consumer
                .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
                .take(5)
@@ -262,7 +263,7 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
 
         recordsConsumed <- Ref.make(Chunk.empty[CommittableRecord[String, String]])
-        consumer        <- KafkaTestUtils.makeConsumer(client, Some(group))
+        consumer        <- KafkaTestUtils.makeConsumer(client, Some(group), rebalanceSafeCommits = false)
         _ <- ZIO.scoped {
                consumer
                  .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -133,7 +133,6 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
               lastEvent,
               consumer,
               assignedStreams = Chunk(streamControl),
-              rebalanceSafeCommits = true,
               committer = committer
             )
           _ <- listener.toRebalanceListener.onRevoked(Set(tp))
@@ -168,7 +167,6 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
               lastEvent,
               consumer,
               assignedStreams = Chunk(streamControl),
-              rebalanceSafeCommits = true,
               committer = committer
             )
           _ <- listener.toRebalanceListener.onRevoked(Set(tp))
@@ -187,7 +185,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
     assignedStreams: Chunk[PartitionStreamControl] = Chunk.empty,
     committer: Committer = new MockCommitter {},
     settings: ConsumerSettings = ConsumerSettings(List("")).withCommitTimeout(1.second),
-    rebalanceSafeCommits: Boolean = false
+    rebalanceSafeCommits: Boolean = true
   ): ZIO[Scope, Throwable, RebalanceCoordinator] =
     Semaphore
       .make(1)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -26,7 +26,7 @@ final case class ConsumerSettings(
   commitTimeout: Duration = ConsumerSettings.defaultCommitTimeout,
   offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(),
   rebalanceListener: RebalanceListener = RebalanceListener.noop,
-  rebalanceSafeCommits: Boolean = false,
+  rebalanceSafeCommits: Boolean = true,
   maxRebalanceDuration: Option[Duration] = None,
   fetchStrategy: FetchStrategy = QueueSizeBasedFetchStrategy(),
   metricLabels: Set[MetricLabel] = Set.empty,
@@ -172,7 +172,7 @@ final case class ConsumerSettings(
    * Make sure that all records from a single poll (see [[withMaxPollRecords maxPollRecords]]) can be processed in this
    * interval, even when there is no concurrency because the records are all in the same partition.
    *
-   * The default is equal to [[withMaxPollInterval maxPollInterval]]).
+   * The default is equal to [[withMaxPollInterval maxPollInterval]].
    */
   def withMaxStreamPullInterval(maxStreamPullInterval: Duration): ConsumerSettings =
     copy(maxStreamPullIntervalOption = Some(maxStreamPullInterval))
@@ -200,8 +200,8 @@ final case class ConsumerSettings(
 
   /**
    * @param value
-   *   Whether to hold up a rebalance until all offsets of consumed messages have been committed. The default is
-   *   `false`, but the recommended value is `true` as it prevents duplicate messages.
+   *   Whether to hold up a rebalance until all offsets of consumed messages have been committed. Since zio-kafka 3 the
+   *   default is `true` as it prevents duplicate messages.
    *
    * Use `false` when:
    *   - your streams do not commit, or
@@ -241,7 +241,7 @@ final case class ConsumerSettings(
    *
    * In this time zio-kafka awaits processing of records and the completion of commits.
    *
-   * By default this value is set to 3/5 of `maxPollInterval` which by default calculates to 3 minutes. Only values
+   * By default, this value is set to 3/5 of `maxPollInterval` which by default calculates to 3 minutes. Only values
    * between `commitTimeout` and `maxPollInterval` are useful. Lower values will make the rebalance callback be done
    * immediately, higher values lead to lost partitions.
    *


### PR DESCRIPTION
RebalanceSafeCommits mode prevents duplicates due to rebalances and is therefore now enabled by default.

Zio-kafka-testkit users will notice that its helper methods to create consumer settings or consumers now also enable rebalanceSafeCommits by default.

Most zio-kafka tests do not commit, or commit after the rebalance started (for example by using `take`). Therefore, we disable rebalanceSafeCommits in all these tests.

Fixes #1477.