### PR TITLE
Preparing for producer diagnostics (2.x)

### DIFF
--- a/docs/creating-a-consumer.md
+++ b/docs/creating-a-consumer.md
@@ -67,7 +67,7 @@ The `provide` section of the main program could look like this:
 ```scala
 .provide(
   consumerSettingsLayer,
-  ZLayer.succeed(Diagnostics.NoOp),
+  ZLayer.succeed(Consumer.NoDiagnostics),
   Consumer.live
 )
 ```

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -14,7 +14,8 @@ object MimaSettings {
         Seq(
           mimaPreviousArtifacts := Set(organization.value %% name.value % binCompatVersion),
           mimaBinaryIssueFilters ++= Seq(
-            exclude[Problem]("zio.kafka.consumer.internal.*")
+            exclude[Problem]("zio.kafka.consumer.internal.*"),
+            exclude[Problem]("zio.kafka.diagnostics.internal.*")
           ),
           mimaFailOnProblem := failOnProblem
         )

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaConsumerBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaConsumerBenchmark.scala
@@ -3,8 +3,8 @@ package zio.kafka.bench
 import org.openjdk.jmh.annotations._
 import zio.kafka.admin.AdminClient.NewTopic
 import zio.kafka.bench.ZioBenchmark.randomThing
-import zio.kafka.consumer.diagnostics.Diagnostics
 import zio.kafka.consumer.{ Consumer, Offset, OffsetBatch, Subscription }
+import zio.kafka.diagnostics.Diagnostics
 import zio.kafka.serde.Serde
 import zio.kafka.testkit.Kafka
 import zio.kafka.testkit.KafkaTestUtils

--- a/zio-kafka-example/src/main/scala/zio/kafka/example/Main.scala
+++ b/zio-kafka-example/src/main/scala/zio/kafka/example/Main.scala
@@ -2,7 +2,6 @@ package zio.kafka.example
 
 import io.github.embeddedkafka.{ EmbeddedK, EmbeddedKafka, EmbeddedKafkaConfig }
 import zio._
-import zio.kafka.consumer.diagnostics.Diagnostics
 import zio.kafka.consumer.{ Consumer, ConsumerSettings, Subscription }
 import zio.kafka.serde.Serde
 import zio.logging.backend.SLF4J
@@ -67,7 +66,7 @@ object Main extends ZIOAppDefault {
       runConsumerStream
         .provide(
           consumerSettings,
-          ZLayer.succeed(Diagnostics.NoOp),
+          ZLayer.succeed(Consumer.NoDiagnostics),
           Consumer.live,
           MyKafka.embedded
         )

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -10,14 +10,10 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import zio._
 import zio.kafka.ZIOSpecDefaultSlf4j
-import zio.kafka.consumer.Consumer.{ AutoOffsetStrategy, CommitTimeout, OffsetRetrieval }
-import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization
-import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization.{
-  ConsumerFinalized,
-  RunloopFinalized,
-  SubscriptionFinalized
-}
-import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
+import zio.kafka.consumer.Consumer.{ AutoOffsetStrategy, CommitTimeout, ConsumerDiagnostics, OffsetRetrieval }
+import zio.kafka.consumer.diagnostics.DiagnosticEvent
+import zio.kafka.consumer.diagnostics.DiagnosticEvent.{ ConsumerFinalized, RunloopFinalized, SubscriptionFinalized }
+import zio.kafka.diagnostics.{ Diagnostics, SlidingDiagnostics }
 import zio.kafka.producer.TransactionalProducer
 import zio.kafka.serde.Serde
 import zio.kafka.testkit.{ Kafka, KafkaRandom, KafkaTestUtils }
@@ -625,64 +621,62 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         val partitionCount = 6
 
         ZIO.scoped {
-          Diagnostics.SlidingQueue
-            .make()
-            .flatMap { diagnostics =>
-              for {
-                // Produce messages on several partitions
-                topic   <- randomTopic
-                group   <- randomGroup
-                client1 <- randomClient
-                client2 <- randomClient
+          SlidingDiagnostics.make[DiagnosticEvent]().flatMap { diagnostics =>
+            for {
+              // Produce messages on several partitions
+              topic   <- randomTopic
+              group   <- randomGroup
+              client1 <- randomClient
+              client2 <- randomClient
 
-                _        <- KafkaTestUtils.createCustomTopic(topic, partitionCount)
-                producer <- KafkaTestUtils.makeProducer
-                _ <- ZIO.foreachDiscard(1 to nrMessages) { i =>
-                       KafkaTestUtils
-                         .produceMany(producer, topic, partition = i % partitionCount, kvs = List(s"key$i" -> s"msg$i"))
-                     }
+              _        <- KafkaTestUtils.createCustomTopic(topic, partitionCount)
+              producer <- KafkaTestUtils.makeProducer
+              _ <- ZIO.foreachDiscard(1 to nrMessages) { i =>
+                     KafkaTestUtils
+                       .produceMany(producer, topic, partition = i % partitionCount, kvs = List(s"key$i" -> s"msg$i"))
+                   }
 
-                consumer1 <- KafkaTestUtils.makeConsumer(client1, Some(group), diagnostics = diagnostics)
-                consumer2 <- KafkaTestUtils.makeConsumer(client2, Some(group))
+              consumer1 <- KafkaTestUtils.makeConsumer(client1, Some(group), diagnostics = diagnostics)
+              consumer2 <- KafkaTestUtils.makeConsumer(client2, Some(group))
 
-                // Consume messages
-                subscription = Subscription.topics(topic)
-                consumer1Ready        <- Promise.make[Nothing, Unit]
-                assignedPartitionsRef <- Ref.make(Set.empty[Int]) // Set of partition numbers
-                consumer1Fib <- consumer1
-                                  .partitionedStream(subscription, Serde.string, Serde.string)
-                                  .flatMapPar(partitionCount) { case (tp, partition) =>
-                                    ZStream
-                                      .fromZIO(
-                                        consumer1Ready
-                                          .succeed(())
-                                          .whenZIO(
-                                            assignedPartitionsRef
-                                              .updateAndGet(_ + tp.partition())
-                                              .map(_.size >= (partitionCount / 2))
-                                          ) *>
-                                          partition.runDrain
-                                      )
-                                      .as(tp)
-                                  }
-                                  .take(partitionCount.toLong / 2)
-                                  .runDrain
-                                  .fork
-                diagnosticStream <- ZStream
-                                      .fromQueue(diagnostics.queue)
-                                      .collect { case rebalance: DiagnosticEvent.Rebalance => rebalance }
-                                      .runCollect
-                                      .fork
-                _ <- consumer1Ready.await
-                consumer2Fib <- consumer2
-                                  .partitionedStream(subscription, Serde.string, Serde.string)
-                                  .take(partitionCount.toLong / 2)
-                                  .runDrain
-                                  .fork
-                _ <- consumer1Fib.join
-                _ <- consumer2Fib.join
-              } yield diagnosticStream.join
-            }
+              // Consume messages
+              subscription = Subscription.topics(topic)
+              consumer1Ready        <- Promise.make[Nothing, Unit]
+              assignedPartitionsRef <- Ref.make(Set.empty[Int]) // Set of partition numbers
+              consumer1Fib <- consumer1
+                                .partitionedStream(subscription, Serde.string, Serde.string)
+                                .flatMapPar(partitionCount) { case (tp, partition) =>
+                                  ZStream
+                                    .fromZIO(
+                                      consumer1Ready
+                                        .succeed(())
+                                        .whenZIO(
+                                          assignedPartitionsRef
+                                            .updateAndGet(_ + tp.partition())
+                                            .map(_.size >= (partitionCount / 2))
+                                        ) *>
+                                        partition.runDrain
+                                    )
+                                    .as(tp)
+                                }
+                                .take(partitionCount.toLong / 2)
+                                .runDrain
+                                .fork
+              diagnosticStream <- ZStream
+                                    .fromQueue(diagnostics.queue)
+                                    .collect { case rebalance: DiagnosticEvent.Rebalance => rebalance }
+                                    .runCollect
+                                    .fork
+              _ <- consumer1Ready.await
+              consumer2Fib <- consumer2
+                                .partitionedStream(subscription, Serde.string, Serde.string)
+                                .take(partitionCount.toLong / 2)
+                                .runDrain
+                                .fork
+              _ <- consumer1Fib.join
+              _ <- consumer2Fib.join
+            } yield diagnosticStream.join
+          }
         }.flatten
           .map(diagnosticEvents => assert(diagnosticEvents.size)(isGreaterThanEqualTo(2)))
       },
@@ -975,7 +969,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           clientId: String,
           groupId: String,
           rebalanceSafeCommits: Boolean,
-          diagnostics: Diagnostics
+          diagnostics: ConsumerDiagnostics
         ): ZIO[Scope with Kafka, Throwable, Consumer] =
           for {
             settings <- KafkaTestUtils.consumerSettings(
@@ -1009,7 +1003,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                  .fork
           _                       <- ZIO.logDebug("Starting consumer 1")
           rebalanceEndTimePromise <- Promise.make[Nothing, Instant]
-          c1Diagnostics = new Diagnostics {
+          c1Diagnostics = new ConsumerDiagnostics {
                             override def emit(event: => DiagnosticEvent): UIO[Unit] = event match {
                               case r: DiagnosticEvent.Rebalance if r.assigned.size == 1 =>
                                 ZIO.logDebug(s"Rebalance finished: $r") *>
@@ -1592,7 +1586,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         test(
           "Booting a Consumer to do something else than consuming should not fail with a timeout exception"
         ) {
-          def test(diagnostics: Diagnostics) =
+          def test(diagnostics: ConsumerDiagnostics) =
             for {
               clientId <- randomClient
               settings <- KafkaTestUtils.consumerSettings(
@@ -1604,18 +1598,18 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             } yield assertCompletes
 
           for {
-            diagnostics <- Diagnostics.SlidingQueue.make(1000)
+            diagnostics <- SlidingDiagnostics.make[DiagnosticEvent](1000)
             testResult <- ZIO.scoped {
                             test(diagnostics)
                           }
-            finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isInstanceOf[Finalization]))
+            finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isFinalizationEvent))
           } yield testResult && assert(finalizationEvents)(hasSameElements(Chunk(ConsumerFinalized)))
         },
         suite(
           "Ordering of finalizers matters. If subscriptions are finalized after the runloop, it creates a deadlock"
         )(
           test("When not consuming, the Runloop is not started so only the Consumer is finalized") {
-            def test(diagnostics: Diagnostics): ZIO[Scope & Kafka, Throwable, TestResult] =
+            def test(diagnostics: ConsumerDiagnostics): ZIO[Scope & Kafka, Throwable, TestResult] =
               for {
                 clientId <- randomClient
                 settings <- KafkaTestUtils.consumerSettings(clientId = clientId)
@@ -1623,17 +1617,17 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
               } yield assertCompletes
 
             for {
-              diagnostics <- Diagnostics.SlidingQueue.make(1000)
+              diagnostics <- SlidingDiagnostics.make[DiagnosticEvent](1000)
               testResult <- ZIO.scoped {
                               test(diagnostics)
                             }
-              finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isInstanceOf[Finalization]))
+              finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isFinalizationEvent))
             } yield testResult && assert(finalizationEvents)(hasSameElements(Chunk(ConsumerFinalized)))
           },
           test("When consuming, the Runloop is started. The finalization orders matters to avoid a deadlock") {
             // This test ensures that we're not inadvertently introducing a deadlock by changing the order of finalizers.
 
-            def test(diagnostics: Diagnostics): ZIO[Scope & Kafka, Throwable, TestResult] =
+            def test(diagnostics: ConsumerDiagnostics): ZIO[Scope & Kafka, Throwable, TestResult] =
               for {
                 clientId <- randomClient
                 topic    <- randomTopic
@@ -1655,11 +1649,11 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
               } yield assert(consumed0)(equalTo(1L)) && assert(consumed1)(equalTo(1L))
 
             for {
-              diagnostics <- Diagnostics.SlidingQueue.make(1000)
+              diagnostics <- SlidingDiagnostics.make[DiagnosticEvent](1000)
               testResult <- ZIO.scoped {
                               test(diagnostics)
                             }
-              finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isInstanceOf[Finalization]))
+              finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isFinalizationEvent))
             } yield testResult && assert(finalizationEvents)(
               // The order is very important.
               // The subscription must be finalized before the runloop, otherwise it creates a deadlock.
@@ -1680,7 +1674,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             val messagesToConsumeBeforeStop     = 1000 // Adjust this threshold as needed
             val kvs: Iterable[(String, String)] = Iterable.tabulate(numberOfMessages)(i => (s"key-$i", s"msg-$i"))
 
-            def test(diagnostics: Diagnostics): ZIO[Scope & Kafka, Throwable, TestResult] =
+            def test(diagnostics: ConsumerDiagnostics): ZIO[Scope & Kafka, Throwable, TestResult] =
               for {
                 clientId <- randomClient
                 topic    <- randomTopic
@@ -1720,11 +1714,11 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                 assert(consumed1)(equalTo(numberOfMessages.toLong))
 
             for {
-              diagnostics <- Diagnostics.SlidingQueue.make(1000)
+              diagnostics <- SlidingDiagnostics.make[DiagnosticEvent](1000)
               testResult <- ZIO.scoped {
                               test(diagnostics)
                             }
-              finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isInstanceOf[Finalization]))
+              finalizationEvents <- diagnostics.queue.takeAll.map(_.filter(_.isFinalizationEvent))
             } yield testResult && assert(finalizationEvents)(
               // The order is very important.
               // The subscription must be finalized before the runloop, otherwise it creates a deadlock.
@@ -1764,5 +1758,14 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
       .provideSomeShared[Scope](
         Kafka.embedded
       ) @@ withLiveClock @@ timeout(2.minutes) @@ TestAspect.timed
+
+  private final implicit class ConsumerDiagnosticsOps(private val event: DiagnosticEvent) extends AnyVal {
+    def isFinalizationEvent: Boolean = event match {
+      case SubscriptionFinalized => true
+      case RunloopFinalized      => true
+      case ConsumerFinalized     => true
+      case _                     => false
+    }
+  }
 
 }

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/diagnostics/DiagnosticsStillCompilesCheck.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/diagnostics/DiagnosticsStillCompilesCheck.scala
@@ -1,0 +1,27 @@
+package zio.kafka.consumer.diagnostics
+
+import zio._
+
+import scala.annotation.nowarn
+
+/**
+ * Check that the type aliases introduced with zio-kafka 2.12.0 still compile code written against zio-kafka 2.11.x.
+ */
+//noinspection ScalaDeprecation
+@nowarn("msg=deprecated")
+object DiagnosticsStillCompilesCheck {
+
+  class MyDiagnostics extends zio.kafka.consumer.diagnostics.Diagnostics {
+    override def emit(event: => DiagnosticEvent): UIO[Unit] =
+      event match {
+        case _: DiagnosticEvent.Poll                            => ZIO.unit
+        case _: DiagnosticEvent.Request                         => ZIO.unit
+        case _: DiagnosticEvent.Commit                          => ZIO.unit
+        case _: DiagnosticEvent.Rebalance                       => ZIO.unit
+        case DiagnosticEvent.Finalization.SubscriptionFinalized => ZIO.unit
+        case DiagnosticEvent.Finalization.RunloopFinalized      => ZIO.unit
+        case DiagnosticEvent.Finalization.ConsumerFinalized     => ZIO.unit
+      }
+  }
+
+}

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/CommitterSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/CommitterSpec.scala
@@ -3,9 +3,9 @@ package zio.kafka.consumer.internal
 import org.apache.kafka.clients.consumer.{ MockConsumer, OffsetAndMetadata, OffsetCommitCallback, OffsetResetStrategy }
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.RebalanceInProgressException
-import zio.kafka.consumer.diagnostics.Diagnostics
 import zio.test._
 import zio._
+import zio.kafka.diagnostics.Diagnostics
 
 import java.util.{ Map => JavaMap }
 import scala.jdk.CollectionConverters.{ MapHasAsJava, MapHasAsScala }

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/PartitionStreamControlSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/PartitionStreamControlSpec.scala
@@ -4,8 +4,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 import zio._
 import zio.kafka.consumer.CommittableRecord
-import zio.kafka.consumer.diagnostics.Diagnostics
 import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
+import zio.kafka.diagnostics.Diagnostics
 import zio.test._
 
 import java.util.concurrent.TimeoutException

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -3,7 +3,6 @@ package zio.kafka.consumer.internal
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 import zio.kafka.ZIOSpecDefaultSlf4j
-import zio.kafka.consumer.diagnostics.Diagnostics
 import zio.kafka.consumer.internal.Committer.CommitOffsets
 import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
 import zio.kafka.consumer.internal.LiveCommitter.Commit
@@ -12,6 +11,7 @@ import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.kafka.consumer.{ CommittableRecord, ConsumerSettings }
 import zio.test._
 import zio._
+import zio.kafka.diagnostics.Diagnostics
 
 import java.util
 

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -4,9 +4,9 @@ import org.apache.kafka.clients.consumer.{ ConsumerConfig, ConsumerRecord }
 import org.apache.kafka.clients.producer.{ ProducerRecord, RecordMetadata }
 import zio._
 import zio.kafka.admin._
-import zio.kafka.consumer.Consumer.{ AutoOffsetStrategy, OffsetRetrieval }
+import zio.kafka.consumer.Consumer.{ AutoOffsetStrategy, ConsumerDiagnostics, OffsetRetrieval }
 import zio.kafka.consumer._
-import zio.kafka.consumer.diagnostics.Diagnostics
+import zio.kafka.diagnostics.Diagnostics
 import zio.kafka.producer._
 import zio.kafka.serde.{ Deserializer, Serde }
 import zio.stream.ZStream
@@ -286,7 +286,7 @@ object KafkaTestUtils {
     clientInstanceId: Option[String] = None,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest),
     allowAutoCreateTopics: Boolean = true,
-    diagnostics: Diagnostics = Diagnostics.NoOp,
+    diagnostics: ConsumerDiagnostics = Diagnostics.NoOp,
     // @deprecated
     // starting zio-kafka 3.0.0 `restartStreamOnRebalancing` is no longer available. As far as the zio-kafka
     // contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs it for
@@ -321,13 +321,17 @@ object KafkaTestUtils {
    *
    * ℹ️ Instead of using a layer, consider using [[KafkaTestUtils.makeConsumer]] to directly get a consumer.
    */
-  def minimalConsumer(diagnostics: Diagnostics = Diagnostics.NoOp): ZLayer[ConsumerSettings, Throwable, Consumer] =
+  def minimalConsumer(
+    diagnostics: ConsumerDiagnostics = Diagnostics.NoOp
+  ): ZLayer[ConsumerSettings, Throwable, Consumer] =
     ZLayer.makeSome[ConsumerSettings, Consumer](
       ZLayer.succeed(diagnostics) >>> Consumer.live
     )
 
   @deprecated("Use [[KafkaTestUtils.minimalConsumer]] instead", "2.3.1")
-  def simpleConsumer(diagnostics: Diagnostics = Diagnostics.NoOp): ZLayer[ConsumerSettings, Throwable, Consumer] =
+  def simpleConsumer(
+    diagnostics: ConsumerDiagnostics = Diagnostics.NoOp
+  ): ZLayer[ConsumerSettings, Throwable, Consumer] =
     minimalConsumer(diagnostics)
 
   /**
@@ -341,7 +345,7 @@ object KafkaTestUtils {
     clientInstanceId: Option[String] = None,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest),
     allowAutoCreateTopics: Boolean = true,
-    diagnostics: Diagnostics = Diagnostics.NoOp,
+    diagnostics: ConsumerDiagnostics = Diagnostics.NoOp,
     // @deprecated
     // starting zio-kafka 3.0.0 `restartStreamOnRebalancing` is no longer available. As far as the zio-kafka
     // contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs it for
@@ -412,7 +416,7 @@ object KafkaTestUtils {
     clientInstanceId: Option[String] = None,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest),
     allowAutoCreateTopics: Boolean = true,
-    diagnostics: Diagnostics = Diagnostics.NoOp,
+    diagnostics: ConsumerDiagnostics = Diagnostics.NoOp,
     // @deprecated
     // starting zio-kafka 3.0.0 `restartStreamOnRebalancing` is no longer available. As far as the zio-kafka
     // contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs it for
@@ -448,7 +452,7 @@ object KafkaTestUtils {
     clientInstanceId: Option[String] = None,
     offsetRetrieval: OffsetRetrieval = OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest),
     allowAutoCreateTopics: Boolean = true,
-    diagnostics: Diagnostics = Diagnostics.NoOp,
+    diagnostics: ConsumerDiagnostics = Diagnostics.NoOp,
     // @deprecated
     // starting zio-kafka 3.0.0 `restartStreamOnRebalancing` is no longer available. As far as the zio-kafka
     // contributors know, this feature is only used for transactional producing. Zio-kafka 3.0.0 no longer needs it for

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -8,9 +8,10 @@ import org.apache.kafka.clients.consumer.{
 }
 import org.apache.kafka.common._
 import zio._
-import zio.kafka.consumer.diagnostics.Diagnostics
-import zio.kafka.consumer.diagnostics.Diagnostics.ConcurrentDiagnostics
+import zio.kafka.consumer.diagnostics.DiagnosticEvent
 import zio.kafka.consumer.internal.{ ConsumerAccess, RunloopAccess }
+import zio.kafka.diagnostics.Diagnostics
+import zio.kafka.diagnostics.internal.ConcurrentDiagnostics
 import zio.kafka.serde.{ Deserializer, Serde }
 import zio.kafka.utils.SslHelper
 import zio.stream._
@@ -170,16 +171,23 @@ trait Consumer {
 }
 
 object Consumer {
+
+  /** A callback for consumer diagnostic events. */
+  type ConsumerDiagnostics = zio.kafka.diagnostics.Diagnostics[DiagnosticEvent]
+
+  /** A diagnostics implementation that does nothing. */
+  val NoDiagnostics: ConsumerDiagnostics = zio.kafka.diagnostics.Diagnostics.NoOp
+
   case object CommitTimeout extends RuntimeException("Commit timeout") with NoStackTrace
 
   val offsetBatches: ZSink[Any, Nothing, Offset, Nothing, OffsetBatch] =
     ZSink.foldLeft[Offset, OffsetBatch](OffsetBatch.empty)(_ add _)
 
-  def live: RLayer[ConsumerSettings & Diagnostics, Consumer] =
+  def live: RLayer[ConsumerSettings & ConsumerDiagnostics, Consumer] =
     ZLayer.scoped {
       for {
         settings    <- ZIO.service[ConsumerSettings]
-        diagnostics <- ZIO.service[Diagnostics]
+        diagnostics <- ZIO.service[ConsumerDiagnostics]
         consumer    <- make(settings, diagnostics)
       } yield consumer
     }
@@ -193,10 +201,10 @@ object Consumer {
    */
   def make(
     settings: ConsumerSettings,
-    diagnostics: Diagnostics = Diagnostics.NoOp
+    diagnostics: ConsumerDiagnostics = Diagnostics.NoOp
   ): ZIO[Scope, Throwable, Consumer] =
     for {
-      wrappedDiagnostics <- ConcurrentDiagnostics.make(diagnostics)
+      wrappedDiagnostics <- makeConcurrentDiagnostics(diagnostics)
       _                  <- SslHelper.validateEndpoint(settings.driverSettings)
       consumerAccess     <- ConsumerAccess.make(settings)
       runloopAccess      <- RunloopAccess.make(settings, consumerAccess, wrappedDiagnostics)
@@ -211,10 +219,10 @@ object Consumer {
   def fromJavaConsumer(
     javaConsumer: JConsumer[Array[Byte], Array[Byte]],
     settings: ConsumerSettings,
-    diagnostics: Diagnostics = Diagnostics.NoOp
+    diagnostics: Consumer.ConsumerDiagnostics = Diagnostics.NoOp
   ): ZIO[Scope, Throwable, Consumer] =
     for {
-      wrappedDiagnostics <- ConcurrentDiagnostics.make(diagnostics)
+      wrappedDiagnostics <- makeConcurrentDiagnostics(diagnostics)
       access             <- Semaphore.make(1)
       consumerAccess = new ConsumerAccess(javaConsumer, access)
       runloopAccess <- RunloopAccess.make(settings, consumerAccess, wrappedDiagnostics)
@@ -252,10 +260,10 @@ object Consumer {
     javaConsumer: JConsumer[Array[Byte], Array[Byte]],
     settings: ConsumerSettings,
     access: Semaphore,
-    diagnostics: Diagnostics = Diagnostics.NoOp
+    diagnostics: ConsumerDiagnostics = Diagnostics.NoOp
   ): ZIO[Scope, Throwable, Consumer] =
     for {
-      wrappedDiagnostics <- ConcurrentDiagnostics.make(diagnostics)
+      wrappedDiagnostics <- makeConcurrentDiagnostics(diagnostics)
       consumerAccess = new ConsumerAccess(javaConsumer, access)
       runloopAccess <- RunloopAccess.make(settings, consumerAccess, wrappedDiagnostics)
     } yield new ConsumerLive(consumerAccess, runloopAccess)
@@ -530,6 +538,11 @@ object Consumer {
     case object Latest   extends AutoOffsetStrategy
     case object None     extends AutoOffsetStrategy
   }
+
+  private def makeConcurrentDiagnostics(diagnostics: ConsumerDiagnostics): ZIO[Scope, Nothing, ConsumerDiagnostics] =
+    if (diagnostics == Diagnostics.NoOp) ZIO.succeed(diagnostics)
+    else ConcurrentDiagnostics.make(diagnostics, DiagnosticEvent.ConsumerFinalized)
+
 }
 
 private[consumer] final class ConsumerLive private[consumer] (

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/DiagnosticEvent.scala
@@ -4,6 +4,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 
 sealed trait DiagnosticEvent
+
 object DiagnosticEvent {
 
   final case class Poll(
@@ -11,6 +12,7 @@ object DiagnosticEvent {
     tpWithData: Set[TopicPartition],
     tpWithoutData: Set[TopicPartition]
   ) extends DiagnosticEvent
+
   final case class Request(partition: TopicPartition) extends DiagnosticEvent
 
   sealed trait Commit extends DiagnosticEvent
@@ -27,11 +29,20 @@ object DiagnosticEvent {
     ended: Set[TopicPartition]
   ) extends DiagnosticEvent
 
+  case object SubscriptionFinalized extends DiagnosticEvent
+  case object RunloopFinalized      extends DiagnosticEvent
+  case object ConsumerFinalized     extends DiagnosticEvent
+
+  @deprecated("Use zio.kafka.consumer.diagnostics.DiagnosticEvent instead", "2.12.0")
   sealed trait Finalization extends DiagnosticEvent
+
   object Finalization {
-    case object SubscriptionFinalized extends Finalization
-    case object RunloopFinalized      extends Finalization
-    case object ConsumerFinalized     extends Finalization
+    @deprecated("Use zio.kafka.consumer.diagnostics.DiagnosticEvent.SubscriptionFinalized instead", "2.12.0")
+    val SubscriptionFinalized: DiagnosticEvent.SubscriptionFinalized.type = DiagnosticEvent.SubscriptionFinalized
+    @deprecated("Use zio.kafka.consumer.diagnostics.DiagnosticEvent.RunloopFinalized instead", "2.12.0")
+    val RunloopFinalized: DiagnosticEvent.RunloopFinalized.type = DiagnosticEvent.RunloopFinalized
+    @deprecated("Use zio.kafka.consumer.diagnostics.DiagnosticEvent.ConsumerFinalized instead", "2.12.0")
+    val ConsumerFinalized: DiagnosticEvent.ConsumerFinalized.type = DiagnosticEvent.ConsumerFinalized
   }
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/Diagnostics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/Diagnostics.scala
@@ -2,21 +2,22 @@ package zio.kafka.consumer.diagnostics
 
 import zio.stream.ZStream
 import zio._
-import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization.ConsumerFinalized
+import zio.kafka.consumer.Consumer
+import zio.kafka.consumer.diagnostics.DiagnosticEvent.ConsumerFinalized
 
-trait Diagnostics {
-  def emit(event: => DiagnosticEvent): UIO[Unit]
-}
 object Diagnostics {
-  case object NoOp extends Diagnostics {
-    override def emit(event: => DiagnosticEvent): UIO[Unit] = ZIO.unit
-  }
 
-  final case class SlidingQueue private[Diagnostics] (queue: Queue[DiagnosticEvent]) extends Diagnostics {
+  /** A diagnostics implementation for [[DiagnosticEvent consumer DiagnosticsEvent]]s that does nothing. */
+  @deprecated("Use zio.kafka.consumer.Consumer.NoDiagnostics instead", "2.12.0")
+  val NoOp: Consumer.ConsumerDiagnostics = Consumer.NoDiagnostics
+
+  final case class SlidingQueue private[Diagnostics] (queue: Queue[DiagnosticEvent])
+      extends Consumer.ConsumerDiagnostics {
     override def emit(event: => DiagnosticEvent): UIO[Unit] = queue.offer(event).unit
   }
 
   object SlidingQueue {
+    @deprecated("Use zio.kafka.diagnostics.SlidingDiagnostics.make[DiagnosticEvent] instead", "2.12.0")
     def make(queueSize: Int = 16): ZIO[Scope, Nothing, SlidingQueue] =
       ZIO.acquireRelease(Queue.sliding[DiagnosticEvent](queueSize))(_.shutdown).map(SlidingQueue(_))
   }
@@ -27,15 +28,19 @@ object Diagnostics {
      * @return
      *   a `Diagnostics` that runs the wrapped `Diagnostics` concurrently in a separate fiber. Events are emitting to
      *   the fiber via an unbounded queue
+     * @deprecated
+     *   This wrapper is automatically applied to all user diagnostics. It is therefore not meant to be used by users of
+     *   the zio-kafka library. This API will no longer by public starting with zio-kafka 3.x.
      */
-    def make(wrapped: Diagnostics): ZIO[Scope, Nothing, Diagnostics] =
-      if (wrapped == Diagnostics.NoOp) ZIO.succeed(Diagnostics.NoOp)
+    @deprecated("Will be removed in zio-kafka 3.x", "2.12.0")
+    def make(wrapped: Consumer.ConsumerDiagnostics): ZIO[Scope, Nothing, Consumer.ConsumerDiagnostics] =
+      if (wrapped == Consumer.NoDiagnostics) ZIO.succeed(Consumer.NoDiagnostics)
       else {
         for {
           queue <- ZIO.acquireRelease(Queue.unbounded[DiagnosticEvent])(_.shutdown)
           fib   <- ZStream.fromQueue(queue).tap(wrapped.emit(_)).takeUntil(_ == ConsumerFinalized).runDrain.forkScoped
           _     <- ZIO.addFinalizer(queue.offer(ConsumerFinalized) *> fib.await)
-        } yield new Diagnostics {
+        } yield new Consumer.ConsumerDiagnostics {
           override def emit(event: => DiagnosticEvent): UIO[Unit] = queue.offer(event).unit
         }
       }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/package.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/diagnostics/package.scala
@@ -1,0 +1,11 @@
+package zio.kafka.consumer
+
+package object diagnostics {
+
+  /**
+   * A callback for consumer diagnostic events.
+   */
+  @deprecated("Use zio.kafka.consumer.Consumer.ConsumerDiagnostics instead", "2.12.0")
+  type Diagnostics = Consumer.ConsumerDiagnostics
+
+}

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/LiveCommitter.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/LiveCommitter.scala
@@ -2,12 +2,12 @@ package zio.kafka.consumer.internal
 import org.apache.kafka.clients.consumer.{ OffsetAndMetadata, OffsetCommitCallback }
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.RebalanceInProgressException
-import zio.kafka.consumer.Consumer.CommitTimeout
-import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
+import zio.kafka.consumer.Consumer.{ CommitTimeout, ConsumerDiagnostics }
 import zio.kafka.consumer.internal.Committer.CommitOffsets
 import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
 import zio.kafka.consumer.internal.LiveCommitter.Commit
 import zio._
+import zio.kafka.consumer.diagnostics.DiagnosticEvent
 
 import java.util.{ Map => JavaMap }
 import scala.collection.mutable
@@ -16,7 +16,7 @@ import scala.jdk.CollectionConverters._
 private[consumer] final class LiveCommitter(
   commitQueue: Queue[Commit],
   commitTimeout: Duration,
-  diagnostics: Diagnostics,
+  diagnostics: ConsumerDiagnostics,
   consumerMetrics: ConsumerMetrics,
   onCommitAvailable: UIO[Unit],
   committedOffsetsRef: Ref[CommitOffsets],
@@ -172,7 +172,7 @@ private[consumer] final class LiveCommitter(
 private[internal] object LiveCommitter {
   def make(
     commitTimeout: Duration,
-    diagnostics: Diagnostics,
+    diagnostics: ConsumerDiagnostics,
     consumerMetrics: ConsumerMetrics,
     onCommitAvailable: UIO[Unit]
   ): ZIO[Scope, Nothing, LiveCommitter] = for {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -1,12 +1,13 @@
 package zio.kafka.consumer.internal
 
 import org.apache.kafka.common.TopicPartition
+import zio.kafka.consumer.Consumer.ConsumerDiagnostics
 import zio.kafka.consumer.Offset
-import zio.kafka.consumer.diagnostics.{ DiagnosticEvent, Diagnostics }
 import zio.kafka.consumer.internal.PartitionStreamControl.QueueInfo
 import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.stream.{ Take, ZStream }
 import zio._
+import zio.kafka.consumer.diagnostics.DiagnosticEvent
 
 import java.util.concurrent.TimeoutException
 import scala.util.control.NoStackTrace
@@ -127,7 +128,7 @@ object PartitionStreamControl {
   private[internal] def newPartitionStream(
     tp: TopicPartition,
     requestData: UIO[Unit],
-    diagnostics: Diagnostics,
+    diagnostics: ConsumerDiagnostics,
     maxStreamPullInterval: Duration
   ): UIO[PartitionStreamControl] = {
     val maxStreamPullIntervalNanos = maxStreamPullInterval.toNanos

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -2,13 +2,14 @@ package zio.kafka.consumer.internal
 
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.TopicPartition
-import zio.kafka.consumer.diagnostics.DiagnosticEvent.Finalization
-import zio.kafka.consumer.diagnostics.Diagnostics
 import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
 import zio.kafka.consumer.{ ConsumerSettings, InvalidSubscriptionUnion, OffsetBatch, Subscription }
 import zio.stream.{ Stream, Take, UStream, ZStream }
 import zio._
+import zio.kafka.consumer.Consumer.ConsumerDiagnostics
+import zio.kafka.consumer.diagnostics.DiagnosticEvent
+import zio.kafka.diagnostics.Diagnostics
 
 private[internal] sealed trait RunloopState
 private[internal] object RunloopState {
@@ -28,7 +29,7 @@ private[consumer] final class RunloopAccess private (
   runloopStateRef: Ref.Synchronized[RunloopState],
   partitionHub: Hub[Take[Throwable, PartitionAssignment]],
   makeRunloop: UIO[Runloop],
-  diagnostics: Diagnostics
+  diagnostics: ConsumerDiagnostics
 ) {
 
   private def withRunloopZIO[E](
@@ -62,7 +63,7 @@ private[consumer] final class RunloopAccess private (
       _ <- withRunloopZIO(requireRunning = true)(_.addSubscription(subscription))
       _ <- ZIO.addFinalizer {
              withRunloopZIO(requireRunning = false)(_.removeSubscription(subscription)) <*
-               diagnostics.emit(Finalization.SubscriptionFinalized)
+               diagnostics.emit(DiagnosticEvent.SubscriptionFinalized)
            }
     } yield stream
 
@@ -77,7 +78,7 @@ private[consumer] object RunloopAccess {
   def make(
     settings: ConsumerSettings,
     consumerAccess: ConsumerAccess,
-    diagnostics: Diagnostics = Diagnostics.NoOp
+    diagnostics: ConsumerDiagnostics = Diagnostics.NoOp
   ): ZIO[Scope, Throwable, RunloopAccess] =
     for {
       maxPollInterval <- maxPollIntervalConfig(settings)

--- a/zio-kafka/src/main/scala/zio/kafka/diagnostics/Diagnostics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/diagnostics/Diagnostics.scala
@@ -1,0 +1,21 @@
+package zio.kafka.diagnostics
+
+import zio.{ UIO, ZIO }
+
+/**
+ * A callback interface for diagnostic events.
+ */
+trait Diagnostics[-DiagnosticEvent] {
+  def emit(event: => DiagnosticEvent): UIO[Unit]
+}
+
+object Diagnostics {
+
+  /**
+   * A diagnostics implementation that does nothing.
+   */
+  val NoOp: Diagnostics[Any] = new Diagnostics[Any] {
+    override def emit(event: => Any): UIO[Unit] = ZIO.unit
+  }
+
+}

--- a/zio-kafka/src/main/scala/zio/kafka/diagnostics/SlidingDiagnostics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/diagnostics/SlidingDiagnostics.scala
@@ -1,0 +1,39 @@
+package zio.kafka.diagnostics
+
+import zio.{ Queue, Scope, UIO, ZIO }
+
+object SlidingDiagnostics {
+
+  /**
+   * Create a [[Diagnostics]] implementation that keeps the last `queueSize` emitted events in a queue.
+   *
+   * Useful for testing, or any other case where you don't want to risk high memory usage due to a slow diagnostics
+   * implementation.
+   *
+   * For example, for a Diagnostics that keeps the last 100
+   * [[zio.kafka.consumer.diagnostics.DiagnosticEvent consumer DiagnosticEvent]]s use:
+   * {{{
+   *   import zio.kafka.consumer.diagnostics.{DiagnosticEvent => ConsumerDiagnosticEvent}
+   *   for {
+   *     diagnostics <- SlidingDiagnostics.make[ConsumerDiagnosticEvent](100)
+   *     ... use diagnostics
+   *     events <- diagnostics.queue.takeAll
+   *   } yield {
+   *     assert(events.length == 100)
+   *   }
+   * }}}
+   *
+   * @param queueSize
+   *   number of events to retain in the queue
+   * @tparam DiagnosticEvent
+   *   the type of event to keep
+   */
+  def make[DiagnosticEvent](queueSize: Int = 16): ZIO[Scope, Nothing, QueuingDiagnostics[DiagnosticEvent]] =
+    ZIO.acquireRelease(Queue.sliding[DiagnosticEvent](queueSize))(_.shutdown).map(QueuingDiagnostics(_))
+
+}
+
+final case class QueuingDiagnostics[DiagnosticEvent] private[diagnostics] (queue: Queue[DiagnosticEvent])
+    extends Diagnostics[DiagnosticEvent] {
+  override def emit(event: => DiagnosticEvent): UIO[Unit] = queue.offer(event).unit
+}

--- a/zio-kafka/src/main/scala/zio/kafka/diagnostics/internal/ConcurrentDiagnostics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/diagnostics/internal/ConcurrentDiagnostics.scala
@@ -1,0 +1,25 @@
+package zio.kafka.diagnostics.internal
+
+import zio._
+import zio.kafka.diagnostics.Diagnostics
+import zio.stream._
+
+object ConcurrentDiagnostics {
+
+  /**
+   * @return
+   *   a `Diagnostics` that runs the wrapped `Diagnostics` concurrently in a separate fiber. Events are emitting to the
+   *   fiber via an unbounded queue. Upon finalization, `finalEvent` is emitted as the last event.
+   */
+  def make[DiagnosticEvent](
+    wrapped: Diagnostics[DiagnosticEvent],
+    finalEvent: DiagnosticEvent
+  ): ZIO[Scope, Nothing, Diagnostics[DiagnosticEvent]] =
+    for {
+      queue <- ZIO.acquireRelease(Queue.unbounded[DiagnosticEvent])(_.shutdown)
+      fib   <- ZStream.fromQueue(queue).tap(wrapped.emit(_)).takeUntil(_ == finalEvent).runDrain.forkScoped
+      _     <- ZIO.addFinalizer(queue.offer(finalEvent) *> fib.await)
+    } yield new Diagnostics[DiagnosticEvent] {
+      override def emit(event: => DiagnosticEvent): UIO[Unit] = queue.offer(event).unit
+    }
+}


### PR DESCRIPTION
It has been a long wish to have producer diagnostics. Although these are not really hard to add, the consumer diagnostics are in the way; these already claim some names and make code sharing awkward. Now that we are moving towards zio-kafka 3.0 we can fix this at the cost of some backward incompatibilities.

This PR prepares for the introduction of producer diagnostics by moving the sharable diagnostics code into a new higher level `diagnostics` package. In addition, zio-kafka internal code is moved to the `diagnostics.internal` package.

This also removes the trait `DiagnosticEvent.Finalization` from the type hierarchy because it doesn't serve any user purpose (it was introduced to make it easier to test the shutdown sequence of the consumer).

All old APIs are still available but are deprecated.

This change is source compatible, but _not_ binary compatible and therefore (following zio-kafka conventions) requires a new minor release.

Partially fixes #1406.