### PR TITLE
More and better producer benchmarks

### DIFF
--- a/zio-kafka-bench/README.md
+++ b/zio-kafka-bench/README.md
@@ -53,20 +53,22 @@ topic subscription.
 ## The producer benchmarks
 
 #### zio.kafka.bench.ZioKafkaProducerBenchmark.produceChunkSeq
+#### zio.kafka.bench.ZioKafkaProducerBenchmark.produceChunkSeqAsync
 
 Sequentially produces 30 batches, where each batch contains 500 small records.
 
 #### zio.kafka.bench.ZioKafkaProducerBenchmark.produceChunkPar
+#### zio.kafka.bench.ZioKafkaProducerBenchmark.produceChunkParAsync
 
 Produces the same batches as the above, but from 4 fibers.
 
-#### zio.kafka.bench.ZioKafkaProducerBenchmark.produceSingleRecordSeq
+#### zio.kafka.bench.ZioKafkaSeqProducerBenchmark.produceSingleRecordSeq
 
-Sequentially produces 100 small records.
+Sequentially produces 100 small records. Lingering is disabled.
 
-#### zio.kafka.bench.ZioKafkaProducerBenchmark.produceSingleRecordPar
+#### zio.kafka.bench.ZioKafkaSeqProducerBenchmark.produceSingleRecordPar
 
-Produces 100 small records from 4 fibers.
+Produces 100 small records from 4 fibers. Lingering is disabled.
 
 # How to run the benchmarks
 

--- a/zio-kafka-bench/README.md
+++ b/zio-kafka-bench/README.md
@@ -57,14 +57,19 @@ topic subscription.
 
 Sequentially produces 30 batches, where each batch contains 500 small records.
 
+The async version does not wait for acknowledges.
+
 #### zio.kafka.bench.ZioKafkaProducerBenchmark.produceChunkPar
-#### zio.kafka.bench.ZioKafkaProducerBenchmark.produceChunkParAsync
 
 Produces the same batches as the above, but from 4 fibers.
 
 #### zio.kafka.bench.ZioKafkaSeqProducerBenchmark.produceSingleRecordSeq
 
 Sequentially produces 100 small records. Lingering is disabled.
+
+#### zio.kafka.bench.ZioKafkaProducerBenchmark.produceSingleRecordSeqAsync
+
+Sequentially produces 100 small records, do not wait for acknowledges.
 
 #### zio.kafka.bench.ZioKafkaSeqProducerBenchmark.produceSingleRecordPar
 

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaProducerBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaProducerBenchmark.scala
@@ -37,7 +37,7 @@ class ZioKafkaProducerBenchmark extends ProducerZioBenchmark[Kafka with Producer
     // Produce 100 records
     for {
       producer <- ZIO.service[Producer]
-      _        <- producer.produceAsync(topic1, "key", "value", Serde.string, Serde.string).schedule(Schedule.recurs(100))
+      _ <- producer.produceAsync(topic1, "key", "value", Serde.string, Serde.string).schedule(Schedule.recurs(100))
     } yield ()
   }
 

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaSeqProducerBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaSeqProducerBenchmark.scala
@@ -1,0 +1,65 @@
+package zio.kafka.bench
+
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.openjdk.jmh.annotations._
+import zio.kafka.admin.AdminClient.NewTopic
+import zio.kafka.producer.Producer
+import zio.kafka.serde.Serde
+import zio.kafka.testkit.{Kafka, KafkaTestUtils}
+import zio.stream.ZStream
+import zio.{Scope => _, _}
+
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+class ZioKafkaSeqProducerBenchmark extends ProducerZioBenchmark[Kafka with Producer] {
+  val records: Chunk[ProducerRecord[String, String]] = Chunk.fromIterable(kvs.map { case (k, v) =>
+    new ProducerRecord(topic1, k, v)
+  })
+
+  override protected def bootstrap: ZLayer[Any, Nothing, Kafka with Producer] =
+    ZLayer
+      .make[Kafka with Producer](
+        Kafka.embedded,
+        // Producing record by record does not play well with linger: set it to zero.
+        ZLayer.fromZIO(KafkaTestUtils.producerSettings.map(_.withLinger(0.millis))),
+        Producer.live
+      )
+      .orDie
+
+  override def initialize: ZIO[Kafka & Producer, Throwable, Any] =
+    ZIO.scoped {
+      for {
+        adminClient <- KafkaTestUtils.makeAdminClient
+        _           <- adminClient.deleteTopic(topic1).ignore
+        _           <- adminClient.createTopic(NewTopic(topic1, partitionCount, replicationFactor = 1))
+      } yield ()
+    }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def produceSingleRecordSeq(): Any = runZIO {
+    // Produce 100 records sequentially
+    for {
+      producer <- ZIO.service[Producer]
+      _        <- producer.produce(topic1, "key", "value", Serde.string, Serde.string).schedule(Schedule.recurs(100))
+    } yield ()
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def produceSingleRecordPar(): Any = runZIO {
+    // Produce 100 records of which 4 run in parallel
+    for {
+      producer <- ZIO.service[Producer]
+      _ <- ZStream
+        .range(0, 100, 1)
+        .mapZIOParUnordered(4) { _ =>
+          producer.produce(topic1, "key", "value", Serde.string, Serde.string)
+        }
+        .runDrain
+    } yield ()
+  }
+
+}

--- a/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaSeqProducerBenchmark.scala
+++ b/zio-kafka-bench/src/main/scala/zio/kafka/bench/ZioKafkaSeqProducerBenchmark.scala
@@ -5,9 +5,9 @@ import org.openjdk.jmh.annotations._
 import zio.kafka.admin.AdminClient.NewTopic
 import zio.kafka.producer.Producer
 import zio.kafka.serde.Serde
-import zio.kafka.testkit.{Kafka, KafkaTestUtils}
+import zio.kafka.testkit.{ Kafka, KafkaTestUtils }
 import zio.stream.ZStream
-import zio.{Scope => _, _}
+import zio.{ Scope => _, _ }
 
 import java.util.concurrent.TimeUnit
 
@@ -54,11 +54,11 @@ class ZioKafkaSeqProducerBenchmark extends ProducerZioBenchmark[Kafka with Produ
     for {
       producer <- ZIO.service[Producer]
       _ <- ZStream
-        .range(0, 100, 1)
-        .mapZIOParUnordered(4) { _ =>
-          producer.produce(topic1, "key", "value", Serde.string, Serde.string)
-        }
-        .runDrain
+             .range(0, 100, 1)
+             .mapZIOParUnordered(4) { _ =>
+               producer.produce(topic1, "key", "value", Serde.string, Serde.string)
+             }
+             .runDrain
     } yield ()
   }
 


### PR DESCRIPTION
The producer benchmarks that do record by record synchronous producing, do not benefit from lingering in the kafka layer. These are therefore split of to a separate file in which lingering is disabled.

Secondly: add asynchronous producer benchmarks.

Also: use `schedule` instead of `repeatN`.