### PR TITLE
Relax offset trait constraint

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
@@ -4,7 +4,7 @@ import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, OffsetAndMetad
 import org.apache.kafka.common.TopicPartition
 import zio._
 
-sealed trait Offset {
+trait Offset {
 
   def topic: String
   def partition: Int


### PR DESCRIPTION
Allows the offset trait to be extended outside of this library.

Addresses: https://github.com/zio/zio-kafka/issues/1487