### PR TITLE
Only run benchmark on code changes (2)

### DIFF
--- a/.github/workflows/benchs.yml
+++ b/.github/workflows/benchs.yml
@@ -13,6 +13,11 @@ on:
     types: [ opened, reopened, synchronize ]
     branches-ignore:
       - gh-pages
+    paths:
+      - '**/build.sbt'
+      - 'project/**'
+      - 'zio-kafka/**'
+      - 'zio-kafka-bench/**'
 
 # Prevent multiple builds at the same time from the same branch (except for 'master').
 concurrency:


### PR DESCRIPTION
Now (in addition to commit d35114d259) we also skip benchmarks for non-code changes in pull requests.