### PR TITLE
Kafka 4.x (Integration tests for embedded-kafka 4.x - DO NOT MERGE)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val binCompatVersionToCompare =
       compatVersion
     }
 
-lazy val kafkaVersion         = "3.9.0"
+lazy val kafkaVersion         = "4.0.0"
 lazy val embeddedKafkaVersion = "3.9.0" // Should be the same as kafkaVersion, except for the patch part
 
 lazy val kafkaClients = "org.apache.kafka" % "kafka-clients"   % kafkaVersion

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val binCompatVersionToCompare =
     }
 
 lazy val kafkaVersion         = "4.0.0"
-lazy val embeddedKafkaVersion = "3.9.0" // Should be the same as kafkaVersion, except for the patch part
+lazy val embeddedKafkaVersion = "3.9.0+23-ee9ab474-SNAPSHOT" // Should be the same as kafkaVersion, except for the patch part
 
 lazy val kafkaClients = "org.apache.kafka" % "kafka-clients"   % kafkaVersion
 lazy val logback      = "ch.qos.logback"   % "logback-classic" % "1.5.17"

--- a/zio-kafka-example/src/main/scala/zio/kafka/example/MyKafka.scala
+++ b/zio-kafka-example/src/main/scala/zio/kafka/example/MyKafka.scala
@@ -19,7 +19,7 @@ object MyKafka {
       customBrokerProperties = Map(
         "group.min.session.timeout.ms"     -> "500",
         "group.initial.rebalance.delay.ms" -> "0",
-        "authorizer.class.name"            -> "kafka.security.authorizer.AclAuthorizer",
+        "authorizer.class.name"            -> "org.apache.kafka.metadata.authorizer.StandardAuthorizer",
         "super.users"                      -> "User:ANONYMOUS"
       )
     )

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/CommitterSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/CommitterSpec.scala
@@ -1,6 +1,7 @@
 package zio.kafka.consumer.internal
 
-import org.apache.kafka.clients.consumer.{ MockConsumer, OffsetAndMetadata, OffsetCommitCallback, OffsetResetStrategy }
+import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy
+import org.apache.kafka.clients.consumer.{ MockConsumer, OffsetAndMetadata, OffsetCommitCallback }
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.RebalanceInProgressException
 import zio.kafka.consumer.diagnostics.Diagnostics
@@ -199,7 +200,7 @@ object CommitterSpec extends ZIOSpecDefault {
     onCommitAsync: Map[TopicPartition, OffsetAndMetadata] => Task[Map[TopicPartition, OffsetAndMetadata]]
   ): ZIO[Any, Nothing, MockConsumer[Array[Byte], Array[Byte]]] =
     ZIO.runtime[Any].map { runtime =>
-      new MockConsumer[Array[Byte], Array[Byte]](OffsetResetStrategy.LATEST) {
+      new MockConsumer[Array[Byte], Array[Byte]](AutoOffsetResetStrategy.LATEST.toString) {
         override def commitAsync(
           offsets: JavaMap[TopicPartition, OffsetAndMetadata],
           callback: OffsetCommitCallback

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/CommitterSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/CommitterSpec.scala
@@ -1,6 +1,5 @@
 package zio.kafka.consumer.internal
 
-import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy
 import org.apache.kafka.clients.consumer.{ MockConsumer, OffsetAndMetadata, OffsetCommitCallback }
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.RebalanceInProgressException
@@ -200,7 +199,7 @@ object CommitterSpec extends ZIOSpecDefault {
     onCommitAsync: Map[TopicPartition, OffsetAndMetadata] => Task[Map[TopicPartition, OffsetAndMetadata]]
   ): ZIO[Any, Nothing, MockConsumer[Array[Byte], Array[Byte]]] =
     ZIO.runtime[Any].map { runtime =>
-      new MockConsumer[Array[Byte], Array[Byte]](AutoOffsetResetStrategy.LATEST.toString) {
+      new MockConsumer[Array[Byte], Array[Byte]]("latest") {
         override def commitAsync(
           offsets: JavaMap[TopicPartition, OffsetAndMetadata],
           callback: OffsetCommitCallback

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -1,7 +1,9 @@
 package zio.kafka.consumer.internal
 
 import org.apache.kafka.clients.consumer._
+import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy
 import org.apache.kafka.common.TopicPartition
+import zio._
 import zio.kafka.ZIOSpecDefaultSlf4j
 import zio.kafka.consumer.diagnostics.Diagnostics
 import zio.kafka.consumer.internal.Committer.CommitOffsets
@@ -9,9 +11,8 @@ import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
 import zio.kafka.consumer.internal.RebalanceCoordinator._
 import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.kafka.consumer.{ CommittableRecord, ConsumerSettings }
-import zio.test._
-import zio._
 import zio.stream.ZStream
+import zio.test._
 
 import java.util.{ Map => JavaMap }
 import scala.jdk.CollectionConverters._
@@ -45,7 +46,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
       test("should track assigned, revoked and lost partitions") {
         for {
           lastEvent <- Ref.Synchronized.make(RebalanceCoordinator.RebalanceEvent.None)
-          consumer = new BinaryMockConsumer(OffsetResetStrategy.LATEST) {}
+          consumer = new BinaryMockConsumer(AutoOffsetResetStrategy.LATEST.toString) {}
           tp       = new TopicPartition("topic", 0)
           tp2      = new TopicPartition("topic", 1)
           tp3      = new TopicPartition("topic", 2)
@@ -81,7 +82,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
       test("should end streams for revoked and lost partitions") {
         for {
           lastEvent <- Ref.Synchronized.make(RebalanceCoordinator.RebalanceEvent.None)
-          consumer = new BinaryMockConsumer(OffsetResetStrategy.LATEST) {}
+          consumer = new BinaryMockConsumer(AutoOffsetResetStrategy.LATEST.toString) {}
           tp       = new TopicPartition("topic", 0)
           tp2      = new TopicPartition("topic", 1)
           tp3      = new TopicPartition("topic", 2)
@@ -154,7 +155,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
           // - Assert that onRevoked takes its time, waiting for the configured max rebalance duration
           for {
             lastEvent <- Ref.Synchronized.make(RebalanceCoordinator.RebalanceEvent.None)
-            consumer = new BinaryMockConsumer(OffsetResetStrategy.LATEST) {}
+            consumer = new BinaryMockConsumer(AutoOffsetResetStrategy.LATEST.toString) {}
             tp       = new TopicPartition("topic", 0)
             streamControl <- makeStreamControl(tp)
             recordCount = 3
@@ -195,7 +196,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
           // - Assert that onRevoked completes immediately, meaning that it does not wait for the stream to commit
           for {
             lastEvent <- Ref.Synchronized.make(RebalanceCoordinator.RebalanceEvent.None)
-            consumer = new BinaryMockConsumer(OffsetResetStrategy.LATEST) {}
+            consumer = new BinaryMockConsumer(AutoOffsetResetStrategy.LATEST.toString) {}
             tp       = new TopicPartition("topic", 0)
             streamControl <- makeStreamControl(tp)
             recordCount = 3
@@ -314,7 +315,7 @@ abstract private class MockCommitter extends Committer {
 private class CommitTrackingMockConsumer(
   runtime: Runtime[Any],
   lastCommittedOffsets: Ref[Map[TopicPartition, Long]]
-) extends MockConsumer[Array[Byte], Array[Byte]](OffsetResetStrategy.LATEST) {
+) extends MockConsumer[Array[Byte], Array[Byte]](AutoOffsetResetStrategy.LATEST.toString) {
   override def commitAsync(
     offsets: JavaMap[TopicPartition, OffsetAndMetadata],
     callback: OffsetCommitCallback

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -1,7 +1,6 @@
 package zio.kafka.consumer.internal
 
 import org.apache.kafka.clients.consumer._
-import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy
 import org.apache.kafka.common.TopicPartition
 import zio._
 import zio.kafka.ZIOSpecDefaultSlf4j
@@ -46,7 +45,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
       test("should track assigned, revoked and lost partitions") {
         for {
           lastEvent <- Ref.Synchronized.make(RebalanceCoordinator.RebalanceEvent.None)
-          consumer = new BinaryMockConsumer(AutoOffsetResetStrategy.LATEST.toString) {}
+          consumer = new BinaryMockConsumer("latest") {}
           tp       = new TopicPartition("topic", 0)
           tp2      = new TopicPartition("topic", 1)
           tp3      = new TopicPartition("topic", 2)
@@ -82,7 +81,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
       test("should end streams for revoked and lost partitions") {
         for {
           lastEvent <- Ref.Synchronized.make(RebalanceCoordinator.RebalanceEvent.None)
-          consumer = new BinaryMockConsumer(AutoOffsetResetStrategy.LATEST.toString) {}
+          consumer = new BinaryMockConsumer("latest") {}
           tp       = new TopicPartition("topic", 0)
           tp2      = new TopicPartition("topic", 1)
           tp3      = new TopicPartition("topic", 2)
@@ -155,7 +154,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
           // - Assert that onRevoked takes its time, waiting for the configured max rebalance duration
           for {
             lastEvent <- Ref.Synchronized.make(RebalanceCoordinator.RebalanceEvent.None)
-            consumer = new BinaryMockConsumer(AutoOffsetResetStrategy.LATEST.toString) {}
+            consumer = new BinaryMockConsumer("latest") {}
             tp       = new TopicPartition("topic", 0)
             streamControl <- makeStreamControl(tp)
             recordCount = 3
@@ -196,7 +195,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
           // - Assert that onRevoked completes immediately, meaning that it does not wait for the stream to commit
           for {
             lastEvent <- Ref.Synchronized.make(RebalanceCoordinator.RebalanceEvent.None)
-            consumer = new BinaryMockConsumer(AutoOffsetResetStrategy.LATEST.toString) {}
+            consumer = new BinaryMockConsumer("latest") {}
             tp       = new TopicPartition("topic", 0)
             streamControl <- makeStreamControl(tp)
             recordCount = 3
@@ -315,7 +314,7 @@ abstract private class MockCommitter extends Committer {
 private class CommitTrackingMockConsumer(
   runtime: Runtime[Any],
   lastCommittedOffsets: Ref[Map[TopicPartition, Long]]
-) extends MockConsumer[Array[Byte], Array[Byte]](AutoOffsetResetStrategy.LATEST.toString) {
+) extends MockConsumer[Array[Byte], Array[Byte]]("latest") {
   override def commitAsync(
     offsets: JavaMap[TopicPartition, OffsetAndMetadata],
     callback: OffsetCommitCallback

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -1,6 +1,5 @@
 package zio.kafka.consumer.internal
 
-import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy
 import org.apache.kafka.clients.consumer.{ ConsumerRebalanceListener, ConsumerRecord, MockConsumer }
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{ AuthenticationException, AuthorizationException }
@@ -103,7 +102,7 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
           var rebalanceListener: ConsumerRebalanceListener = null
 
           // Catches the rebalance listener so we can use it
-          val mockConsumer: BinaryMockConsumer = new BinaryMockConsumer(AutoOffsetResetStrategy.LATEST.toString) {
+          val mockConsumer: BinaryMockConsumer = new BinaryMockConsumer("latest") {
             override def subscribe(
               topics: util.Collection[String],
               listener: ConsumerRebalanceListener
@@ -185,7 +184,7 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
 
   private def withRunloop(
     diagnostics: Diagnostics = Diagnostics.NoOp,
-    mockConsumer: BinaryMockConsumer = new BinaryMockConsumer(AutoOffsetResetStrategy.LATEST.toString)
+    mockConsumer: BinaryMockConsumer = new BinaryMockConsumer("latest")
   )(
     f: (BinaryMockConsumer, PartitionsHub, Runloop) => ZIO[Scope, Throwable, TestResult]
   ): ZIO[Scope, Throwable, TestResult] =

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -1,11 +1,7 @@
 package zio.kafka.consumer.internal
 
-import org.apache.kafka.clients.consumer.{
-  ConsumerRebalanceListener,
-  ConsumerRecord,
-  MockConsumer,
-  OffsetResetStrategy
-}
+import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy
+import org.apache.kafka.clients.consumer.{ ConsumerRebalanceListener, ConsumerRecord, MockConsumer }
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{ AuthenticationException, AuthorizationException }
 import zio._
@@ -107,7 +103,7 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
           var rebalanceListener: ConsumerRebalanceListener = null
 
           // Catches the rebalance listener so we can use it
-          val mockConsumer: BinaryMockConsumer = new BinaryMockConsumer(OffsetResetStrategy.LATEST) {
+          val mockConsumer: BinaryMockConsumer = new BinaryMockConsumer(AutoOffsetResetStrategy.LATEST.toString) {
             override def subscribe(
               topics: util.Collection[String],
               listener: ConsumerRebalanceListener
@@ -189,7 +185,7 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
 
   private def withRunloop(
     diagnostics: Diagnostics = Diagnostics.NoOp,
-    mockConsumer: BinaryMockConsumer = new BinaryMockConsumer(OffsetResetStrategy.LATEST)
+    mockConsumer: BinaryMockConsumer = new BinaryMockConsumer(AutoOffsetResetStrategy.LATEST.toString)
   )(
     f: (BinaryMockConsumer, PartitionsHub, Runloop) => ZIO[Scope, Throwable, TestResult]
   ): ZIO[Scope, Throwable, TestResult] =

--- a/zio-kafka-test/src/test/scala/zio/kafka/producer/AsyncProducerTestSupport.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/producer/AsyncProducerTestSupport.scala
@@ -4,6 +4,7 @@ import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, OffsetAndMetad
 import org.apache.kafka.clients.producer.{ Callback, ProducerRecord, RecordMetadata }
 import org.apache.kafka.common.{ Metric, MetricName, PartitionInfo, TopicPartition, Uuid }
 import org.apache.kafka.clients.producer.{ Producer => KafkaProducer }
+import org.apache.kafka.common.metrics.KafkaMetric
 import zio._
 
 import java.time.Duration
@@ -251,11 +252,6 @@ class NotSupportedProducer[K, V] extends KafkaProducer[K, V] {
 
   override def sendOffsetsToTransaction(
     offsets: JMap[TopicPartition, OffsetAndMetadata],
-    consumerGroupId: String
-  ): Unit = throw new UnsupportedOperationException()
-
-  override def sendOffsetsToTransaction(
-    offsets: JMap[TopicPartition, OffsetAndMetadata],
     groupMetadata: ConsumerGroupMetadata
   ): Unit = throw new UnsupportedOperationException()
 
@@ -279,4 +275,8 @@ class NotSupportedProducer[K, V] extends KafkaProducer[K, V] {
   override def close(): Unit = throw new UnsupportedOperationException()
 
   override def close(timeout: Duration): Unit = throw new UnsupportedOperationException()
+
+  override def registerMetricForSubscription(metric: KafkaMetric): Unit = throw new UnsupportedOperationException()
+
+  override def unregisterMetricFromSubscription(metric: KafkaMetric): Unit = throw new UnsupportedOperationException()
 }

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -38,7 +38,7 @@ import org.apache.kafka.clients.consumer.{ OffsetAndMetadata => JOffsetAndMetada
 import org.apache.kafka.common.config.{ ConfigResource => JConfigResource }
 import org.apache.kafka.common.errors.ApiException
 import org.apache.kafka.common.{
-  ConsumerGroupState => JConsumerGroupState,
+  GroupState => JGroupState,
   IsolationLevel => JIsolationLevel,
   KafkaFuture,
   Metric => JMetric,
@@ -53,7 +53,7 @@ import zio.kafka.admin.acl._
 import zio.kafka.utils.SslHelper
 
 import java.util.Optional
-import scala.annotation.{ nowarn, tailrec }
+import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
@@ -279,23 +279,6 @@ trait AdminClient {
    */
   def incrementalAlterConfigsAsync(
     configs: Map[ConfigResource, Iterable[AlterConfigOp]],
-    options: AlterConfigsOptions
-  ): Task[Map[ConfigResource, Task[Unit]]]
-
-  /**
-   * Update the configuration for the specified resources.
-   *
-   * If you are using brokers with version 2.3.0 or higher, please use incrementalAlterConfigs instead.
-   */
-  def alterConfigs(configs: Map[ConfigResource, KafkaConfig], options: AlterConfigsOptions): Task[Unit]
-
-  /**
-   * Update the configuration for the specified resources async.
-   *
-   * If you are using brokers with version 2.3.0 or higher, please use incrementalAlterConfigs instead.
-   */
-  def alterConfigsAsync(
-    configs: Map[ConfigResource, KafkaConfig],
     options: AlterConfigsOptions
   ): Task[Map[ConfigResource, Task[Unit]]]
 
@@ -845,42 +828,6 @@ object AdminClient {
           (ConfigResource(configResource), ZIO.fromCompletionStage(kf.toCompletionStage).unit)
         }.toMap)
 
-    @nowarn("msg=deprecated")
-    override def alterConfigs(configs: Map[ConfigResource, KafkaConfig], options: AlterConfigsOptions): Task[Unit] =
-      fromKafkaFutureVoid(
-        ZIO
-          .attempt(
-            adminClient
-              .alterConfigs(
-                configs.map { case (configResource, kafkaConfig) =>
-                  (configResource.asJava, kafkaConfig.asJava)
-                }.asJava,
-                options.asJava
-              )
-              .all()
-          )
-      )
-
-    @nowarn("msg=deprecated")
-    override def alterConfigsAsync(
-      configs: Map[ConfigResource, KafkaConfig],
-      options: AlterConfigsOptions
-    ): Task[Map[ConfigResource, Task[Unit]]] =
-      ZIO
-        .attempt(
-          adminClient
-            .alterConfigs(
-              configs.map { case (configResource, kafkaConfig) =>
-                (configResource.asJava, kafkaConfig.asJava)
-              }.asJava,
-              options.asJava
-            )
-            .values()
-        )
-        .map(_.asScala.map { case (configResource, kf) =>
-          (ConfigResource(configResource), ZIO.fromCompletionStage(kf.toCompletionStage).unit)
-        }.toMap)
-
     override def describeAcls(
       filter: AclBindingFilter,
       options: Option[DescribeAclOptions]
@@ -1010,6 +957,10 @@ object AdminClient {
       override def asJava = JConfigResource.Type.CLIENT_METRICS
     }
 
+    case object Group extends ConfigResourceType {
+      override def asJava = JConfigResource.Type.GROUP
+    }
+
     def apply(jcrt: JConfigResource.Type): ConfigResourceType =
       jcrt match {
         case JConfigResource.Type.BROKER_LOGGER  => BrokerLogger
@@ -1017,56 +968,57 @@ object AdminClient {
         case JConfigResource.Type.TOPIC          => Topic
         case JConfigResource.Type.UNKNOWN        => Unknown
         case JConfigResource.Type.CLIENT_METRICS => ClientMetrics
+        case JConfigResource.Type.GROUP          => Group
       }
   }
 
-  sealed trait ConsumerGroupState {
-    def asJava: JConsumerGroupState
+  sealed trait GroupState {
+    def asJava: JGroupState
   }
 
-  object ConsumerGroupState {
-    case object Unknown extends ConsumerGroupState {
-      override def asJava: JConsumerGroupState = JConsumerGroupState.UNKNOWN
+  object GroupState {
+    case object Unknown extends GroupState {
+      override def asJava: JGroupState = JGroupState.UNKNOWN
     }
 
-    case object PreparingRebalance extends ConsumerGroupState {
-      override def asJava: JConsumerGroupState = JConsumerGroupState.PREPARING_REBALANCE
+    case object PreparingRebalance extends GroupState {
+      override def asJava: JGroupState = JGroupState.PREPARING_REBALANCE
     }
 
-    case object CompletingRebalance extends ConsumerGroupState {
-      override def asJava: JConsumerGroupState = JConsumerGroupState.COMPLETING_REBALANCE
+    case object CompletingRebalance extends GroupState {
+      override def asJava: JGroupState = JGroupState.COMPLETING_REBALANCE
     }
 
-    case object Stable extends ConsumerGroupState {
-      override def asJava: JConsumerGroupState = JConsumerGroupState.STABLE
+    case object Stable extends GroupState {
+      override def asJava: JGroupState = JGroupState.STABLE
     }
 
-    case object Dead extends ConsumerGroupState {
-      override def asJava: JConsumerGroupState = JConsumerGroupState.DEAD
+    case object Dead extends GroupState {
+      override def asJava: JGroupState = JGroupState.DEAD
     }
 
-    case object Empty extends ConsumerGroupState {
-      override def asJava: JConsumerGroupState = JConsumerGroupState.EMPTY
+    case object Empty extends GroupState {
+      override def asJava: JGroupState = JGroupState.EMPTY
     }
 
-    case object Assigning extends ConsumerGroupState {
-      override def asJava: JConsumerGroupState = JConsumerGroupState.ASSIGNING
+    case object Assigning extends GroupState {
+      override def asJava: JGroupState = JGroupState.ASSIGNING
     }
 
-    case object Reconciling extends ConsumerGroupState {
-      override def asJava: JConsumerGroupState = JConsumerGroupState.RECONCILING
+    case object Reconciling extends GroupState {
+      override def asJava: JGroupState = JGroupState.RECONCILING
     }
 
-    def apply(state: JConsumerGroupState): ConsumerGroupState =
+    def apply(state: JGroupState): GroupState =
       state match {
-        case JConsumerGroupState.UNKNOWN              => ConsumerGroupState.Unknown
-        case JConsumerGroupState.PREPARING_REBALANCE  => ConsumerGroupState.PreparingRebalance
-        case JConsumerGroupState.COMPLETING_REBALANCE => ConsumerGroupState.CompletingRebalance
-        case JConsumerGroupState.STABLE               => ConsumerGroupState.Stable
-        case JConsumerGroupState.DEAD                 => ConsumerGroupState.Dead
-        case JConsumerGroupState.EMPTY                => ConsumerGroupState.Empty
-        case JConsumerGroupState.ASSIGNING            => ConsumerGroupState.Assigning
-        case JConsumerGroupState.RECONCILING          => ConsumerGroupState.Reconciling
+        case JGroupState.UNKNOWN              => GroupState.Unknown
+        case JGroupState.PREPARING_REBALANCE  => GroupState.PreparingRebalance
+        case JGroupState.COMPLETING_REBALANCE => GroupState.CompletingRebalance
+        case JGroupState.STABLE               => GroupState.Stable
+        case JGroupState.DEAD                 => GroupState.Dead
+        case JGroupState.EMPTY                => GroupState.Empty
+        case JGroupState.ASSIGNING            => GroupState.Assigning
+        case JGroupState.RECONCILING          => GroupState.Reconciling
       }
   }
 
@@ -1094,7 +1046,7 @@ object AdminClient {
     isSimpleConsumerGroup: Boolean,
     members: List[MemberDescription],
     partitionAssignor: String,
-    state: ConsumerGroupState,
+    state: GroupState,
     coordinator: Option[Node],
     authorizedOperations: Set[AclOperation]
   )
@@ -1107,7 +1059,7 @@ object AdminClient {
         isSimpleConsumerGroup = description.isSimpleConsumerGroup,
         members = description.members.asScala.map(MemberDescription.apply).toList,
         partitionAssignor = description.partitionAssignor,
-        state = ConsumerGroupState(description.state),
+        state = GroupState(description.groupState),
         coordinator = Node(description.coordinator()),
         authorizedOperations = Option(description.authorizedOperations())
           .fold(Set.empty[AclOperation])(_.asScala.map(AclOperation.apply).toSet)
@@ -1441,18 +1393,16 @@ object AdminClient {
       ListOffsetsResultInfo(lo.offset(), lo.timestamp(), lo.leaderEpoch().toScala.map(_.toInt))
   }
 
-  @nowarn("msg=deprecated")
-  final case class ListConsumerGroupOffsetsOptions(partitions: Chunk[TopicPartition], requireStable: Boolean) {
+  final case class ListConsumerGroupOffsetsOptions(requireStable: Boolean) {
     def asJava: JListConsumerGroupOffsetsOptions = {
       val opts = new JListConsumerGroupOffsetsOptions()
       opts.requireStable(requireStable)
-      if (partitions.isEmpty) opts else opts.topicPartitions(partitions.map(_.asJava).asJava)
     }
   }
 
   object ListConsumerGroupOffsetsOptions {
     def apply(requireStable: Boolean): ListConsumerGroupOffsetsOptions =
-      new ListConsumerGroupOffsetsOptions(Chunk.empty, requireStable)
+      new ListConsumerGroupOffsetsOptions(requireStable)
   }
 
   final case class ListConsumerGroupOffsetsSpec(partitions: Chunk[TopicPartition]) {
@@ -1486,18 +1436,18 @@ object AdminClient {
     }
   }
 
-  final case class ListConsumerGroupsOptions(states: Set[ConsumerGroupState]) {
-    def asJava: JListConsumerGroupsOptions = new JListConsumerGroupsOptions().inStates(states.map(_.asJava).asJava)
+  final case class ListConsumerGroupsOptions(states: Set[GroupState]) {
+    def asJava: JListConsumerGroupsOptions = new JListConsumerGroupsOptions().inGroupStates(states.map(_.asJava).asJava)
   }
 
-  final case class ConsumerGroupListing(groupId: String, isSimple: Boolean, state: Option[ConsumerGroupState])
+  final case class ConsumerGroupListing(groupId: String, isSimple: Boolean, state: Option[GroupState])
 
   object ConsumerGroupListing {
     def apply(cg: JConsumerGroupListing): ConsumerGroupListing =
       ConsumerGroupListing(
         groupId = cg.groupId(),
         isSimple = cg.isSimpleConsumerGroup,
-        state = cg.state().toScala.map(ConsumerGroupState(_))
+        state = cg.groupState().toScala.map(GroupState(_))
       )
   }
 


### PR DESCRIPTION
This adds commits on top of the ongoing work to support Kafka 4.x in https://github.com/zio/zio-kafka/pull/1504, just as a way to share changes. This PR is not intended to be merged.

This also serves as integration tests for embedded-kafka 4.x (https://github.com/embeddedkafka/embedded-kafka/pull/562)

---

Test status:

- `AdminSpec`: consistent failures in 4 tests, the errors makes it look like it's a timing issue, it's like the `listTopicsFiltered` gives obsolete data or doesn't wait for the previous action (create/delete topic) to actually be done.
  - `client admin test / create, describe, delete multiple topic`
  - `client admin test / create, list, delete single topic`
  - `client admin test / create, list, delete multiple topic`
  - `client admin test - create, describe topic config, delete multiple topic`
- `ConsumerSpec`: two tests failing after a 2mn timeout
  - `Consumer Streaming - does not process messages twice for transactional producer, even when rebalancing - org.apache.kafka.clients.consumer.RangeAssignor`
  - `Consumer Streaming - does not process messages twice for transactional producer, even when rebalancing - org.apache.kafka.clients.consumer.CooperativeStickyAssignor`
- `ProducerSpec`: a few tests failing, likely caused by the 1st error `Compacted topic cannot accept message without key in topic partition`. It's unclear to me why it would start failing now and I'm also unclear if this is deliberate in the tests to have no key or not.
- `AdminSaslSpec`: errors due to `org.apache.kafka.common.errors.ClusterAuthorizationException: Request Request(processor=0, connectionId=127.0.0.1:7001-127.0.0.1:56736-0-0, session=org.apache.kafka.network.Session@3d97f66e, listenerName=ListenerName(CONTROLLER), securityProtocol=PLAINTEXT, buffer=null, envelope=None) is not authorized.`. This one may be related to the setup of the tests and/or embedded-kafka. Unclear for now.

 