### PR TITLE
Improve documentation about duration of rebalances

### DIFF
--- a/docs/preventing-duplicates.md
+++ b/docs/preventing-duplicates.md
@@ -17,18 +17,21 @@ val consumerSettings: ConsumerSettings =
     .withGroupId("group")
     .withRebalanceSafeCommits(true)       // enable rebalance-safe-commits mode
     .withMaxRebalanceDuration(30.seconds) // defaults to 3 minutes
+    .withCommitTimeout(15.seconds)        // defaults to 15 seconds
 ```
 
 With rebalance-safe-commits mode enabled, rebalances are held up for up to max-rebalance-duration to wait for pending
 commits to be completed. Once pending commits are completed, it is safe for another consumer in the group to take over
 a partition.
 
-For this to work correctly, your program must process a chunk of records within max-rebalance-duration. The clock
-starts the moment the chunk is pushed into the stream and ends when the commits for these records complete.
+For this to work correctly, your program must process a chunk (of up to `max.poll.records` records) within the
+configured max-rebalance-duration. The clock starts the moment the chunk is pushed into the stream and ends when the
+commits for these records complete. Zio-kafka uses `commit-timeout` as the worse case time to commit. Therefore, with
+the default settings, your program has 2 minutes and 45 seconds until the offsets should be committed.
 
-In addition, your program must commit the offsets of consumed records. The most straightforward way is to commit to the
-Kafka brokers. This is done by calling `.commit` on the offset of consumed records (see the consumer documentation).
-However, there are more options: external commits and transactional producing.
+It is probably clear now that your program should commit the offsets of consumed records. The most straightforward way
+is to commit to the kafka brokers. This is done by calling `.commit` on the offset of consumed records (see the consumer
+documentation). However, there are more options: external commits and transactional producing.
 
 ### Commit to an external system
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -85,6 +85,12 @@ final case class ConsumerSettings(
   def withCloseTimeout(timeout: Duration): ConsumerSettings =
     copy(closeTimeout = timeout)
 
+  /**
+   * The maximum time that zio-kafka waits for a commit to complete.
+   *
+   * Note: this configuration also affects the duration in which records should be processed when `rebalanceSafeCommits`
+   * is enabled.
+   */
   def withCommitTimeout(timeout: Duration): ConsumerSettings =
     copy(commitTimeout = timeout)
 
@@ -220,7 +226,10 @@ final case class ConsumerSettings(
    * messages until the revoked streams are ready committing.
    *
    * Rebalances are held up for at most 3/5 of `maxPollInterval` (see [[withMaxPollInterval]]), by default this
-   * calculates to 3 minutes. See [[#withMaxRebalanceDuration]] to change the default.
+   * calculates to 3 minutes but this value can be changed with [[#withMaxRebalanceDuration]]. In this time your program
+   * should be able to process up to [[withMaxPollRecords maxPollRecords]] records, including commits! Commits take time
+   * as well. Zio-kafka assumes [[#withCommitTimeout]] as worse case (defaults to 15 seconds). Therefore, with all
+   * default settings, your program has 2 minutes and 45 seconds to process and commit the records.
    *
    * External commits (that is, commits to an external system, e.g. a relational database) must be registered to the
    * consumer with [[Consumer.registerExternalCommits]].


### PR DESCRIPTION
The documentation now documents that commit-time also affects rebalances when rebalanceSafeCommits is enabled.