### PR TITLE
Add comment highlighting motivation behind usage of lazy val during records publication

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -406,6 +406,8 @@ private[producer] final class ProducerLive(
       val totalRecordCount = records.size
       val diagEm           = diagnosticsEmitterMaker.makeDiagnosticsEmitter(records)
 
+      // Collects the send results over one or more retries.
+      // Lazy to prevent allocation when all sends succeed on the first attempt.
       lazy val finalResults: Array[Either[Throwable, RecordMetadata]] =
         Array.fill(totalRecordCount)(leftPublishOmitted)
 


### PR DESCRIPTION
https://github.com/zio/zio-kafka/pull/1437 introduced a clever way to retry records publication after specific errors (more details in the referred PR).
There is a place of `lazy val` usage in that implementation, which may raise questions of why we need it, from the folks unfamiliar with the implementation.
To add a bit more clarity, this PR adds a comment with the reasoning for using  `lazy val`.