### PR TITLE
Make all benchmarks report average time

### DIFF
--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaProducerBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaProducerBenchmark.scala
@@ -64,8 +64,7 @@ class ZioKafkaProducerBenchmark extends ProducerZioBenchmark[Kafka with Producer
   }
 
   @Benchmark
-  @BenchmarkMode(Array(Mode.Throughput))
-  @OutputTimeUnit(TimeUnit.SECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
   def produceSingleRecordSeq(): Any = runZIO {
     // Produce 100 records sequentially
     for {
@@ -75,8 +74,7 @@ class ZioKafkaProducerBenchmark extends ProducerZioBenchmark[Kafka with Producer
   }
 
   @Benchmark
-  @BenchmarkMode(Array(Mode.Throughput))
-  @OutputTimeUnit(TimeUnit.SECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
   def produceSingleRecordPar(): Any = runZIO {
     // Produce 100 records of which 4 run in parallel
     for {


### PR DESCRIPTION
There are 2 benchmarks that deviate from the others by reporting their results in throughput (ops/s) i.s.o. average time (ms/op). With this change all benchmarks use average time.