### PR TITLE
Fix rebalance coordinator spec

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -46,7 +46,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
           tp2      = new TopicPartition("topic", 1)
           tp3      = new TopicPartition("topic", 2)
           tp4      = new TopicPartition("topic", 3)
-          listener <- makeCoordinator(lastEvent, consumer, rebalanceSafeCommits = true)
+          listener <- makeCoordinator(lastEvent, consumer, rebalanceSafeCommits = false)
           _        <- listener.toRebalanceListener.onAssigned(Set(tp))
           _        <- listener.toRebalanceListener.onAssigned(Set(tp4))
           _        <- listener.toRebalanceListener.onRevoked(Set(tp2))

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -270,7 +270,8 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
       )
     )
 
-  private implicit class RecordStreamOps(val s: ZStream[Any, Throwable, ByteArrayCommittableRecord]) extends AnyVal {
+  private implicit class RecordStreamOps(private val s: ZStream[Any, Throwable, ByteArrayCommittableRecord])
+      extends AnyVal {
     def completePromiseWhenOffsetSeen(
       offsetToSee: Long,
       offsetSeenPromise: Promise[Nothing, Unit]
@@ -289,7 +290,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
 
   }
 
-  private implicit class ZStreamTapChunks[R, E, A](val s: ZStream[R, E, A]) extends AnyVal {
+  private implicit class ZStreamTapChunks[R, E, A](private val s: ZStream[R, E, A]) extends AnyVal {
     def tapChunksZIO[R1 <: R, E1 >: E](f: Chunk[A] => ZIO[R1, E1, Any])(implicit trace: Trace): ZStream[R1, E1, A] =
       s.mapChunksZIO(chunk => f(chunk).as(chunk))
   }

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -117,7 +117,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
             _ <- streamControl.offerRecords(records)
 
             recordsPulledByStream <- Promise.make[Nothing, Unit]
-            committer <- LiveCommitter.make(10.seconds, Diagnostics.NoOp, mockMetrics, ZIO.unit)
+            committer             <- LiveCommitter.make(10.seconds, Diagnostics.NoOp, mockMetrics, ZIO.unit)
             _ <- streamControl.stream
                    .completePromiseWhenOffsetSeen(recordCount.toLong, recordsPulledByStream)
                    .tap(_ => ZIO.sleep(50.millis))
@@ -159,7 +159,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
             streamControl <- makeStreamControl(tp)
             recordCount = 3
             records     = createTestRecords(tp, recordCount)
-            _                     <- streamControl.offerRecords(records)
+            _ <- streamControl.offerRecords(records)
 
             recordsPulledByStream <- Promise.make[Nothing, Unit]
             _ <- streamControl.stream


### PR DESCRIPTION
Previously, some of the rebalanceSafeCommits tests passed regardless of whether rebalanceSafeCommits was enabled or not. This is now fixed.

Also:
- added test outlines
- made assertions more precise
- removed unnecessary code
- add a test for when rebalanceSafeCommits is disabled