### PR TITLE
More tests for rebalanceSafeCommit mode and Small stuff

### DIFF
--- a/docs/migrating-to-zio-kafka-3.md
+++ b/docs/migrating-to-zio-kafka-3.md
@@ -161,7 +161,11 @@ expect only a few very experienced users to make use of it. Therefore, only the 
 
 # 3. `restartStreamOnRebalancing` mode
 
-This mode will no longer be available in zio-kafka 3. Contact us on [Discord](https://discord.com/channels/629491597070827530/629497941719121960) for alternatives.
+This mode is longer be available in zio-kafka 3. With `restartStreamOnRebalancing` all streams are ended during a
+rebalance, even when the partition for that stream was not revoked. One of its purposes was to enable transactional
+consuming. Since zio-kafka 3 however, transactional consuming no longer needs this mode.
+
+If your goal is to [prevent duplicates](preventing-duplicates.md), please use `rebalanceSafeCommits` instead.
 
 # Other changes?
 

--- a/docs/migrating-to-zio-kafka-3.md
+++ b/docs/migrating-to-zio-kafka-3.md
@@ -3,16 +3,26 @@ id: migrating-to-zio-kafka-3
 title: "Migrating to zio-kafka 3"
 ---
 
+Zio-kafka 3.0.0 brings a number of backwards incompatible changes:
+
+1. Removal of all deprecated methods, _including accessor methods,_
+2. The transactional producer is now much easier to use, 
+3. `restartStreamOnRebalancing` mode is no longer supported.
+
+This document helps you migrate from zio-kafka 2 to zio-kafka 3.
+
+# 1. Deprecations
+
 Zio-kafka 3.0.0 removes everything that was deprecated in the zio-kafka 2.x series. In particular, this includes
 accessor methods. To prepare for zio-kafka 3.0, _you should always first migrate to zio-kafka 2.11.0_ and solve all
 deprecation issues, using this page as a guide.
 
-# Renamed methods
+## Renamed methods
 
 Some methods have just been renamed. Read the deprecation message and try the new method name. If it compiles, you're
 done. Otherwise, read on.
 
-# Consumer, Producer and TransactionalProducer accessor methods
+## Consumer, Producer and TransactionalProducer accessor methods
 
 Accessor methods are little helper methods that look up a service from the environment, and then forward your call to
 that service. Accessor methods have not been recommended for some time and are now deprecated. The
@@ -22,7 +32,7 @@ services.
 All accessor methods provided by zio-kafka are deprecated in zio-kafka 2.11 and will be removed in zio-kafka 3.0. If
 you use these accessor methods follow one of these approaches:
 
-## Use the ZIO Service pattern
+### Use the ZIO Service pattern
 
 This is the best option. For established codebases it may be a lot of work to get here. If you are already follow
 this pattern, using it for zio-kafka services as well will be easy. See [ZIO service pattern](https://zio.dev/reference/service-pattern/) for more information.
@@ -60,7 +70,7 @@ case class ServiceLive(consumer: Consumer) extends Service {
 Constructing a `Consumer` layer is described in [creating a consumer](creating-a-consumer.md). Constructing a
 `Producer` or `TransactionalProducer` layer works in a similar way.
 
-## YOLO, use `ZIO.service` everywhere
+### YOLO, use `ZIO.service` everywhere
 
 The other option is to replace all accessor methods of `Consumer`, `Producer` and `TransactionalProducer` as follows:
 
@@ -78,7 +88,7 @@ for {
 } yield () 
 ```
 
-# Zio-test-kit
+## Zio-test-kit
 
 Zio-kafka provides a `zio-kafka-testkit` library to help you test your code using zio-kafka. Several methods in the
 `KafkaTestUtils` class have been replaced:
@@ -143,7 +153,13 @@ for {
 } yield ()
 ```
 
-# `restartStreamOnRebalancing` mode
+# 2. Changes in the transactional producer
+
+The transactional producer is now much easier to use. The zio-kafka 2.x transactional API is so complicated that we
+expect only a few very experienced users to make use of it. Therefore, only the new API is described in
+[transactions](transactions.md).
+
+# 3. `restartStreamOnRebalancing` mode
 
 This mode will no longer be available in zio-kafka 3. Contact us on [Discord](https://discord.com/channels/629491597070827530/629497941719121960) for alternatives.
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -60,7 +60,27 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                        .take(5)
                        .runCollect
           kvOut = records.map(r => (r.record.key, r.record.value)).toList
-        } yield assert(kvOut)(equalTo(kvs))
+        } yield assertTrue(kvOut == kvs)
+      },
+      test("plainStream in rebalanceSafeCommits mode with commits") {
+        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          topic  <- randomTopic
+          client <- randomClient
+          group  <- randomGroup
+
+          producer <- KafkaTestUtils.makeProducer
+          _        <- KafkaTestUtils.produceMany(producer, topic, kvs)
+
+          settings <- KafkaTestUtils.consumerSettings(client, Some(group), `max.poll.records` = 1)
+          consumer <- Consumer.make(settings)
+          records <- consumer
+                       .plainStream(Subscription.Topics(Set(topic)), Serde.string, Serde.string)
+                       .tap(_.offset.commit)
+                       .take(5)
+                       .runCollect
+          kvOut = records.map(r => (r.record.key, r.record.value)).toList
+        } yield assertTrue(kvOut == kvs)
       },
       test("chunk sizes") {
         val kvs = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
@@ -313,14 +333,13 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           group  <- randomGroup
           client <- randomClient
 
-          consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
           producer <- KafkaTestUtils.makeProducer
-
-          keepProducing <- Ref.make(true)
           _ <- KafkaTestUtils
                  .produceOne(producer, topic, "key", "value")
-                 .repeatWhileZIO(_ => keepProducing.get)
-                 .fork
+                 .forever
+                 .forkScoped
+
+          consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
           _ <- consumer
                  .partitionedStream(Subscription.topics(topic), Serde.string, Serde.string)
                  .flatMapPar(Int.MaxValue) { case (_, partitionStream) =>
@@ -332,7 +351,6 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                  }
                  .runDrain
                  .zipLeft(ZIO.logDebug("Stream completed"))
-          _ <- keepProducing.set(false)
         } yield assertCompletes
       },
       test("process outstanding commits after a graceful shutdown") {
@@ -622,6 +640,62 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                             .fork
           _ <- consumer1Fib.join
           _ <- consumer2Fib.join
+        } yield assertCompletes
+      },
+      test("handle rebalancing by completing topic-partition streams - rebalanceSafeCommits") {
+        val nrMessages     = 50
+        val partitionCount = 6 // Must be even and strictly positive
+
+        for {
+          // Produce messages on several partitions
+          topic   <- randomTopic
+          group   <- randomGroup
+          client1 <- randomClient
+          client2 <- randomClient
+
+          _        <- KafkaTestUtils.createCustomTopic(topic, partitionCount)
+          producer <- KafkaTestUtils.makeProducer
+          _ <- ZIO.foreachDiscard(1 to nrMessages) { i =>
+                 KafkaTestUtils
+                   .produceMany(producer, topic, partition = i % partitionCount, kvs = List(s"key$i" -> s"msg$i"))
+               }
+
+          consumer1 <- KafkaTestUtils.makeConsumer(client1, Some(group), rebalanceSafeCommits = true)
+          consumer2 <- KafkaTestUtils.makeConsumer(client2, Some(group), rebalanceSafeCommits = true)
+
+          // Consume messages
+          subscription = Subscription.topics(topic)
+          assignedPartitionsRef <- Ref.make(Set.empty[Int]) // Set of partition numbers
+          // Create a Promise to signal when consumer1 has processed half the partitions
+          consumer1Ready <- Promise.make[Nothing, Unit]
+          _ <- consumer1
+                 .partitionedStream(subscription, Serde.string, Serde.string)
+                 .flatMapPar(partitionCount) { case (tp, partitionStream) =>
+                   ZStream
+                     .fromZIO(
+                       consumer1Ready
+                         .succeed(())
+                         .whenZIO(
+                           assignedPartitionsRef
+                             .updateAndGet(_ + tp.partition())
+                             .map(_.size >= (partitionCount / 2))
+                         ) *>
+                         partitionStream.tap(_.offset.commit).runDrain
+                     )
+                     .as(tp)
+                 }
+                 .take(partitionCount.toLong / 2)
+                 .runDrain
+                 .forkScoped
+          _ <- consumer1Ready.await
+          _ <- consumer2
+                 .partitionedStream(subscription, Serde.string, Serde.string)
+                 .take(partitionCount.toLong / 2)
+                 .flatMapPar(partitionCount) { case (_, partitionStream) =>
+                   partitionStream.tap(_.offset.commit)
+                 }
+                 .runDrain
+                 .forkScoped
         } yield assertCompletes
       },
       test("produce diagnostic events when rebalancing") {
@@ -1184,94 +1258,6 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           _      <- allAssignments.update(_ - 1)
           _      <- check(Set(0))
           _      <- fiber0.interrupt
-        } yield assertCompletes
-      },
-      test("handles RebalanceInProgressExceptions transparently") {
-        val nrPartitions = 5
-        val nrMessages   = 10000
-
-        def makeConsumer(clientId: String, groupId: String) =
-          KafkaTestUtils
-            .consumerSettings(
-              clientId = clientId,
-              groupId = Some(groupId),
-              clientInstanceId = None,
-              properties = Map(
-                ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG -> classOf[CooperativeStickyAssignor].getName
-              )
-            )
-            .map(_.withPollTimeout(500.millis))
-            .flatMap(settings => Consumer.make(settings))
-
-        for {
-          // Produce messages on several partitions
-          topic <- randomTopic
-          group <- randomGroup
-
-          _        <- KafkaTestUtils.createCustomTopic(topic, nrPartitions)
-          producer <- KafkaTestUtils.makeProducer
-          _ <- ZIO
-                 .foreachDiscard(1 to nrMessages) { i =>
-                   KafkaTestUtils
-                     .produceMany(producer, topic, partition = i % nrPartitions, kvs = List(s"key$i" -> s"msg$i"))
-                 }
-                 .forkScoped
-
-          // Consume messages
-          messagesReceivedConsumer1 <- Ref.make[Int](0)
-          messagesReceivedConsumer2 <- Ref.make[Int](0)
-          drainCount                <- Ref.make(0)
-          subscription = Subscription.topics(topic)
-          stopConsumer1 <- Promise.make[Nothing, Unit]
-          consumer1     <- makeConsumer("consumer1", group)
-          fib <-
-            ZIO
-              .logAnnotate("consumer", "1") {
-                consumer1
-                  .partitionedAssignmentStream(subscription, Serde.string, Serde.string)
-                  .rechunk(1)
-                  .mapZIOPar(16) { partitions =>
-                    ZIO.logDebug(s"Consumer 1 got new partition assignment: ${partitions.map(_._1.toString)}") *>
-                      ZStream
-                        .fromIterable(partitions.map(_._2))
-                        .flatMapPar(Int.MaxValue)(s => s)
-                        .mapZIO(record => messagesReceivedConsumer1.update(_ + 1).as(record))
-                        .map(_.offset)
-                        .aggregateAsync(Consumer.offsetBatches)
-                        .mapZIO(offsetBatch => offsetBatch.commit)
-                        .runDrain
-                  }
-                  .mapZIO(_ => drainCount.updateAndGet(_ + 1))
-                  .interruptWhen(stopConsumer1.await)
-                  .runDrain
-                  .tapError(e => ZIO.logErrorCause(e.getMessage, Cause.fail(e)))
-              }
-              .forkScoped
-
-          _ <- messagesReceivedConsumer1.get
-                 .repeat(Schedule.recurUntil((n: Int) => n >= 20) && Schedule.fixed(100.millis))
-          _ <- ZIO.logDebug("Starting consumer 2")
-
-          consumer2 <- makeConsumer("consumer2", group)
-          fib2 <-
-            ZIO
-              .logAnnotate("consumer", "2") {
-                consumer2
-                  .plainStream(subscription, Serde.string, Serde.string)
-                  .mapZIO(record => messagesReceivedConsumer2.update(_ + 1).as(record))
-                  .map(_.offset)
-                  .aggregateAsync(Consumer.offsetBatches)
-                  .mapZIO(offsetBatch => offsetBatch.commit)
-                  .runDrain
-                  .tapError(e => ZIO.logErrorCause("Error in consumer 2", Cause.fail(e)))
-              }
-              .forkScoped
-
-          _ <- messagesReceivedConsumer2.get
-                 .repeat(Schedule.recurUntil((n: Int) => n >= 20) && Schedule.fixed(100.millis))
-          _ <- stopConsumer1.succeed(())
-          _ <- fib.join
-          _ <- fib2.interrupt
         } yield assertCompletes
       },
       suite("does not process messages twice for transactional producer, even when rebalancing")({

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -294,7 +294,7 @@ object KafkaTestUtils {
   // -----------------------------------------------------------------------------------------
 
   /**
-   * Makes `ConsumerSettings` for a transactional consumer, use in tests.
+   * Makes `ConsumerSettings` for a transactional consumer, for use in tests.
    */
   def transactionalConsumerSettings(
     groupId: String,
@@ -314,7 +314,7 @@ object KafkaTestUtils {
       rebalanceSafeCommits = rebalanceSafeCommits,
       properties = properties
     )
-      .map(_.withProperties(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed"))
+      .map(_.withReadCommitted())
 
   /**
    * Makes a transactional `Consumer` for use in tests.

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -121,6 +121,22 @@ object KafkaTestUtils {
     producer.produce[Any, String, String](new ProducerRecord(topic, key, message), Serde.string, Serde.string)
 
   /**
+   * Produce a single message to the given partition of a topic.
+   */
+  def produceOne(
+    producer: Producer,
+    topic: String,
+    partition: Int,
+    key: String,
+    message: String
+  ): ZIO[Any, Throwable, RecordMetadata] =
+    producer.produce[Any, String, String](
+      new ProducerRecord(topic, partition, key, message),
+      Serde.string,
+      Serde.string
+    )
+
+  /**
    * Produce many messages to the given partition of a topic.
    */
   def produceMany(

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -172,7 +172,7 @@ final case class ConsumerSettings(
    * Make sure that all records from a single poll (see [[withMaxPollRecords maxPollRecords]]) can be processed in this
    * interval, even when there is no concurrency because the records are all in the same partition.
    *
-   * The default is equal to [[withMaxPollInterval maxPollInterval]]).
+   * The default is equal to [[withMaxPollInterval maxPollInterval]].
    */
   def withMaxStreamPullInterval(maxStreamPullInterval: Duration): ConsumerSettings =
     copy(maxStreamPullIntervalOption = Some(maxStreamPullInterval))
@@ -241,7 +241,7 @@ final case class ConsumerSettings(
    *
    * In this time zio-kafka awaits processing of records and the completion of commits.
    *
-   * By default this value is set to 3/5 of `maxPollInterval` which by default calculates to 3 minutes. Only values
+   * By default, this value is set to 3/5 of `maxPollInterval` which by default calculates to 3 minutes. Only values
    * between `commitTimeout` and `maxPollInterval` are useful. Lower values will make the rebalance callback be done
    * immediately, higher values lead to lost partitions.
    *


### PR DESCRIPTION
More tests for rebalanceSafeCommit mode.

Also:
- Improve structure of zio-kafka 3 migration docs.
- Remove redundant integration test. The behavior that should be tested is already covered in a unit test in `CommitterSpec`. The removed integration test probably doesn't test the wanted behavior anyway.
- Use `forkScoped` for endless producing in a unit test instead of a `Ref`.
- Use ConsumerSettings helper method where possible.
- Small spelling fixes.