### PR TITLE
Provide diagnostics via `ConsumerSettings`

### DIFF
--- a/docs/creating-a-consumer.md
+++ b/docs/creating-a-consumer.md
@@ -57,7 +57,21 @@ val consumerLayer: Layer[Any, Throwable, Consumer] =
 
 (1) By using `ZLayer.scoped`, the consumer is closed when the layer is no longer needed.
 
-## Consumer settings from a layer
+## Consumer settings from a layer (zio-kafka 3.x)
+
+If you wish to create the `ConsumerSettings` and the `Consumer` from a layer, you can use `Consumer.live`. It takes
+the consumer settings as a layer and produces a consumer.
+
+The `provide` section of the main program could look like this:
+
+```scala
+.provide(
+  consumerSettingsLayer,
+  Consumer.live
+)
+```
+
+## Consumer settings from a layer (zio-kafka 2.x)
 
 If you wish to create the `ConsumerSettings` and the `Consumer` from a layer, you can use `Consumer.live`. It takes
 the consumer settings and diagnostics settings as a layer and produces a consumer.

--- a/docs/migrating-to-zio-kafka-3.md
+++ b/docs/migrating-to-zio-kafka-3.md
@@ -6,8 +6,9 @@ title: "Migrating to zio-kafka 3"
 Zio-kafka 3.0.0 brings a number of backwards incompatible changes:
 
 1. Removal of all deprecated methods, _including accessor methods,_
-2. The transactional producer is now much easier to use, 
-3. `restartStreamOnRebalancing` mode is no longer supported.
+2. The transactional producer is now much easier to use,
+3. Diagnostics set via consumer settings, 
+4. `restartStreamOnRebalancing` mode is no longer supported.
 
 This document helps you migrate from zio-kafka 2 to zio-kafka 3.
 
@@ -159,7 +160,75 @@ The transactional producer is now much easier to use. The zio-kafka 2.x transact
 expect only a few very experienced users to make use of it. Therefore, only the new API is described in
 [transactions](transactions.md).
 
-# 3. `restartStreamOnRebalancing` mode
+# 3. Diagnostics set via consumer settings
+
+Diagnostics, an optional callback for key events in the consumer life-cycle, is now set via
+`ConsumerSettings.withDiagnostics`. In zio-kafka 2.x it was the second (optional) argument to `Consumer.make`, or an
+additional input layer for `Consumer.live`.
+
+### Migrate a layers app without diagnostics
+
+If your program uses ZIO layers, but you don't need diagnostics, it will look like this:
+
+```scala
+// zio-kafka 2.x
+.provide(
+  consumerSettingsLayer,
+  ZLayer.succeed(Consumer.NoDiagnostics), // 1
+  Consumer.live
+)
+```
+
+For zio-kafka 3.x simply remove the line marked with `// 1` and you are done.
+
+### Migrate uses of `Consumer.make` with diagnostics
+
+Rewrite your code following this example:
+
+```scala
+// zio-kafka 2.x
+val diagnostics = ???
+val settings = ConsumerSettings(bootstrap)
+val consumer = Consumer.make(settings, diagnostics)
+
+// zio-kafka 3.x
+val diagnostics = ???
+val settings = ConsumerSettings(bootstrap).withDiagnostics(diagnostics)
+val consumer = Consumer.make(settings)
+```
+
+## Migrate a layers app with diagnostics
+
+In case your application provides diagnostics via a layer, providing the layers looks like this:
+
+```scala
+// zio-kafka 2.x
+.provide(
+  consumerSettingsLayer,
+  diagnosticsLayer,
+  Consumer.live
+)
+```
+
+The cleanest solution is to merge the code that constructs `diagnosticsLayer` into the code that constructs
+`consumerSettingsLayer`.
+
+The other option is to apply a 'quick fix' that transforms the two layers into a single layer:
+
+```scala
+// zio-kafka 3.x
+.provide(
+  (consumerSettingsLayer ++ diagnosticsLayer) >>> ZLayer {
+    for {
+      settings <- ZIO.service[ConsumerSettings]
+      diagnostics <- ZIO.service[Consumer.ConsumerDiagnostics]
+    } yield settings.withDiagnostics(diagnostics)
+  },
+  Consumer.live
+)
+```
+
+# 4. `restartStreamOnRebalancing` mode
 
 This mode is no longer available in zio-kafka 3. With `restartStreamOnRebalancing` all streams are ended during a
 rebalance, even when the partition for that stream was not revoked. One of its purposes was to enable transactional

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -239,7 +239,7 @@ object Transactional extends ZIOAppDefault {
     runConsumerStream
       .provide(
         consumerSettings,
-        ZLayer.succeed(Consumer.NoDiagnostics),
+        ZLayer.succeed(Consumer.NoDiagnostics),  // No longer needed in zio-kafka 3.x
         Consumer.live,
         producerSettings,
         TransactionalProducer.live

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaConsumerBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaConsumerBenchmark.scala
@@ -4,7 +4,6 @@ import org.openjdk.jmh.annotations._
 import zio.kafka.admin.AdminClient.NewTopic
 import zio.kafka.bench.ZioBenchmark.randomThing
 import zio.kafka.consumer.{ Consumer, Offset, OffsetBatch, Subscription }
-import zio.kafka.diagnostics.Diagnostics
 import zio.kafka.serde.Serde
 import zio.kafka.testkit.Kafka
 import zio.kafka.testkit.KafkaTestUtils
@@ -40,7 +39,7 @@ class ZioKafkaConsumerBenchmark extends ConsumerZioBenchmark[Kafka] {
                       `max.poll.records` = 1000
                     )
                     .map(_.withPartitionPreFetchBufferLimit(8192))
-      consumer <- Consumer.make(settings, Diagnostics.NoOp)
+      consumer <- Consumer.make(settings)
     } yield consumer
 
   @Benchmark

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ComparisonBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/comparison/ComparisonBenchmark.scala
@@ -50,7 +50,7 @@ trait ComparisonBenchmark extends ConsumerZioBenchmark[Env] {
         Kafka.embedded,
         settings,
         javaKafkaConsumer,
-        KafkaTestUtils.minimalConsumer()
+        Consumer.live
       )
       .orDie
 

--- a/zio-kafka-example/src/main/scala/zio/kafka/example/Main.scala
+++ b/zio-kafka-example/src/main/scala/zio/kafka/example/Main.scala
@@ -41,7 +41,6 @@ object Main extends ZIOAppDefault {
       runConsumerStream
         .provide(
           consumerSettings,
-          ZLayer.succeed(Consumer.NoDiagnostics),
           Consumer.live,
           MyKafka.embedded
         )

--- a/zio-kafka-example/src/main/scala/zio/kafka/example/Transactional.scala
+++ b/zio-kafka-example/src/main/scala/zio/kafka/example/Transactional.scala
@@ -81,7 +81,6 @@ object Transactional extends ZIOAppDefault {
       runConsumerStream
         .provide(
           consumerSettings,
-          ZLayer.succeed(Consumer.NoDiagnostics),
           Consumer.live,
           producerSettings,
           TransactionalProducer.live,

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -1005,9 +1005,10 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                           `max.poll.records` = 1,
                           rebalanceSafeCommits = rebalanceSafeCommits,
                           maxRebalanceDuration = 20.seconds,
-                          commitTimeout = 1.second
+                          commitTimeout = 1.second,
+                          diagnostics = diagnostics
                         )
-            consumer <- Consumer.make(settings, diagnostics)
+            consumer <- Consumer.make(settings)
           } yield consumer
 
         for {
@@ -1383,9 +1384,10 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
               clientId <- randomClient
               settings <- KafkaTestUtils.consumerSettings(
                             clientId = clientId,
-                            maxPollInterval = 500.millis
+                            maxPollInterval = 500.millis,
+                            diagnostics = diagnostics
                           )
-              _ <- Consumer.make(settings, diagnostics = diagnostics)
+              _ <- Consumer.make(settings)
               _ <- ZIO.sleep(1.second)
             } yield assertCompletes
 
@@ -1404,8 +1406,8 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             def test(diagnostics: ConsumerDiagnostics): ZIO[Scope & Kafka, Throwable, TestResult] =
               for {
                 clientId <- randomClient
-                settings <- KafkaTestUtils.consumerSettings(clientId = clientId)
-                _        <- Consumer.make(settings, diagnostics = diagnostics)
+                settings <- KafkaTestUtils.consumerSettings(clientId = clientId, diagnostics = diagnostics)
+                _        <- Consumer.make(settings)
               } yield assertCompletes
 
             for {
@@ -1427,8 +1429,8 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                 producer <- KafkaTestUtils.makeProducer
                 _        <- KafkaTestUtils.produceOne(producer, topic, "key1", "message1")
 
-                settings <- KafkaTestUtils.consumerSettings(clientId = clientId)
-                consumer <- Consumer.make(settings, diagnostics = diagnostics)
+                settings <- KafkaTestUtils.consumerSettings(clientId = clientId, diagnostics = diagnostics)
+                consumer <- Consumer.make(settings)
                 // Starting a consumption session to start the Runloop.
                 consumed0 <- consumer
                                .plainStream(Subscription.manual(topic -> 0), Serde.string, Serde.string)
@@ -1474,8 +1476,8 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                 producer <- KafkaTestUtils.makeProducer
                 _        <- KafkaTestUtils.produceMany(producer, topic, kvs)
 
-                settings <- KafkaTestUtils.consumerSettings(clientId = clientId)
-                consumer <- Consumer.make(settings, diagnostics = diagnostics)
+                settings <- KafkaTestUtils.consumerSettings(clientId = clientId, diagnostics = diagnostics)
+                consumer <- Consumer.make(settings)
                 // Create a Ref to track messages consumed and a Promise to signal when to stop consumption
                 messagesConsumedRef <- Ref.make(0)
                 stopPromise         <- Promise.make[Nothing, Unit]

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -32,7 +32,8 @@ final case class ConsumerSettings(
   metricLabels: Set[MetricLabel] = Set.empty,
   runloopMetricsSchedule: Schedule[Any, Unit, Long] = Schedule.fixed(500.millis),
   authErrorRetrySchedule: Schedule[Any, Throwable, Any] = Schedule.recurs(5) && Schedule.spaced(500.millis),
-  maxStreamPullIntervalOption: Option[Duration] = None
+  maxStreamPullIntervalOption: Option[Duration] = None,
+  diagnostics: Consumer.ConsumerDiagnostics = Consumer.NoDiagnostics
 ) {
   // Parse booleans in a way compatible with how Kafka does this in org.apache.kafka.common.config.ConfigDef.parseType:
   require(
@@ -346,6 +347,14 @@ final case class ConsumerSettings(
     val isolationLevel = if (readCommitted) IsolationLevel.READ_COMMITTED else IsolationLevel.READ_UNCOMMITTED
     withProperty(ConsumerConfig.ISOLATION_LEVEL_CONFIG, isolationLevel.toString)
   }
+
+  /**
+   * @param diagnostics
+   *   an optional callback for key events in the consumer life-cycle. The callbacks will be executed in a separate
+   *   fiber. Since the events are queued, failure to handle these events leads to out of memory errors.
+   */
+  def withDiagnostics(diagnostics: Consumer.ConsumerDiagnostics): ConsumerSettings =
+    copy(diagnostics = diagnostics)
 
 }
 


### PR DESCRIPTION
Since most people do not use consumer diagnostics, it is a bit annoying that everybody has to provide a (dummy) diagnostics layer when the zio-kafka `Consumer` is constructed via a layer.

This is solved by moving the configuration of diagnostics to `ConsumerSettings`.

This approach also makes it consistent with the to-be-introduced `ProducerDiagnostics`.