### PR TITLE
Producer micro optimizations by using `Iterable` instead of `Chunk`

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -428,8 +428,8 @@ private[producer] final class ProducerLive(
             // Note that if we get here, all Left's can be retried. Also, we know there is at least 1 Left.
             val toRetry: Chunk[(Int, ByteRecord)] =
               (results lazyZip recordIndices lazyZip records).flatMap {
-                case (Right(_), _, _)     => Chunk.empty
-                case (Left(_), i, record) => Chunk.single((i, record))
+                case (Right(_), _, _)     => Iterable.empty
+                case (Left(_), i, record) => Iterable.single((i, record))
               }
             val (retryIndices, retryRecords) = toRetry.unzip
             ZIO.logInfo(


### PR DESCRIPTION
Some nitpicking here:
Following https://github.com/zio/zio-kafka/pull/1527#discussion_r2072424219 I believe `Iterable` should be a better choice instead of `Chunk` for the temp collection.
The way this collection is used (inside `LazyZip.flatMap`) is by calling `.iterator` on it.
`Chunk.[empty|single].iterator` is comparatively way heavier than `Iterable.[empty|single].iterator` (sure we are talking about very-very small impact).