### PR TITLE
Add implicit trace parameter

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/fetch/ManyPartitionsQueueSizeBasedFetchStrategySpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/fetch/ManyPartitionsQueueSizeBasedFetchStrategySpec.scala
@@ -111,7 +111,7 @@ object ManyPartitionsQueueSizeBasedFetchStrategySpec extends ZIOSpecDefaultSlf4j
 
   private def newStream(topicPartition: TopicPartition, currentQueueSize: Int): PartitionStream =
     new PartitionStream {
-      override def tp: TopicPartition  = topicPartition
-      override def queueSize: UIO[Int] = ZIO.succeed(currentQueueSize)
+      override def tp: TopicPartition                         = topicPartition
+      override def queueSize(implicit trace: Trace): UIO[Int] = ZIO.succeed(currentQueueSize)
     }
 }

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/fetch/QueueSizeBasedFetchStrategySpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/fetch/QueueSizeBasedFetchStrategySpec.scala
@@ -49,7 +49,7 @@ object QueueSizeBasedFetchStrategySpec extends ZIOSpecDefaultSlf4j {
 
   private def newStream(topicPartition: TopicPartition, currentQueueSize: Int): PartitionStream =
     new PartitionStream {
-      override def tp: TopicPartition  = topicPartition
-      override def queueSize: UIO[Int] = ZIO.succeed(currentQueueSize)
+      override def tp: TopicPartition                         = topicPartition
+      override def queueSize(implicit trace: Trace): UIO[Int] = ZIO.succeed(currentQueueSize)
     }
 }

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/DummyMetrics.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/DummyMetrics.scala
@@ -2,22 +2,25 @@ package zio.kafka.consumer.internal
 import zio._
 
 private[internal] class DummyMetrics extends ConsumerMetrics {
-  override def observePoll(resumedCount: Int, pausedCount: Int, latency: zio.Duration, pollSize: Int): UIO[Unit] =
+  override def observePoll(resumedCount: Int, pausedCount: Int, latency: zio.Duration, pollSize: Int)(implicit
+    trace: Trace
+  ): UIO[Unit] =
     ZIO.unit
 
-  override def observeCommit(latency: zio.Duration): UIO[Unit]                                 = ZIO.unit
-  override def observeAggregatedCommit(latency: zio.Duration, commitSize: NanoTime): UIO[Unit] = ZIO.unit
+  override def observeCommit(latency: zio.Duration)(implicit trace: Trace): UIO[Unit] = ZIO.unit
+  override def observeAggregatedCommit(latency: zio.Duration, commitSize: NanoTime)(implicit trace: Trace): UIO[Unit] =
+    ZIO.unit
   override def observeRebalance(
     currentlyAssignedCount: Int,
     assignedCount: Int,
     revokedCount: Int,
     lostCount: Int
-  ): UIO[Unit] = ZIO.unit
+  )(implicit trace: Trace): UIO[Unit] = ZIO.unit
   override def observeRunloopMetrics(
     state: Runloop.State,
     commandQueueSize: Int,
     commitQueueSize: Int,
     pendingCommits: Int
-  ): UIO[Unit] = ZIO.unit
-  override def observePollAuthError(): UIO[Unit] = ZIO.unit
+  )(implicit trace: Trace): UIO[Unit] = ZIO.unit
+  override def observePollAuthError()(implicit trace: Trace): UIO[Unit] = ZIO.unit
 }

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -302,8 +302,8 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
 }
 
 abstract private class MockCommitter extends Committer {
-  override val commit: Map[TopicPartition, OffsetAndMetadata] => Task[Unit]                  = _ => ZIO.unit
-  override val registerExternalCommits: Map[TopicPartition, OffsetAndMetadata] => Task[Unit] = _ => ZIO.unit
+  override def commit(offsets: Map[TopicPartition, OffsetAndMetadata])(implicit trace: Trace): Task[Unit] = ZIO.unit
+  override def registerExternalCommits(offsets: Map[TopicPartition, OffsetAndMetadata])(implicit trace: Trace): Task[Unit] = ZIO.unit
 
   override def processQueuedCommits(consumer: ByteArrayKafkaConsumer, executeOnEmpty: Boolean)(implicit
     trace: Trace

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -20,24 +20,28 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
   type BinaryMockConsumer = MockConsumer[Array[Byte], Array[Byte]]
 
   private val mockMetrics = new ConsumerMetrics {
-    override def observePoll(resumedCount: Int, pausedCount: Int, latency: zio.Duration, pollSize: Int): UIO[Unit] =
+    override def observePoll(resumedCount: Int, pausedCount: Int, latency: zio.Duration, pollSize: Int)(implicit
+      trace: Trace
+    ): UIO[Unit] =
       ZIO.unit
 
-    override def observeCommit(latency: zio.Duration): UIO[Unit]                                 = ZIO.unit
-    override def observeAggregatedCommit(latency: zio.Duration, commitSize: NanoTime): UIO[Unit] = ZIO.unit
+    override def observeCommit(latency: zio.Duration)(implicit trace: Trace): UIO[Unit] = ZIO.unit
+    override def observeAggregatedCommit(latency: zio.Duration, commitSize: NanoTime)(implicit
+      trace: Trace
+    ): UIO[Unit] = ZIO.unit
     override def observeRebalance(
       currentlyAssignedCount: Int,
       assignedCount: Int,
       revokedCount: Int,
       lostCount: Int
-    ): UIO[Unit] = ZIO.unit
+    )(implicit trace: Trace): UIO[Unit] = ZIO.unit
     override def observeRunloopMetrics(
       state: Runloop.State,
       commandQueueSize: Int,
       commitQueueSize: Int,
       pendingCommits: Int
-    ): UIO[Unit] = ZIO.unit
-    override def observePollAuthError(): UIO[Unit] = ZIO.unit
+    )(implicit trace: Trace): UIO[Unit] = ZIO.unit
+    override def observePollAuthError()(implicit trace: Trace): UIO[Unit] = ZIO.unit
   }
 
   def spec: Spec[TestEnvironment with Scope, Throwable] =
@@ -301,14 +305,17 @@ abstract private class MockCommitter extends Committer {
   override val commit: Map[TopicPartition, OffsetAndMetadata] => Task[Unit]                  = _ => ZIO.unit
   override val registerExternalCommits: Map[TopicPartition, OffsetAndMetadata] => Task[Unit] = _ => ZIO.unit
 
-  override def processQueuedCommits(consumer: ByteArrayKafkaConsumer, executeOnEmpty: Boolean): Task[Unit] = ZIO.unit
+  override def processQueuedCommits(consumer: ByteArrayKafkaConsumer, executeOnEmpty: Boolean)(implicit
+    trace: Trace
+  ): Task[Unit] = ZIO.unit
 
-  override def queueSize: UIO[Int]                   = ZIO.succeed(0)
-  override def pendingCommitCount: UIO[Int]          = ZIO.succeed(0)
-  override def getPendingCommits: UIO[CommitOffsets] = ZIO.succeed(CommitOffsets.empty)
-  override def cleanupPendingCommits: UIO[Unit]      = ZIO.unit
-  override def keepCommitsForPartitions(assignedPartitions: Set[TopicPartition]): UIO[Unit] = ZIO.unit
-  override def getCommittedOffsets: UIO[CommitOffsets] = ZIO.succeed(CommitOffsets.empty)
+  override def queueSize(implicit trace: Trace): UIO[Int]                   = ZIO.succeed(0)
+  override def pendingCommitCount(implicit trace: Trace): UIO[Int]          = ZIO.succeed(0)
+  override def getPendingCommits(implicit trace: Trace): UIO[CommitOffsets] = ZIO.succeed(CommitOffsets.empty)
+  override def cleanupPendingCommits(implicit trace: Trace): UIO[Unit]      = ZIO.unit
+  override def keepCommitsForPartitions(assignedPartitions: Set[TopicPartition])(implicit trace: Trace): UIO[Unit] =
+    ZIO.unit
+  override def getCommittedOffsets(implicit trace: Trace): UIO[CommitOffsets] = ZIO.succeed(CommitOffsets.empty)
 }
 
 private class CommitTrackingMockConsumer(

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -303,7 +303,9 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
 
 abstract private class MockCommitter extends Committer {
   override def commit(offsets: Map[TopicPartition, OffsetAndMetadata])(implicit trace: Trace): Task[Unit] = ZIO.unit
-  override def registerExternalCommits(offsets: Map[TopicPartition, OffsetAndMetadata])(implicit trace: Trace): Task[Unit] = ZIO.unit
+  override def registerExternalCommits(offsets: Map[TopicPartition, OffsetAndMetadata])(implicit
+    trace: Trace
+  ): Task[Unit] = ZIO.unit
 
   override def processQueuedCommits(consumer: ByteArrayKafkaConsumer, executeOnEmpty: Boolean)(implicit
     trace: Trace

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/Kafka.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/Kafka.scala
@@ -2,6 +2,7 @@ package zio.kafka.testkit
 
 import io.github.embeddedkafka.{ EmbeddedK, EmbeddedKafka, EmbeddedKafkaConfig }
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 trait Kafka {
   def bootstrapServers: List[String]

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaRandom.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaRandom.scala
@@ -8,11 +8,11 @@ trait KafkaRandom {
 
   def kafkaPrefix: String
 
-  def randomThing(prefix: String): Task[String] = ZIO.attempt(s"$prefix-${UUID.randomUUID()}")
+  def randomThing(prefix: String)(implicit trace: Trace): Task[String] = ZIO.attempt(s"$prefix-${UUID.randomUUID()}")
 
-  def randomTopic: Task[String] = randomThing(s"$kafkaPrefix-topic")
+  def randomTopic(implicit trace: Trace): Task[String] = randomThing(s"$kafkaPrefix-topic")
 
-  def randomGroup: Task[String] = randomThing(s"$kafkaPrefix-group")
+  def randomGroup(implicit trace: Trace): Task[String] = randomThing(s"$kafkaPrefix-group")
 
-  def randomClient: Task[String] = randomThing(s"$kafkaPrefix-client")
+  def randomClient(implicit trace: Trace): Task[String] = randomThing(s"$kafkaPrefix-client")
 }

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaRandom.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaRandom.scala
@@ -1,6 +1,7 @@
 package zio.kafka.testkit
 
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.UUID
 

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -10,6 +10,7 @@ import zio.kafka.diagnostics.Diagnostics
 import zio.kafka.producer._
 import zio.kafka.serde.{ Deserializer, Serde }
 import zio.stream.ZStream
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.File
 import java.nio.file.{ Files, StandardCopyOption }

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/ZIOSpecWithKafka.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/ZIOSpecWithKafka.scala
@@ -2,6 +2,7 @@ package zio.kafka.testkit
 
 import zio.ZLayer
 import zio.test._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * This trait should be used if you want to run your tests with a shared-across-your-suites embedded Kafka cluster.

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -58,6 +58,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success, Try }
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * Admin client, can be used to create, list, delete topics, consumer groups, etc.

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -72,12 +72,12 @@ trait AdminClient {
   def createTopics(
     newTopics: Iterable[NewTopic],
     options: Option[CreateTopicsOptions] = None
-  ): Task[Unit]
+  )(implicit trace: Trace): Task[Unit]
 
   /**
    * Create a single topic.
    */
-  def createTopic(newTopic: NewTopic, validateOnly: Boolean = false): Task[Unit]
+  def createTopic(newTopic: NewTopic, validateOnly: Boolean = false)(implicit trace: Trace): Task[Unit]
 
   /**
    * Delete consumer groups.
@@ -85,7 +85,7 @@ trait AdminClient {
   def deleteConsumerGroups(
     groupIds: Iterable[String],
     options: Option[DeleteConsumerGroupOptions] = None
-  ): Task[Unit]
+  )(implicit trace: Trace): Task[Unit]
 
   /**
    * Delete multiple topics.
@@ -93,12 +93,12 @@ trait AdminClient {
   def deleteTopics(
     topics: Iterable[String],
     options: Option[DeleteTopicsOptions] = None
-  ): Task[Unit]
+  )(implicit trace: Trace): Task[Unit]
 
   /**
    * Delete a single topic.
    */
-  def deleteTopic(topic: String): Task[Unit]
+  def deleteTopic(topic: String)(implicit trace: Trace): Task[Unit]
 
   /**
    * Delete records.
@@ -106,12 +106,14 @@ trait AdminClient {
   def deleteRecords(
     recordsToDelete: Map[TopicPartition, RecordsToDelete],
     deleteRecordsOptions: Option[DeleteRecordsOptions] = None
-  ): Task[Unit]
+  )(implicit trace: Trace): Task[Unit]
 
   /**
    * List the topics in the cluster.
    */
-  def listTopics(listTopicsOptions: Option[ListTopicsOptions] = None): Task[Map[String, TopicListing]]
+  def listTopics(listTopicsOptions: Option[ListTopicsOptions] = None)(implicit
+    trace: Trace
+  ): Task[Map[String, TopicListing]]
 
   /**
    * Describe the specified topics.
@@ -119,7 +121,7 @@ trait AdminClient {
   def describeTopics(
     topicNames: Iterable[String],
     options: Option[DescribeTopicsOptions] = None
-  ): Task[Map[String, TopicDescription]]
+  )(implicit trace: Trace): Task[Map[String, TopicDescription]]
 
   /**
    * Get the configuration for the specified resources.
@@ -127,7 +129,7 @@ trait AdminClient {
   def describeConfigs(
     configResources: Iterable[ConfigResource],
     options: Option[DescribeConfigsOptions] = None
-  ): Task[Map[ConfigResource, KafkaConfig]]
+  )(implicit trace: Trace): Task[Map[ConfigResource, KafkaConfig]]
 
   /**
    * Get the configuration for the specified resources async.
@@ -135,29 +137,31 @@ trait AdminClient {
   def describeConfigsAsync(
     configResources: Iterable[ConfigResource],
     options: Option[DescribeConfigsOptions] = None
-  ): Task[Map[ConfigResource, Task[KafkaConfig]]]
+  )(implicit trace: Trace): Task[Map[ConfigResource, Task[KafkaConfig]]]
 
   /**
    * Get the cluster nodes.
    */
-  def describeClusterNodes(options: Option[DescribeClusterOptions] = None): Task[List[Node]]
+  def describeClusterNodes(options: Option[DescribeClusterOptions] = None)(implicit trace: Trace): Task[List[Node]]
 
   /**
    * Get the cluster controller.
    */
-  def describeClusterController(options: Option[DescribeClusterOptions] = None): Task[Option[Node]]
+  def describeClusterController(options: Option[DescribeClusterOptions] = None)(implicit
+    trace: Trace
+  ): Task[Option[Node]]
 
   /**
    * Get the cluster id.
    */
-  def describeClusterId(options: Option[DescribeClusterOptions] = None): Task[String]
+  def describeClusterId(options: Option[DescribeClusterOptions] = None)(implicit trace: Trace): Task[String]
 
   /**
    * Get the cluster authorized operations.
    */
   def describeClusterAuthorizedOperations(
     options: Option[DescribeClusterOptions] = None
-  ): Task[Set[AclOperation]]
+  )(implicit trace: Trace): Task[Set[AclOperation]]
 
   /**
    * Add new partitions to a topic.
@@ -165,7 +169,7 @@ trait AdminClient {
   def createPartitions(
     newPartitions: Map[String, NewPartitions],
     options: Option[CreatePartitionsOptions] = None
-  ): Task[Unit]
+  )(implicit trace: Trace): Task[Unit]
 
   /**
    * List offset for the specified partitions.
@@ -173,7 +177,7 @@ trait AdminClient {
   def listOffsets(
     topicPartitionOffsets: Map[TopicPartition, OffsetSpec],
     options: Option[ListOffsetsOptions] = None
-  ): Task[Map[TopicPartition, ListOffsetsResultInfo]]
+  )(implicit trace: Trace): Task[Map[TopicPartition, ListOffsetsResultInfo]]
 
   /**
    * List offset for the specified partitions.
@@ -181,7 +185,7 @@ trait AdminClient {
   def listOffsetsAsync(
     topicPartitionOffsets: Map[TopicPartition, OffsetSpec],
     options: Option[ListOffsetsOptions] = None
-  ): Task[Map[TopicPartition, Task[ListOffsetsResultInfo]]]
+  )(implicit trace: Trace): Task[Map[TopicPartition, Task[ListOffsetsResultInfo]]]
 
   /**
    * List Consumer Group offsets for the specified partitions.
@@ -189,7 +193,7 @@ trait AdminClient {
   def listConsumerGroupOffsets(
     groupId: String,
     options: Option[ListConsumerGroupOffsetsOptions] = None
-  ): Task[Map[TopicPartition, OffsetAndMetadata]]
+  )(implicit trace: Trace): Task[Map[TopicPartition, OffsetAndMetadata]]
 
   /**
    * Given a mapping of consumer group IDs and list of partitions, list the consumer group offsets available in the
@@ -197,7 +201,7 @@ trait AdminClient {
    */
   def listConsumerGroupOffsets(
     groupSpecs: Map[String, ListConsumerGroupOffsetsSpec]
-  ): Task[Map[String, Map[TopicPartition, OffsetAndMetadata]]]
+  )(implicit trace: Trace): Task[Map[String, Map[TopicPartition, OffsetAndMetadata]]]
 
   /**
    * Given a mapping of consumer group IDs and list of partitions, list the consumer group offsets available in the
@@ -206,7 +210,7 @@ trait AdminClient {
   def listConsumerGroupOffsets(
     groupSpecs: Map[String, ListConsumerGroupOffsetsSpec],
     options: ListConsumerGroupOffsetsOptions
-  ): Task[Map[String, Map[TopicPartition, OffsetAndMetadata]]]
+  )(implicit trace: Trace): Task[Map[String, Map[TopicPartition, OffsetAndMetadata]]]
 
   /**
    * Alter offsets for the specified partitions and consumer group.
@@ -215,22 +219,24 @@ trait AdminClient {
     groupId: String,
     offsets: Map[TopicPartition, OffsetAndMetadata],
     options: Option[AlterConsumerGroupOffsetsOptions] = None
-  ): Task[Unit]
+  )(implicit trace: Trace): Task[Unit]
 
   /**
    * Retrieves metrics for the underlying AdminClient
    */
-  def metrics: Task[Map[MetricName, Metric]]
+  def metrics(implicit trace: Trace): Task[Map[MetricName, Metric]]
 
   /**
    * List the consumer groups in the cluster.
    */
-  def listConsumerGroups(options: Option[ListConsumerGroupsOptions] = None): Task[List[ConsumerGroupListing]]
+  def listConsumerGroups(options: Option[ListConsumerGroupsOptions] = None)(implicit
+    trace: Trace
+  ): Task[List[ConsumerGroupListing]]
 
   /**
    * Describe the specified consumer groups.
    */
-  def describeConsumerGroups(groupIds: String*): Task[Map[String, ConsumerGroupDescription]]
+  def describeConsumerGroups(groupIds: String*)(implicit trace: Trace): Task[Map[String, ConsumerGroupDescription]]
 
   /**
    * Describe the specified consumer groups.
@@ -238,31 +244,31 @@ trait AdminClient {
   def describeConsumerGroups(
     groupIds: List[String],
     options: Option[DescribeConsumerGroupsOptions]
-  ): Task[Map[String, ConsumerGroupDescription]]
+  )(implicit trace: Trace): Task[Map[String, ConsumerGroupDescription]]
 
   /**
    * Remove the specified members from a consumer group.
    */
-  def removeMembersFromConsumerGroup(groupId: String, membersToRemove: Set[String]): Task[Unit]
+  def removeMembersFromConsumerGroup(groupId: String, membersToRemove: Set[String])(implicit trace: Trace): Task[Unit]
 
   /**
    * Remove all members from a consumer group.
    */
-  def removeMembersFromConsumerGroup(groupId: String): Task[Unit]
+  def removeMembersFromConsumerGroup(groupId: String)(implicit trace: Trace): Task[Unit]
 
   /**
    * Describe the log directories of the specified brokers
    */
   def describeLogDirs(
     brokersId: Iterable[Int]
-  ): ZIO[Any, Throwable, Map[Int, Map[String, LogDirDescription]]]
+  )(implicit trace: Trace): ZIO[Any, Throwable, Map[Int, Map[String, LogDirDescription]]]
 
   /**
    * Describe the log directories of the specified brokers async
    */
   def describeLogDirsAsync(
     brokersId: Iterable[Int]
-  ): ZIO[Any, Throwable, Map[Int, Task[Map[String, LogDirDescription]]]]
+  )(implicit trace: Trace): ZIO[Any, Throwable, Map[Int, Task[Map[String, LogDirDescription]]]]
 
   /**
    * Incrementally update the configuration for the specified resources. Only supported by brokers with version 2.3.0 or
@@ -271,7 +277,7 @@ trait AdminClient {
   def incrementalAlterConfigs(
     configs: Map[ConfigResource, Iterable[AlterConfigOp]],
     options: AlterConfigsOptions
-  ): Task[Unit]
+  )(implicit trace: Trace): Task[Unit]
 
   /**
    * Incrementally update the configuration for the specified resources async. Only supported by brokers with version
@@ -280,7 +286,7 @@ trait AdminClient {
   def incrementalAlterConfigsAsync(
     configs: Map[ConfigResource, Iterable[AlterConfigOp]],
     options: AlterConfigsOptions
-  ): Task[Map[ConfigResource, Task[Unit]]]
+  )(implicit trace: Trace): Task[Map[ConfigResource, Task[Unit]]]
 
   /*
    * Lists access control lists (ACLs) according to the supplied filter.
@@ -288,12 +294,14 @@ trait AdminClient {
    * Note: it may take some time for changes made by createAcls or deleteAcls to be reflected in the output of
    * describeAcls.
    */
-  def describeAcls(filter: AclBindingFilter, options: Option[DescribeAclOptions] = None): Task[Set[AclBinding]]
+  def describeAcls(filter: AclBindingFilter, options: Option[DescribeAclOptions] = None)(implicit
+    trace: Trace
+  ): Task[Set[AclBinding]]
 
   /**
    * Creates access control lists (ACLs) which are bound to specific resources.
    */
-  def createAcls(acls: Set[AclBinding], options: Option[CreateAclOptions] = None): Task[Unit]
+  def createAcls(acls: Set[AclBinding], options: Option[CreateAclOptions] = None)(implicit trace: Trace): Task[Unit]
 
   /**
    * Creates access control lists (ACLs) which are bound to specific resources async.
@@ -301,12 +309,14 @@ trait AdminClient {
   def createAclsAsync(
     acls: Set[AclBinding],
     options: Option[CreateAclOptions] = None
-  ): Task[Map[AclBinding, Task[Unit]]]
+  )(implicit trace: Trace): Task[Map[AclBinding, Task[Unit]]]
 
   /**
    * Deletes access control lists (ACLs) according to the supplied filters.
    */
-  def deleteAcls(filters: Set[AclBindingFilter], options: Option[DeleteAclsOptions] = None): Task[Set[AclBinding]]
+  def deleteAcls(filters: Set[AclBindingFilter], options: Option[DeleteAclsOptions] = None)(implicit
+    trace: Trace
+  ): Task[Set[AclBinding]]
 
   /**
    * Deletes access control lists (ACLs) according to the supplied filters async.
@@ -314,7 +324,7 @@ trait AdminClient {
   def deleteAclsAsync(
     filters: Set[AclBindingFilter],
     options: Option[DeleteAclsOptions] = None
-  ): Task[Map[AclBindingFilter, Task[Map[AclBinding, Option[Throwable]]]]]
+  )(implicit trace: Trace): Task[Map[AclBindingFilter, Task[Map[AclBinding, Option[Throwable]]]]]
 
 }
 
@@ -330,7 +340,7 @@ object AdminClient {
   ) extends AdminClient {
 
     // workaround for https://issues.apache.org/jira/browse/KAFKA-18818
-    private val kafka18818Workaround: ZIO[Any, Nothing, Unit] =
+    private def kafka18818Workaround(implicit trace: Trace): ZIO[Any, Nothing, Unit] =
       ZIO.sleep(550.millis).unit
 
     /**
@@ -339,7 +349,7 @@ object AdminClient {
     override def createTopics(
       newTopics: Iterable[NewTopic],
       options: Option[CreateTopicsOptions] = None
-    ): Task[Unit] = {
+    )(implicit trace: Trace): Task[Unit] = {
       val asJava = newTopics.map(_.asJava).asJavaCollection
 
       fromKafkaFutureVoid {
@@ -354,7 +364,7 @@ object AdminClient {
     /**
      * Create a single topic.
      */
-    override def createTopic(newTopic: NewTopic, validateOnly: Boolean = false): Task[Unit] =
+    override def createTopic(newTopic: NewTopic, validateOnly: Boolean = false)(implicit trace: Trace): Task[Unit] =
       createTopics(List(newTopic), Some(CreateTopicsOptions(validateOnly = validateOnly, timeout = Option.empty)))
 
     /**
@@ -363,7 +373,7 @@ object AdminClient {
     override def deleteConsumerGroups(
       groupIds: Iterable[String],
       options: Option[DeleteConsumerGroupOptions]
-    ): Task[Unit] = {
+    )(implicit trace: Trace): Task[Unit] = {
       val asJava = groupIds.asJavaCollection
       fromKafkaFutureVoid {
         ZIO.attempt(
@@ -382,7 +392,7 @@ object AdminClient {
     override def deleteTopics(
       topics: Iterable[String],
       options: Option[DeleteTopicsOptions] = None
-    ): Task[Unit] = {
+    )(implicit trace: Trace): Task[Unit] = {
       val asJava = topics.asJavaCollection
       fromKafkaFutureVoid {
         ZIO.attempt(
@@ -396,8 +406,8 @@ object AdminClient {
     /**
      * Delete a single topic.
      */
-    override def deleteTopic(topic: String): Task[Unit] =
-      deleteTopics(List(topic))
+    override def deleteTopic(topic: String)(implicit trace: Trace): Task[Unit] =
+      deleteTopics(List(topic), None)
 
     /**
      * Delete records.
@@ -405,7 +415,7 @@ object AdminClient {
     override def deleteRecords(
       recordsToDelete: Map[TopicPartition, RecordsToDelete],
       deleteRecordsOptions: Option[DeleteRecordsOptions] = None
-    ): Task[Unit] = {
+    )(implicit trace: Trace): Task[Unit] = {
       val records = recordsToDelete.map { case (k, v) => k.asJava -> v }.asJava
       fromKafkaFutureVoid {
         ZIO.attempt(
@@ -419,7 +429,9 @@ object AdminClient {
     /**
      * List the topics in the cluster.
      */
-    override def listTopics(listTopicsOptions: Option[ListTopicsOptions] = None): Task[Map[String, TopicListing]] =
+    override def listTopics(
+      listTopicsOptions: Option[ListTopicsOptions] = None
+    )(implicit trace: Trace): Task[Map[String, TopicListing]] =
       fromKafkaFuture {
         ZIO.attempt(
           listTopicsOptions
@@ -434,7 +446,7 @@ object AdminClient {
     override def describeTopics(
       topicNames: Iterable[String],
       options: Option[DescribeTopicsOptions] = None
-    ): Task[Map[String, TopicDescription]] = {
+    )(implicit trace: Trace): Task[Map[String, TopicDescription]] = {
       val asJava = topicNames.asJavaCollection
       fromKafkaFuture {
         ZIO.attempt(
@@ -456,7 +468,7 @@ object AdminClient {
     override def describeConfigs(
       configResources: Iterable[ConfigResource],
       options: Option[DescribeConfigsOptions] = None
-    ): Task[Map[ConfigResource, KafkaConfig]] = {
+    )(implicit trace: Trace): Task[Map[ConfigResource, KafkaConfig]] = {
       val asJava = configResources.map(_.asJava).asJavaCollection
       fromKafkaFuture {
         ZIO.attempt(
@@ -477,7 +489,7 @@ object AdminClient {
     override def describeConfigsAsync(
       configResources: Iterable[ConfigResource],
       options: Option[DescribeConfigsOptions] = None
-    ): Task[Map[ConfigResource, Task[KafkaConfig]]] = {
+    )(implicit trace: Trace): Task[Map[ConfigResource, Task[KafkaConfig]]] = {
       val asJava = configResources.map(_.asJava).asJavaCollection
       ZIO
         .attempt(
@@ -498,7 +510,9 @@ object AdminClient {
         }
     }
 
-    private def describeCluster(options: Option[DescribeClusterOptions]): Task[DescribeClusterResult] =
+    private def describeCluster(
+      options: Option[DescribeClusterOptions]
+    )(implicit trace: Trace): Task[DescribeClusterResult] =
       ZIO.attempt(
         options.fold(adminClient.describeCluster())(opts => adminClient.describeCluster(opts.asJava))
       )
@@ -506,7 +520,9 @@ object AdminClient {
     /**
      * Get the cluster nodes.
      */
-    override def describeClusterNodes(options: Option[DescribeClusterOptions] = None): Task[List[Node]] =
+    override def describeClusterNodes(
+      options: Option[DescribeClusterOptions] = None
+    )(implicit trace: Trace): Task[List[Node]] =
       fromKafkaFuture(
         describeCluster(options).map(_.nodes())
       ).flatMap { nodes =>
@@ -523,7 +539,9 @@ object AdminClient {
     /**
      * Get the cluster controller.
      */
-    override def describeClusterController(options: Option[DescribeClusterOptions] = None): Task[Option[Node]] =
+    override def describeClusterController(
+      options: Option[DescribeClusterOptions] = None
+    )(implicit trace: Trace): Task[Option[Node]] =
       fromKafkaFuture(
         describeCluster(options).map(_.controller())
       ).map(Node(_))
@@ -531,7 +549,9 @@ object AdminClient {
     /**
      * Get the cluster id.
      */
-    override def describeClusterId(options: Option[DescribeClusterOptions] = None): Task[String] =
+    override def describeClusterId(
+      options: Option[DescribeClusterOptions] = None
+    )(implicit trace: Trace): Task[String] =
       fromKafkaFuture(
         describeCluster(options).map(_.clusterId())
       )
@@ -541,7 +561,7 @@ object AdminClient {
      */
     override def describeClusterAuthorizedOperations(
       options: Option[DescribeClusterOptions] = None
-    ): Task[Set[AclOperation]] =
+    )(implicit trace: Trace): Task[Set[AclOperation]] =
       for {
         res <- describeCluster(options)
         opt <- fromKafkaFuture(ZIO.attempt(res.authorizedOperations())).map(Option(_))
@@ -555,7 +575,7 @@ object AdminClient {
     override def createPartitions(
       newPartitions: Map[String, NewPartitions],
       options: Option[CreatePartitionsOptions] = None
-    ): Task[Unit] = {
+    )(implicit trace: Trace): Task[Unit] = {
       val asJava = newPartitions.map { case (k, v) => k -> v.asJava }.asJava
       fromKafkaFutureVoid {
         ZIO.attempt(
@@ -572,7 +592,7 @@ object AdminClient {
     override def listOffsets(
       topicPartitionOffsets: Map[TopicPartition, OffsetSpec],
       options: Option[ListOffsetsOptions] = None
-    ): Task[Map[TopicPartition, ListOffsetsResultInfo]] = {
+    )(implicit trace: Trace): Task[Map[TopicPartition, ListOffsetsResultInfo]] = {
       val asJava = topicPartitionOffsets.bimap(_.asJava, _.asJava).asJava
       fromKafkaFuture {
         ZIO.attempt(
@@ -589,7 +609,7 @@ object AdminClient {
     override def listOffsetsAsync(
       topicPartitionOffsets: Map[TopicPartition, OffsetSpec],
       options: Option[ListOffsetsOptions]
-    ): Task[Map[TopicPartition, Task[ListOffsetsResultInfo]]] = {
+    )(implicit trace: Trace): Task[Map[TopicPartition, Task[ListOffsetsResultInfo]]] = {
       val topicPartitionOffsetsAsJava = topicPartitionOffsets.bimap(_.asJava, _.asJava)
       val topicPartitionsAsJava       = topicPartitionOffsetsAsJava.keySet
       val asJava                      = topicPartitionOffsetsAsJava.asJava
@@ -613,7 +633,7 @@ object AdminClient {
     override def listConsumerGroupOffsets(
       groupId: String,
       options: Option[ListConsumerGroupOffsetsOptions] = None
-    ): Task[Map[TopicPartition, OffsetAndMetadata]] =
+    )(implicit trace: Trace): Task[Map[TopicPartition, OffsetAndMetadata]] =
       fromKafkaFuture {
         ZIO.attempt(
           options
@@ -630,7 +650,7 @@ object AdminClient {
      */
     override def listConsumerGroupOffsets(
       groupSpecs: Map[String, ListConsumerGroupOffsetsSpec]
-    ): Task[Map[String, Map[TopicPartition, OffsetAndMetadata]]] =
+    )(implicit trace: Trace): Task[Map[String, Map[TopicPartition, OffsetAndMetadata]]] =
       fromKafkaFuture {
         ZIO.attempt(
           adminClient
@@ -651,7 +671,7 @@ object AdminClient {
     override def listConsumerGroupOffsets(
       groupSpecs: Map[String, ListConsumerGroupOffsetsSpec],
       options: ListConsumerGroupOffsetsOptions
-    ): Task[Map[String, Map[TopicPartition, OffsetAndMetadata]]] =
+    )(implicit trace: Trace): Task[Map[String, Map[TopicPartition, OffsetAndMetadata]]] =
       fromKafkaFuture {
         ZIO.attempt(
           adminClient
@@ -677,7 +697,7 @@ object AdminClient {
       groupId: String,
       offsets: Map[TopicPartition, OffsetAndMetadata],
       options: Option[AlterConsumerGroupOffsetsOptions] = None
-    ): Task[Unit] = {
+    )(implicit trace: Trace): Task[Unit] = {
       val asJava = offsets.bimap(_.asJava, _.asJava).asJava
       fromKafkaFutureVoid {
         ZIO.attempt(
@@ -693,7 +713,7 @@ object AdminClient {
     /**
      * Retrieves metrics for the underlying AdminClient
      */
-    override def metrics: Task[Map[MetricName, Metric]] =
+    override def metrics(implicit trace: Trace): Task[Map[MetricName, Metric]] =
       ZIO.attempt(
         adminClient.metrics().asScala.toMap.map { case (metricName, metric) =>
           (MetricName(metricName), Metric(metric))
@@ -705,7 +725,7 @@ object AdminClient {
      */
     override def listConsumerGroups(
       options: Option[ListConsumerGroupsOptions] = None
-    ): Task[List[ConsumerGroupListing]] =
+    )(implicit trace: Trace): Task[List[ConsumerGroupListing]] =
       fromKafkaFuture {
         ZIO.attempt(
           options
@@ -717,7 +737,9 @@ object AdminClient {
     /**
      * Describe the specified consumer groups.
      */
-    override def describeConsumerGroups(groupIds: String*): Task[Map[String, ConsumerGroupDescription]] =
+    override def describeConsumerGroups(groupIds: String*)(implicit
+      trace: Trace
+    ): Task[Map[String, ConsumerGroupDescription]] =
       describeConsumerGroups(groupIds.toList, options = None)
 
     /**
@@ -726,7 +748,7 @@ object AdminClient {
     override def describeConsumerGroups(
       groupIds: List[String],
       options: Option[DescribeConsumerGroupsOptions]
-    ): Task[Map[String, ConsumerGroupDescription]] =
+    )(implicit trace: Trace): Task[Map[String, ConsumerGroupDescription]] =
       fromKafkaFuture(
         ZIO.attempt(
           options
@@ -740,7 +762,9 @@ object AdminClient {
     /**
      * Remove the specified members from a consumer group.
      */
-    override def removeMembersFromConsumerGroup(groupId: String, membersToRemove: Set[String]): Task[Unit] = {
+    override def removeMembersFromConsumerGroup(groupId: String, membersToRemove: Set[String])(implicit
+      trace: Trace
+    ): Task[Unit] = {
       val options = new RemoveMembersFromConsumerGroupOptions(
         membersToRemove.map(new MemberToRemove(_)).asJavaCollection
       )
@@ -754,7 +778,7 @@ object AdminClient {
     /**
      * Remove all members from a consumer group.
      */
-    override def removeMembersFromConsumerGroup(groupId: String): Task[Unit] = {
+    override def removeMembersFromConsumerGroup(groupId: String)(implicit trace: Trace): Task[Unit] = {
       val options = new RemoveMembersFromConsumerGroupOptions()
       fromKafkaFuture(
         ZIO.attempt(
@@ -765,7 +789,7 @@ object AdminClient {
 
     override def describeLogDirs(
       brokersId: Iterable[Int]
-    ): ZIO[Any, Throwable, Map[Int, Map[String, LogDirDescription]]] =
+    )(implicit trace: Trace): ZIO[Any, Throwable, Map[Int, Map[String, LogDirDescription]]] =
       fromKafkaFuture(
         ZIO.attempt(
           adminClient.describeLogDirs(brokersId.map(Int.box).asJavaCollection).allDescriptions()
@@ -779,7 +803,7 @@ object AdminClient {
      */
     override def describeLogDirsAsync(
       brokersId: Iterable[Int]
-    ): ZIO[Any, Throwable, Map[Int, Task[Map[String, LogDirDescription]]]] =
+    )(implicit trace: Trace): ZIO[Any, Throwable, Map[Int, Task[Map[String, LogDirDescription]]]] =
       ZIO
         .attempt(
           adminClient.describeLogDirs(brokersId.map(Int.box).asJavaCollection).descriptions()
@@ -798,7 +822,7 @@ object AdminClient {
     override def incrementalAlterConfigs(
       configs: Map[ConfigResource, Iterable[AlterConfigOp]],
       options: AlterConfigsOptions
-    ): Task[Unit] =
+    )(implicit trace: Trace): Task[Unit] =
       fromKafkaFutureVoid(
         ZIO
           .attempt(
@@ -816,7 +840,7 @@ object AdminClient {
     override def incrementalAlterConfigsAsync(
       configs: Map[ConfigResource, Iterable[AlterConfigOp]],
       options: AlterConfigsOptions
-    ): Task[Map[ConfigResource, Task[Unit]]] =
+    )(implicit trace: Trace): Task[Map[ConfigResource, Task[Unit]]] =
       ZIO
         .attempt(
           adminClient
@@ -835,7 +859,7 @@ object AdminClient {
     override def describeAcls(
       filter: AclBindingFilter,
       options: Option[DescribeAclOptions]
-    ): Task[Set[AclBinding]] =
+    )(implicit trace: Trace): Task[Set[AclBinding]] =
       fromKafkaFuture(
         ZIO
           .attempt(
@@ -845,7 +869,9 @@ object AdminClient {
           )
       ).map(_.asScala.view.map(AclBinding(_)).toSet)
 
-    override def createAcls(acls: Set[AclBinding], options: Option[CreateAclOptions]): Task[Unit] =
+    override def createAcls(acls: Set[AclBinding], options: Option[CreateAclOptions])(implicit
+      trace: Trace
+    ): Task[Unit] =
       fromKafkaFutureVoid(
         ZIO
           .attempt(
@@ -860,7 +886,7 @@ object AdminClient {
     override def createAclsAsync(
       acls: Set[AclBinding],
       options: Option[CreateAclOptions]
-    ): Task[Map[AclBinding, Task[Unit]]] =
+    )(implicit trace: Trace): Task[Map[AclBinding, Task[Unit]]] =
       ZIO
         .attempt(
           options
@@ -873,7 +899,9 @@ object AdminClient {
           (AclBinding(k), ZIO.fromCompletionStage(v.toCompletionStage).unit)
         }.toMap)
 
-    override def deleteAcls(filters: Set[AclBindingFilter], options: Option[DeleteAclsOptions]): Task[Set[AclBinding]] =
+    override def deleteAcls(filters: Set[AclBindingFilter], options: Option[DeleteAclsOptions])(implicit
+      trace: Trace
+    ): Task[Set[AclBinding]] =
       fromKafkaFuture(
         ZIO
           .attempt(
@@ -888,7 +916,7 @@ object AdminClient {
     override def deleteAclsAsync(
       filters: Set[AclBindingFilter],
       options: Option[DeleteAclsOptions]
-    ): Task[Map[AclBindingFilter, Task[Map[AclBinding, Option[Throwable]]]]] =
+    )(implicit trace: Trace): Task[Map[AclBindingFilter, Task[Map[AclBinding, Option[Throwable]]]]] =
       ZIO
         .attempt(
           options
@@ -913,7 +941,7 @@ object AdminClient {
 
   }
 
-  val live: ZLayer[AdminClientSettings, Throwable, AdminClient] =
+  def live(implicit trace: Trace): ZLayer[AdminClientSettings, Throwable, AdminClient] =
     ZLayer.scoped {
       for {
         settings <- ZIO.service[AdminClientSettings]
@@ -921,10 +949,10 @@ object AdminClient {
       } yield admin
     }
 
-  def fromKafkaFuture[R, T](kfv: RIO[R, KafkaFuture[T]]): RIO[R, T] =
+  def fromKafkaFuture[R, T](kfv: RIO[R, KafkaFuture[T]])(implicit trace: Trace): RIO[R, T] =
     kfv.flatMap(f => ZIO.fromCompletionStage(f.toCompletionStage))
 
-  def fromKafkaFutureVoid[R](kfv: RIO[R, KafkaFuture[Void]]): RIO[R, Unit] =
+  def fromKafkaFutureVoid[R](kfv: RIO[R, KafkaFuture[Void]])(implicit trace: Trace): RIO[R, Unit] =
     fromKafkaFuture(kfv).unit
 
   final case class ConfigResource(`type`: ConfigResourceType, name: String) {
@@ -1478,20 +1506,20 @@ object AdminClient {
       ReplicaInfo(size = ri.size(), offsetLag = ri.offsetLag(), isFuture = ri.isFuture)
   }
 
-  def make(settings: AdminClientSettings): ZIO[Scope, Throwable, AdminClient] =
+  def make(settings: AdminClientSettings)(implicit trace: Trace): ZIO[Scope, Throwable, AdminClient] =
     fromScopedJavaClient(javaClientFromSettings(settings))
 
-  def fromJavaClient(javaClient: JAdmin): URIO[Any, AdminClient] =
+  def fromJavaClient(javaClient: JAdmin)(implicit trace: Trace): URIO[Any, AdminClient] =
     ZIO.succeed(new LiveAdminClient(javaClient))
 
   def fromScopedJavaClient[R, E](
     scopedJavaClient: ZIO[R & Scope, E, JAdmin]
-  ): ZIO[R & Scope, E, AdminClient] =
+  )(implicit trace: Trace): ZIO[R & Scope, E, AdminClient] =
     scopedJavaClient.flatMap { javaClient =>
       fromJavaClient(javaClient)
     }
 
-  def javaClientFromSettings(settings: AdminClientSettings): ZIO[Scope, Throwable, JAdmin] =
+  def javaClientFromSettings(settings: AdminClientSettings)(implicit trace: Trace): ZIO[Scope, Throwable, JAdmin] =
     ZIO.acquireRelease {
       val endpointCheck = SslHelper
         .validateEndpoint(settings.driverSettings)

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClientSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClientSettings.scala
@@ -3,6 +3,7 @@ package zio.kafka.admin
 import org.apache.kafka.clients.admin.AdminClientConfig
 import zio._
 import zio.kafka.security.KafkaCredentialStore
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * Settings for the admin client.

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
@@ -4,6 +4,7 @@ import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 import zio.kafka.serde.Deserializer
 import zio.{ RIO, Task, Trace }
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 final case class CommittableRecord[K, V](
   record: ConsumerRecord[K, V],

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
@@ -3,7 +3,7 @@ package zio.kafka.consumer
 import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, ConsumerRecord, OffsetAndMetadata }
 import org.apache.kafka.common.TopicPartition
 import zio.kafka.serde.Deserializer
-import zio.{ RIO, Task }
+import zio.{ RIO, Task, Trace }
 
 final case class CommittableRecord[K, V](
   record: ConsumerRecord[K, V],
@@ -13,7 +13,7 @@ final case class CommittableRecord[K, V](
   def deserializeWith[R, K1, V1](
     keyDeserializer: Deserializer[R, K1],
     valueDeserializer: Deserializer[R, V1]
-  )(implicit ev1: K <:< Array[Byte], ev2: V <:< Array[Byte]): RIO[R, CommittableRecord[K1, V1]] =
+  )(implicit ev1: K <:< Array[Byte], ev2: V <:< Array[Byte], trace: Trace): RIO[R, CommittableRecord[K1, V1]] =
     for {
       key   <- keyDeserializer.deserialize(record.topic(), record.headers(), record.key())
       value <- valueDeserializer.deserialize(record.topic(), record.headers(), record.value())

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -15,6 +15,7 @@ import zio.kafka.diagnostics.internal.ConcurrentDiagnostics
 import zio.kafka.serde.{ Deserializer, Serde }
 import zio.kafka.utils.SslHelper
 import zio.stream._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.jdk.CollectionConverters._
 import scala.util.control.NoStackTrace

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -257,10 +257,10 @@ object Consumer {
 
   case object CommitTimeout extends RuntimeException("Commit timeout") with NoStackTrace
 
-  val offsetBatches: ZSink[Any, Nothing, Offset, Nothing, OffsetBatch] =
+  def offsetBatches(implicit trace: Trace): ZSink[Any, Nothing, Offset, Nothing, OffsetBatch] =
     ZSink.foldLeft[Offset, OffsetBatch](OffsetBatch.empty)(_ add _)
 
-  def live: RLayer[ConsumerSettings, Consumer] =
+  def live(implicit trace: Trace): RLayer[ConsumerSettings, Consumer] =
     ZLayer.scoped {
       for {
         settings <- ZIO.service[ConsumerSettings]

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -7,6 +7,7 @@ import zio.kafka.consumer.Consumer.OffsetRetrieval
 import zio.kafka.consumer.fetch.{ FetchStrategy, QueueSizeBasedFetchStrategy }
 import zio.kafka.security.KafkaCredentialStore
 import zio.metrics.MetricLabel
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * Settings for the consumer.

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
@@ -3,6 +3,7 @@ package zio.kafka.consumer
 import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, OffsetAndMetadata, RetriableCommitFailedException }
 import org.apache.kafka.common.TopicPartition
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 trait Offset {
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
@@ -9,7 +9,7 @@ trait Offset {
   def topic: String
   def partition: Int
   def offset: Long
-  def commit: Task[Unit]
+  def commit(implicit trace: Trace): Task[Unit]
   def batch: OffsetBatch
   def consumerGroupMetadata: Option[ConsumerGroupMetadata]
   def withMetadata(metadata: String): Offset
@@ -21,7 +21,7 @@ trait Offset {
    * Attempts to commit and retries according to the given policy when the commit fails with a
    * RetriableCommitFailedException
    */
-  final def commitOrRetry[R](policy: Schedule[R, Throwable, Any]): RIO[R, Unit] =
+  final def commitOrRetry[R](policy: Schedule[R, Throwable, Any])(implicit trace: Trace): RIO[R, Unit] =
     Offset.commitOrRetry(commit, policy)
 
   final lazy val topicPartition: TopicPartition = new TopicPartition(topic, partition)
@@ -31,7 +31,7 @@ object Offset {
   private[consumer] def commitOrRetry[R, B](
     commit: Task[Unit],
     policy: Schedule[R, Throwable, B]
-  ): RIO[R, Unit] =
+  )(implicit trace: Trace): RIO[R, Unit] =
     commit.retry(
       Schedule.recurWhile[Throwable] {
         case _: RetriableCommitFailedException => true
@@ -49,7 +49,7 @@ private final case class OffsetImpl(
   consumerGroupMetadata: Option[ConsumerGroupMetadata],
   metadata: Option[String] = None
 ) extends Offset {
-  def commit: Task[Unit] = commitHandle(Map(topicPartition -> asJavaOffsetAndMetadata))
+  def commit(implicit trace: Trace): Task[Unit] = commitHandle(Map(topicPartition -> asJavaOffsetAndMetadata))
   def batch: OffsetBatch = OffsetBatchImpl(
     Map(topicPartition -> asJavaOffsetAndMetadata),
     commitHandle,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
@@ -6,7 +6,7 @@ import zio._
 
 sealed trait OffsetBatch {
   def offsets: Map[TopicPartition, OffsetAndMetadata]
-  def commit: Task[Unit]
+  def commit(implicit trace: Trace): Task[Unit]
   def add(offset: Offset): OffsetBatch
   def merge(offsets: OffsetBatch): OffsetBatch
   def consumerGroupMetadata: Option[ConsumerGroupMetadata]
@@ -32,7 +32,7 @@ private final case class OffsetBatchImpl(
   commitHandle: Map[TopicPartition, OffsetAndMetadata] => Task[Unit],
   consumerGroupMetadata: Option[ConsumerGroupMetadata]
 ) extends OffsetBatch {
-  override def commit: Task[Unit] = commitHandle(offsets)
+  override def commit(implicit trace: Trace): Task[Unit] = commitHandle(offsets)
 
   override def add(offset: Offset): OffsetBatch = {
     val maxOffsetAndMetadata = offsets.get(offset.topicPartition) match {
@@ -62,7 +62,7 @@ private final case class OffsetBatchImpl(
 
 case object EmptyOffsetBatch extends OffsetBatch {
   override val offsets: Map[TopicPartition, OffsetAndMetadata]      = Map.empty
-  override val commit: Task[Unit]                                   = ZIO.unit
+  override def commit(implicit trace: Trace): Task[Unit]            = ZIO.unit
   override def add(offset: Offset): OffsetBatch                     = offset.batch
   override def merge(offsets: OffsetBatch): OffsetBatch             = offsets
   override def consumerGroupMetadata: Option[ConsumerGroupMetadata] = None

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
@@ -15,7 +15,7 @@ sealed trait OffsetBatch {
    * Attempts to commit and retries according to the given policy when the commit fails with a
    * RetriableCommitFailedException
    */
-  def commitOrRetry[R](policy: Schedule[R, Throwable, Any]): RIO[R, Unit] =
+  def commitOrRetry[R](policy: Schedule[R, Throwable, Any])(implicit trace: Trace): RIO[R, Unit] =
     Offset.commitOrRetry(commit, policy)
 }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/OffsetBatch.scala
@@ -3,6 +3,7 @@ package zio.kafka.consumer
 import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, OffsetAndMetadata }
 import org.apache.kafka.common.TopicPartition
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 sealed trait OffsetBatch {
   def offsets: Map[TopicPartition, OffsetAndMetadata]

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
@@ -3,6 +3,7 @@ package zio.kafka.consumer
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
 import org.apache.kafka.common.TopicPartition
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.jdk.CollectionConverters._
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/RebalanceListener.scala
@@ -18,14 +18,14 @@ final case class RebalanceListener(
   /**
    * Combine with another [[RebalanceListener]] and execute their actions sequentially
    */
-  def ++(that: RebalanceListener): RebalanceListener =
+  def ++(that: RebalanceListener)(implicit trace: Trace): RebalanceListener =
     RebalanceListener(
       assigned => onAssigned(assigned) *> that.onAssigned(assigned),
       revoked => onRevoked(revoked) *> that.onRevoked(revoked),
       lost => onLost(lost) *> that.onLost(lost)
     )
 
-  def runOnExecutor(executor: Executor): RebalanceListener = RebalanceListener(
+  def runOnExecutor(executor: Executor)(implicit trace: Trace): RebalanceListener = RebalanceListener(
     assigned => onAssigned(assigned).onExecutor(executor),
     revoked => onRevoked(revoked).onExecutor(executor),
     lost => onLost(lost).onExecutor(executor)
@@ -49,7 +49,7 @@ object RebalanceListener {
   private[kafka] def toKafka(
     rebalanceListener: RebalanceListener,
     runtime: Runtime[Any]
-  ): ConsumerRebalanceListener =
+  )(implicit trace: Trace): ConsumerRebalanceListener =
     new ConsumerRebalanceListener {
       override def onPartitionsRevoked(
         partitions: java.util.Collection[TopicPartition]

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/StreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/StreamControl.scala
@@ -1,6 +1,7 @@
 package zio.kafka.consumer
 import zio.{ Trace, UIO }
 import zio.stream.ZStream
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 trait StreamControl[-R, +E, +A] {
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/StreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/StreamControl.scala
@@ -1,5 +1,5 @@
 package zio.kafka.consumer
-import zio.UIO
+import zio.{ Trace, UIO }
 import zio.stream.ZStream
 
 trait StreamControl[-R, +E, +A] {
@@ -10,7 +10,7 @@ trait StreamControl[-R, +E, +A] {
    * The stream should be run at most once. Running it more than once will result in chunks of records being divided
    * over the streams. After ending, running the stream another time will not produce records
    */
-  def stream: ZStream[R, E, A]
+  def stream(implicit trace: Trace): ZStream[R, E, A]
 
   /**
    * Stops fetching data for all partitions associated with this subscription. The stream will end and the effect
@@ -19,15 +19,15 @@ trait StreamControl[-R, +E, +A] {
    * @return
    *   Effect that will complete immediately.
    */
-  def end: UIO[Unit]
+  def end(implicit trace: Trace): UIO[Unit]
 }
 
 object StreamControl {
   implicit class StreamControlOps[-R, +E, +A](streamControl: StreamControl[R, E, A]) {
     def map[R1 <: R, E1 >: E, B](f: ZStream[R, E, A] => ZStream[R1, E1, B]): StreamControl[R1, E1, B] =
       new StreamControl[R1, E1, B] {
-        def stream = f(streamControl.stream)
-        def end    = streamControl.end
+        def stream(implicit trace: Trace): ZStream[R1, E1, B] = f(streamControl.stream)
+        def end(implicit trace: Trace): UIO[Unit]             = streamControl.end
       }
   }
 }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Subscription.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Subscription.scala
@@ -1,6 +1,7 @@
 package zio.kafka.consumer
 
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.util.matching.Regex
 import java.util.regex.{ Pattern => JPattern }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Subscription.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Subscription.scala
@@ -40,7 +40,7 @@ object Subscription {
    * @return
    *   The created subscription or failure when the pattern is invalid
    */
-  def pattern(pattern: String): Task[Subscription] =
+  def pattern(pattern: String)(implicit trace: Trace): Task[Subscription] =
     ZIO.attempt(new Regex(pattern)).map(Pattern.apply)
 
   /**

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/fetch/FetchStrategy.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/fetch/FetchStrategy.scala
@@ -3,6 +3,7 @@ package zio.kafka.consumer.fetch
 import org.apache.kafka.common.TopicPartition
 import zio.kafka.consumer.internal.PartitionStream
 import zio.{ Chunk, Trace, ZIO }
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.mutable
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/fetch/ManyPartitionsQueueSizeBasedFetchStrategy.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/fetch/ManyPartitionsQueueSizeBasedFetchStrategy.scala
@@ -3,6 +3,7 @@ package zio.kafka.consumer.fetch
 import org.apache.kafka.common.TopicPartition
 import zio.{ Chunk, Trace, ZIO }
 import zio.kafka.consumer.internal.PartitionStream
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.mutable
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/fetch/ManyPartitionsQueueSizeBasedFetchStrategy.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/fetch/ManyPartitionsQueueSizeBasedFetchStrategy.scala
@@ -1,7 +1,7 @@
 package zio.kafka.consumer.fetch
 
 import org.apache.kafka.common.TopicPartition
-import zio.{ Chunk, ZIO }
+import zio.{ Chunk, Trace, ZIO }
 import zio.kafka.consumer.internal.PartitionStream
 
 import scala.collection.mutable
@@ -41,7 +41,7 @@ final case class ManyPartitionsQueueSizeBasedFetchStrategy(
 ) extends FetchStrategy {
   override def selectPartitionsToFetch(
     streams: Chunk[PartitionStream]
-  ): ZIO[Any, Nothing, Set[TopicPartition]] =
+  )(implicit trace: Trace): ZIO[Any, Nothing, Set[TopicPartition]] =
     for {
       random          <- ZIO.random
       shuffledStreams <- random.shuffle(streams)

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Committer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Committer.scala
@@ -6,6 +6,7 @@ import zio.kafka.consumer.internal.Committer.CommitOffsets
 import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
 import zio.kafka.consumer.internal.LiveCommitter.Commit
 import zio.{ Chunk, Task, Trace, UIO }
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.lang.Math.max
 import scala.collection.mutable
@@ -13,10 +14,10 @@ import scala.collection.mutable
 private[internal] trait Committer {
 
   /** A function to commit offsets. */
-  val commit: Map[TopicPartition, OffsetAndMetadata] => Task[Unit]
+  def commit(offsets: Map[TopicPartition, OffsetAndMetadata])(implicit trace: Trace): Task[Unit]
 
   /** A function to register offsets that have been committed externally. */
-  val registerExternalCommits: Map[TopicPartition, OffsetAndMetadata] => Task[Unit]
+  def registerExternalCommits(offsets: Map[TopicPartition, OffsetAndMetadata])(implicit trace: Trace): Task[Unit]
 
   /**
    * Takes commits from the queue, commits them and adds them to pending commits

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Committer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Committer.scala
@@ -5,7 +5,7 @@ import org.apache.kafka.common.TopicPartition
 import zio.kafka.consumer.internal.Committer.CommitOffsets
 import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
 import zio.kafka.consumer.internal.LiveCommitter.Commit
-import zio.{ Chunk, Task, UIO }
+import zio.{ Chunk, Task, Trace, UIO }
 
 import java.lang.Math.max
 import scala.collection.mutable
@@ -34,20 +34,20 @@ private[internal] trait Committer {
   def processQueuedCommits(
     consumer: ByteArrayKafkaConsumer,
     executeOnEmpty: Boolean = false
-  ): Task[Unit]
+  )(implicit trace: Trace): Task[Unit]
 
-  def queueSize: UIO[Int]
+  def queueSize(implicit trace: Trace): UIO[Int]
 
-  def pendingCommitCount: UIO[Int]
+  def pendingCommitCount(implicit trace: Trace): UIO[Int]
 
-  def getPendingCommits: UIO[CommitOffsets]
+  def getPendingCommits(implicit trace: Trace): UIO[CommitOffsets]
 
   /** Removes all completed commits from `pendingCommits`. */
-  def cleanupPendingCommits: UIO[Unit]
+  def cleanupPendingCommits(implicit trace: Trace): UIO[Unit]
 
-  def keepCommitsForPartitions(assignedPartitions: Set[TopicPartition]): UIO[Unit]
+  def keepCommitsForPartitions(assignedPartitions: Set[TopicPartition])(implicit trace: Trace): UIO[Unit]
 
-  def getCommittedOffsets: UIO[CommitOffsets]
+  def getCommittedOffsets(implicit trace: Trace): UIO[CommitOffsets]
 }
 
 private[internal] object Committer {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerAccess.scala
@@ -6,6 +6,7 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import zio._
 import zio.kafka.consumer.ConsumerSettings
 import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.jdk.CollectionConverters._
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/ConsumerMetrics.scala
@@ -3,6 +3,7 @@ package zio.kafka.consumer.internal
 import zio.metrics.MetricKeyType.Histogram
 import zio.metrics._
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * Implementations of this trait are responsible for measuring all consumer metrics. The different methods are invoked

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/LiveCommitter.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/LiveCommitter.scala
@@ -8,6 +8,7 @@ import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
 import zio.kafka.consumer.internal.LiveCommitter.Commit
 import zio._
 import zio.kafka.consumer.diagnostics.DiagnosticEvent
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.{ Map => JavaMap }
 import scala.collection.mutable
@@ -23,31 +24,27 @@ private[consumer] final class LiveCommitter(
   pendingCommits: Ref.Synchronized[Chunk[Commit]]
 ) extends Committer {
 
-  override def registerExternalCommits(implicit
-    trace: Trace
-  ): Map[
-    TopicPartition,
-    OffsetAndMetadata
-  ] => Task[Unit] = offsets =>
+  override def registerExternalCommits(
+    offsets: Map[TopicPartition, OffsetAndMetadata]
+  )(implicit trace: Trace): Task[Unit] =
     committedOffsetsRef.modify {
       // The continuation promise can be `null` because this commit is not actually handled by the consumer.
       _.addCommits(Chunk(Commit(java.lang.System.nanoTime(), offsets, null)))
     }.unit
 
   /** This is the implementation behind the user facing api `Offset.commit`. */
-  override def commit(implicit trace: Trace): Map[TopicPartition, OffsetAndMetadata] => Task[Unit] =
-    offsets =>
-      for {
-        p <- Promise.make[Throwable, Unit]
-        startTime = java.lang.System.nanoTime()
-        _ <- commitQueue.offer(Commit(startTime, offsets, p))
-        _ <- onCommitAvailable
-        _ <- diagnostics.emit(DiagnosticEvent.Commit.Started(offsets))
-        _ <- p.await.timeoutFail(CommitTimeout)(commitTimeout)
-        endTime = java.lang.System.nanoTime()
-        latency = (endTime - startTime).nanoseconds
-        _ <- consumerMetrics.observeCommit(latency)
-      } yield ()
+  override def commit(offsets: Map[TopicPartition, OffsetAndMetadata])(implicit trace: Trace): Task[Unit] =
+    for {
+      p <- Promise.make[Throwable, Unit]
+      startTime = java.lang.System.nanoTime()
+      _ <- commitQueue.offer(Commit(startTime, offsets, p))
+      _ <- onCommitAvailable
+      _ <- diagnostics.emit(DiagnosticEvent.Commit.Started(offsets))
+      _ <- p.await.timeoutFail(CommitTimeout)(commitTimeout)
+      endTime = java.lang.System.nanoTime()
+      latency = (endTime - startTime).nanoseconds
+      _ <- consumerMetrics.observeCommit(latency)
+    } yield ()
 
   /**
    * WARNING: this method is used during a rebalance from the same-thread-runtime. This restricts what ZIO operations

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/LiveCommitter.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/LiveCommitter.scala
@@ -23,7 +23,9 @@ private[consumer] final class LiveCommitter(
   pendingCommits: Ref.Synchronized[Chunk[Commit]]
 ) extends Committer {
 
-  override val registerExternalCommits: Map[
+  override def registerExternalCommits(implicit
+    trace: Trace
+  ): Map[
     TopicPartition,
     OffsetAndMetadata
   ] => Task[Unit] = offsets =>
@@ -33,7 +35,7 @@ private[consumer] final class LiveCommitter(
     }.unit
 
   /** This is the implementation behind the user facing api `Offset.commit`. */
-  override val commit: Map[TopicPartition, OffsetAndMetadata] => Task[Unit] =
+  override def commit(implicit trace: Trace): Map[TopicPartition, OffsetAndMetadata] => Task[Unit] =
     offsets =>
       for {
         p <- Promise.make[Throwable, Unit]

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -8,6 +8,7 @@ import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.stream.{ Take, ZStream }
 import zio._
 import zio.kafka.consumer.diagnostics.DiagnosticEvent
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.TimeoutException
 import scala.util.control.NoStackTrace

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RebalanceCoordinator.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RebalanceCoordinator.scala
@@ -5,6 +5,7 @@ import zio.kafka.consumer.internal.RebalanceCoordinator._
 import zio.kafka.consumer.{ ConsumerSettings, RebalanceListener }
 import zio.stream.ZStream
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * The Runloop's RebalanceListener gets notified of partitions that are assigned, revoked and lost

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RebalanceCoordinator.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RebalanceCoordinator.scala
@@ -185,7 +185,7 @@ private[internal] class RebalanceCoordinator(
   // - ends streams that need to be ended
   // - updates `lastRebalanceEvent`
   //
-  def toRebalanceListener: RebalanceListener = RebalanceListener(
+  def toRebalanceListener(implicit trace: Trace): RebalanceListener = RebalanceListener(
     onAssigned = assignedTps =>
       lastRebalanceEvent.updateZIO { rebalanceEvent =>
         ZIO.logDebug {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -12,6 +12,7 @@ import zio.kafka.consumer.internal.RebalanceCoordinator._
 import zio.kafka.consumer.internal.Runloop._
 import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
 import zio.stream._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.jdk.CollectionConverters._
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -78,7 +78,7 @@ private[consumer] final class Runloop private (
       r       <- promise.await
     } yield r
 
-  private def makeRebalanceListener: ConsumerRebalanceListener = {
+  private def makeRebalanceListener(implicit trace: Trace): ConsumerRebalanceListener = {
     // Here we just want to avoid any executor shift if the user provided listener is the noop listener.
     val userRebalanceListener =
       settings.rebalanceListener match {
@@ -99,7 +99,7 @@ private[consumer] final class Runloop private (
     pendingRequests: Chunk[RunloopCommand.Request],
     assignedStreams: Chunk[PartitionStreamControl],
     isRevoked: TopicPartition => Boolean
-  ): UIO[Runloop.RevokeResult] = {
+  )(implicit trace: Trace): UIO[Runloop.RevokeResult] = {
     val (revokedStreams, newAssignedStreams) =
       assignedStreams.partition(control => isRevoked(control.tp))
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -10,6 +10,7 @@ import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
 import zio.kafka.consumer._
 import zio.kafka.diagnostics.Diagnostics
 import zio.stream.{ Stream, Take, ZStream }
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 private[internal] sealed trait RunloopState
 private[internal] object RunloopState {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
@@ -27,14 +27,14 @@ object RunloopCommand {
 
   final case class AddSubscription(subscription: Subscription, cont: Promise[InvalidSubscriptionUnion, Unit])
       extends StreamCommand {
-    @inline def succeed: UIO[Unit]                           = cont.succeed(()).unit
-    @inline def fail(e: InvalidSubscriptionUnion): UIO[Unit] = cont.fail(e).unit
+    @inline def succeed(implicit trace: Trace): UIO[Unit]                           = cont.succeed(()).unit
+    @inline def fail(e: InvalidSubscriptionUnion)(implicit trace: Trace): UIO[Unit] = cont.fail(e).unit
   }
   final case class RemoveSubscription(subscription: Subscription, cont: Promise[Throwable, Unit]) extends StreamCommand
 
   final case class EndStreamsBySubscription(subscription: Subscription, cont: Promise[Nothing, Unit])
       extends StreamCommand {
-    @inline def succeed: UIO[Unit] = cont.succeed(()).unit
+    @inline def succeed(implicit trace: Trace): UIO[Unit] = cont.succeed(()).unit
   }
 
   case object RemoveAllSubscriptions extends StreamCommand

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
@@ -3,6 +3,7 @@ package zio.kafka.consumer.internal
 import org.apache.kafka.common.TopicPartition
 import zio._
 import zio.kafka.consumer.{ InvalidSubscriptionUnion, Subscription }
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 sealed trait RunloopCommand
 object RunloopCommand {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopExecutor.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopExecutor.scala
@@ -1,6 +1,7 @@
 package zio.kafka.consumer.internal
 
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopExecutor.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopExecutor.scala
@@ -9,7 +9,7 @@ private[consumer] object RunloopExecutor {
 
   private val counter: AtomicLong = new AtomicLong(0)
 
-  private val newSingleThreadedExecutor: URIO[Scope, Executor] =
+  private def newSingleThreadedExecutor(implicit trace: Trace): URIO[Scope, Executor] =
     ZIO.acquireRelease {
       ZIO.succeed {
         val javaExecutor =

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/SubscriptionState.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/SubscriptionState.scala
@@ -1,6 +1,7 @@
 package zio.kafka.consumer.internal
 
 import zio.kafka.consumer.Subscription
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 private[internal] sealed trait SubscriptionState {
   def isSubscribed: Boolean =

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/package.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/package.scala
@@ -2,6 +2,7 @@ package zio.kafka.consumer
 
 import zio._
 import zio.internal.ExecutionMetrics
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 package object internal {
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/package.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/package.scala
@@ -33,7 +33,7 @@ package object internal {
   /**
    * A sleep that is safe to use from the same-thread-runtime.
    */
-  private[internal] def blockingSleep(sleepTime: Duration): Task[Unit] =
+  private[internal] def blockingSleep(sleepTime: Duration)(implicit trace: Trace): Task[Unit] =
     ZIO.attempt(Thread.sleep(sleepTime.toMillis))
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/diagnostics/Diagnostics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/diagnostics/Diagnostics.scala
@@ -1,6 +1,7 @@
 package zio.kafka.diagnostics
 
 import zio.{ Trace, UIO, ZIO }
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * A callback interface for diagnostic events.

--- a/zio-kafka/src/main/scala/zio/kafka/diagnostics/Diagnostics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/diagnostics/Diagnostics.scala
@@ -1,12 +1,12 @@
 package zio.kafka.diagnostics
 
-import zio.{ UIO, ZIO }
+import zio.{ Trace, UIO, ZIO }
 
 /**
  * A callback interface for diagnostic events.
  */
 trait Diagnostics[-DiagnosticEvent] {
-  def emit(event: => DiagnosticEvent): UIO[Unit]
+  def emit(event: => DiagnosticEvent)(implicit trace: Trace): UIO[Unit]
 }
 
 object Diagnostics {
@@ -15,7 +15,7 @@ object Diagnostics {
    * A diagnostics implementation that does nothing.
    */
   val NoOp: Diagnostics[Any] = new Diagnostics[Any] {
-    override def emit(event: => Any): UIO[Unit] = ZIO.unit
+    override def emit(event: => Any)(implicit trace: Trace): UIO[Unit] = ZIO.unit
   }
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/diagnostics/SlidingDiagnostics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/diagnostics/SlidingDiagnostics.scala
@@ -1,6 +1,7 @@
 package zio.kafka.diagnostics
 
 import zio.{ Queue, Scope, Trace, UIO, ZIO }
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 object SlidingDiagnostics {
 

--- a/zio-kafka/src/main/scala/zio/kafka/diagnostics/internal/ConcurrentDiagnostics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/diagnostics/internal/ConcurrentDiagnostics.scala
@@ -3,6 +3,7 @@ package zio.kafka.diagnostics.internal
 import zio._
 import zio.kafka.diagnostics.Diagnostics
 import zio.stream._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 object ConcurrentDiagnostics {
 

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -13,6 +13,7 @@ import zio.kafka.producer.internal.{ ProducerMetrics, ZioProducerMetrics }
 import zio.kafka.serde.Serializer
 import zio.kafka.utils.SslHelper
 import zio.stream.{ ZPipeline, ZStream }
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.atomic.{ AtomicInteger, AtomicLong }
 import scala.collection.immutable.BitSet

--- a/zio-kafka/src/main/scala/zio/kafka/producer/ProducerCompression.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/ProducerCompression.scala
@@ -2,6 +2,7 @@ package zio.kafka.producer
 
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.record.CompressionType
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 abstract sealed class ProducerCompression(name: String, extra: Option[(String, AnyRef)] = None) {
   def properties: Map[String, AnyRef] =

--- a/zio-kafka/src/main/scala/zio/kafka/producer/ProducerEvent.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/ProducerEvent.scala
@@ -1,6 +1,7 @@
 package zio.kafka.producer
 
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 sealed trait ProducerEvent
 

--- a/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
@@ -4,6 +4,7 @@ import org.apache.kafka.clients.producer.ProducerConfig
 import zio._
 import zio.kafka.security.KafkaCredentialStore
 import zio.metrics.MetricLabel
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * Settings for the Producer.

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Transaction.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Transaction.scala
@@ -14,30 +14,30 @@ trait Transaction {
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V],
     offset: Option[Offset]
-  ): RIO[R, RecordMetadata]
+  )(implicit trace: Trace): RIO[R, RecordMetadata]
 
   def produce[R, K, V](
     producerRecord: ProducerRecord[K, V],
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V],
     offset: Option[Offset]
-  ): RIO[R, RecordMetadata]
+  )(implicit trace: Trace): RIO[R, RecordMetadata]
 
   def produceChunk[R, K, V](
     records: Chunk[ProducerRecord[K, V]],
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V],
     offset: Option[Offset]
-  ): RIO[R, Chunk[RecordMetadata]]
+  )(implicit trace: Trace): RIO[R, Chunk[RecordMetadata]]
 
   def produceChunkBatch[R, K, V](
     records: Chunk[ProducerRecord[K, V]],
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V],
     offsets: OffsetBatch
-  ): RIO[R, Chunk[RecordMetadata]]
+  )(implicit trace: Trace): RIO[R, Chunk[RecordMetadata]]
 
-  def abort: IO[TransactionalProducer.UserInitiatedAbort.type, Nothing]
+  def abort(implicit trace: Trace): IO[TransactionalProducer.UserInitiatedAbort.type, Nothing]
 }
 
 private[producer] final class TransactionImpl(
@@ -52,7 +52,7 @@ private[producer] final class TransactionImpl(
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V],
     offset: Option[Offset]
-  ): RIO[R, RecordMetadata] =
+  )(implicit trace: Trace): RIO[R, RecordMetadata] =
     produce(new ProducerRecord[K, V](topic, key, value), keySerializer, valueSerializer, offset)
 
   def produce[R, K, V](
@@ -60,7 +60,7 @@ private[producer] final class TransactionImpl(
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V],
     offset: Option[Offset]
-  ): RIO[R, RecordMetadata] =
+  )(implicit trace: Trace): RIO[R, RecordMetadata] =
     haltIfClosed *>
       ZIO.whenCase(offset) { case Some(offset) => offsetBatchRef.update(_ add offset) } *>
       producer.produce[R, K, V](producerRecord, keySerializer, valueSerializer)
@@ -70,7 +70,7 @@ private[producer] final class TransactionImpl(
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V],
     offset: Option[Offset]
-  ): RIO[R, Chunk[RecordMetadata]] =
+  )(implicit trace: Trace): RIO[R, Chunk[RecordMetadata]] =
     haltIfClosed *>
       ZIO.whenCase(offset) { case Some(offset) => offsetBatchRef.update(_ add offset) } *>
       producer.produceChunk[R, K, V](records, keySerializer, valueSerializer)
@@ -80,17 +80,17 @@ private[producer] final class TransactionImpl(
     keySerializer: Serializer[R, K],
     valueSerializer: Serializer[R, V],
     offsets: OffsetBatch
-  ): RIO[R, Chunk[RecordMetadata]] =
+  )(implicit trace: Trace): RIO[R, Chunk[RecordMetadata]] =
     haltIfClosed *>
       offsetBatchRef.update(_ merge offsets) *>
       producer.produceChunk[R, K, V](records, keySerializer, valueSerializer)
 
-  def abort: IO[TransactionalProducer.UserInitiatedAbort.type, Nothing] =
+  def abort(implicit trace: Trace): IO[TransactionalProducer.UserInitiatedAbort.type, Nothing] =
     ZIO.fail(UserInitiatedAbort)
 
-  private[producer] def markAsClosed: UIO[Unit] = closed.set(true)
+  private[producer] def markAsClosed(implicit trace: Trace): UIO[Unit] = closed.set(true)
 
-  private def haltIfClosed: IO[TransactionLeaked, Unit] =
+  private def haltIfClosed(implicit trace: Trace): IO[TransactionLeaked, Unit] =
     offsetBatchRef.get
       .flatMap(offsetBatch => ZIO.fail(TransactionLeaked(offsetBatch)))
       .whenZIO(closed.get)

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Transaction.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Transaction.scala
@@ -5,6 +5,7 @@ import zio.kafka.consumer.{ Offset, OffsetBatch }
 import zio.kafka.producer.TransactionalProducer.{ TransactionLeaked, UserInitiatedAbort }
 import zio.kafka.serde.Serializer
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 trait Transaction {
   def produce[R, K, V](

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -10,6 +10,7 @@ import zio._
 import zio.kafka.consumer.{ Consumer, OffsetBatch }
 import zio.kafka.producer.ProducerLive.NanoTime
 import zio.kafka.producer.internal.ZioProducerMetrics
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util
 import scala.jdk.CollectionConverters._

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducerSettings.scala
@@ -2,6 +2,7 @@ package zio.kafka.producer
 
 import org.apache.kafka.clients.producer.ProducerConfig
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * Settings for a transactional producer.

--- a/zio-kafka/src/main/scala/zio/kafka/producer/internal/ProducerMetrics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/internal/ProducerMetrics.scala
@@ -78,7 +78,7 @@ private[producer] class ZioProducerMetrics(metricLabels: Set[MetricLabel]) exten
       .contramap[Int](_.toDouble)
       .tagged(metricLabels)
 
-  override def observeProduce(latency: Duration, batchSize: Int): UIO[Unit] =
+  override def observeProduce(latency: Duration, batchSize: Int)(implicit trace: Trace): UIO[Unit] =
     for {
       _ <- produceCounter.increment
       _ <- produceLatencyHistogram.update(latency)
@@ -122,10 +122,10 @@ private[producer] class ZioProducerMetrics(metricLabels: Set[MetricLabel]) exten
       .contramap[Duration](_.toNanos.toDouble / 1e9)
       .tagged(metricLabels)
 
-  override def observeSendQueueSize(size: Int): UIO[Unit] =
+  override def observeSendQueueSize(size: Int)(implicit trace: Trace): UIO[Unit] =
     sendQueueSizeHistogram.update(size)
 
-  override def observeSendQueueTake(latency: Duration): UIO[Unit] =
+  override def observeSendQueueTake(latency: Duration)(implicit trace: Trace): UIO[Unit] =
     sendQueueLatencyHistogram.update(latency)
 
   // -----------------------------------------------------

--- a/zio-kafka/src/main/scala/zio/kafka/producer/internal/ProducerMetrics.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/internal/ProducerMetrics.scala
@@ -3,6 +3,7 @@ package zio.kafka.producer.internal
 import zio.metrics.MetricKeyType.Histogram
 import zio.metrics._
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * Implementations of this trait are responsible for measuring all Producer metrics. The different methods are invoked
@@ -12,10 +13,10 @@ import zio._
  * zio-kafka version.
  */
 private[producer] trait ProducerMetrics {
-  def observeProduce(latency: Duration, batchSize: Int): UIO[Unit]
-  def observeSendQueueSize(size: Int): UIO[Unit]
-  def observeSendQueueTake(latency: Duration): UIO[Unit]
-  def observeSendAuthError(errorCount: Int): UIO[Unit]
+  def observeProduce(latency: Duration, batchSize: Int)(implicit trace: Trace): UIO[Unit]
+  def observeSendQueueSize(size: Int)(implicit trace: Trace): UIO[Unit]
+  def observeSendQueueTake(latency: Duration)(implicit trace: Trace): UIO[Unit]
+  def observeSendAuthError(errorCount: Int)(implicit trace: Trace): UIO[Unit]
 }
 
 /**
@@ -141,7 +142,7 @@ private[producer] class ZioProducerMetrics(metricLabels: Set[MetricLabel]) exten
       )
       .tagged(metricLabels)
 
-  override def observeSendAuthError(errorCount: Int): UIO[Unit] =
+  override def observeSendAuthError(errorCount: Int)(implicit trace: Trace): UIO[Unit] =
     sendAuthErrorCounter.incrementBy(errorCount)
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
@@ -3,6 +3,7 @@ package zio.kafka.serde
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.{ Deserializer => KafkaDeserializer }
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success, Try }

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
@@ -20,25 +20,25 @@ trait Serde[-R, T] extends Deserializer[R, T] with Serializer[R, T] {
   /**
    * Creates a new Serde that uses optional values. Null data will be mapped to None values.
    */
-  override def asOption: Serde[R, Option[T]] =
+  override def asOption(implicit trace: Trace): Serde[R, Option[T]] =
     Serde(super[Deserializer].asOption)(super[Serializer].asOption)
 
   /**
    * Creates a new Serde that executes its serialization and deserialization functions on the blocking threadpool.
    */
-  override def blocking: Serde[R, T] =
+  override def blocking(implicit trace: Trace): Serde[R, T] =
     Serde(super[Deserializer].blocking)(super[Serializer].blocking)
 
   /**
    * Converts to a Serde of type U with pure transformations
    */
-  def inmap[U](f: T => U)(g: U => T): Serde[R, U] =
+  def inmap[U](f: T => U)(g: U => T)(implicit trace: Trace): Serde[R, U] =
     Serde(map(f))(contramap(g))
 
   /**
    * Convert to a Serde of type U with effectful transformations
    */
-  def inmapZIO[R1 <: R, U](f: T => RIO[R1, U])(g: U => RIO[R1, T]): Serde[R1, U] =
+  def inmapZIO[R1 <: R, U](f: T => RIO[R1, U])(g: U => RIO[R1, T])(implicit trace: Trace): Serde[R1, U] =
     Serde(mapZIO(f))(contramapZIO(g))
 }
 

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
@@ -3,6 +3,7 @@ package zio.kafka.serde
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.{ Serde => KafkaSerde }
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.jdk.CollectionConverters._
 import scala.util.Try

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
@@ -53,9 +53,13 @@ object Serde extends Serdes {
     deser: (String, Headers, Array[Byte]) => RIO[R, T]
   )(ser: (String, Headers, T) => RIO[R, Array[Byte]]): Serde[R, T] =
     new Serde[R, T] {
-      override final def serialize(topic: String, headers: Headers, value: T): RIO[R, Array[Byte]] =
+      override final def serialize(topic: String, headers: Headers, value: T)(implicit
+        trace: Trace
+      ): RIO[R, Array[Byte]] =
         ser(topic, headers, value)
-      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[R, T] =
+      override final def deserialize(topic: String, headers: Headers, data: Array[Byte])(implicit
+        trace: Trace
+      ): RIO[R, T] =
         deser(topic, headers, data)
     }
 
@@ -64,31 +68,41 @@ object Serde extends Serdes {
    */
   def apply[R, T](deser: Deserializer[R, T])(ser: Serializer[R, T]): Serde[R, T] =
     new Serde[R, T] {
-      override final def serialize(topic: String, headers: Headers, value: T): RIO[R, Array[Byte]] =
+      override final def serialize(topic: String, headers: Headers, value: T)(implicit
+        trace: Trace
+      ): RIO[R, Array[Byte]] =
         ser.serialize(topic, headers, value)
-      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[R, T] =
+      override final def deserialize(topic: String, headers: Headers, data: Array[Byte])(implicit
+        trace: Trace
+      ): RIO[R, T] =
         deser.deserialize(topic, headers, data)
     }
 
   /**
    * Create a Serde from a Kafka Serde
    */
-  def fromKafkaSerde[T](serde: KafkaSerde[T], props: Map[String, AnyRef], isKey: Boolean): Task[Serde[Any, T]] =
+  def fromKafkaSerde[A](serde: KafkaSerde[A], props: Map[String, AnyRef], isKey: Boolean)(implicit
+    trace: Trace
+  ): Task[Serde[Any, A]] =
     ZIO
       .attempt(serde.configure(props.asJava, isKey))
       .as(
-        new Serde[Any, T] {
+        new Serde[Any, A] {
           private final val serializer   = serde.serializer()
           private final val deserializer = serde.deserializer()
 
-          override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): Task[T] =
+          override final def deserialize(topic: String, headers: Headers, data: Array[Byte])(implicit
+            trace: Trace
+          ): Task[A] =
             ZIO.attempt(deserializer.deserialize(topic, headers, data))
 
-          override final def serialize(topic: String, headers: Headers, value: T): Task[Array[Byte]] =
+          override final def serialize(topic: String, headers: Headers, value: A)(implicit
+            trace: Trace
+          ): Task[Array[Byte]] =
             ZIO.attempt(serializer.serialize(topic, headers, value))
         }
       )
 
-  implicit def deserializerWithError[R, T](implicit deser: Deserializer[R, T]): Deserializer[R, Try[T]] =
+  implicit def deserializerWithError[R, T](implicit deser: Deserializer[R, T], trace: Trace): Deserializer[R, Try[T]] =
     deser.asTry
 }

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serdes.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serdes.scala
@@ -4,6 +4,7 @@ import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.{ Serde => KafkaSerde, Serdes => KafkaSerdes }
 import org.apache.kafka.common.utils.Bytes
 import zio.{ RIO, Trace, ZIO }
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.nio.ByteBuffer
 import java.util.UUID

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -7,37 +7,37 @@ import zio._
 import scala.jdk.CollectionConverters._
 
 /**
- * Serializer from values of some type T to a byte array
+ * Serializer from values of some type A to a byte array
  *
  * @tparam R
  *   Environment available to the serializer
- * @tparam T
+ * @tparam A
  */
-trait Serializer[-R, -T] {
-  def serialize(topic: String, headers: Headers, value: T): RIO[R, Array[Byte]]
+trait Serializer[-R, -A] {
+  def serialize(topic: String, headers: Headers, value: A)(implicit trace: Trace): RIO[R, Array[Byte]]
 
   /**
    * Create a serializer for a type U based on the serializer for type T and a mapping function
    */
-  def contramap[U](f: U => T): Serializer[R, U] =
+  def contramap[U](f: U => A): Serializer[R, U] =
     Serializer((topic, headers, u) => serialize(topic, headers, f(u)))
 
   /**
    * Create a serializer for a type U based on the serializer for type T and an effectful mapping function
    */
-  def contramapZIO[R1 <: R, U](f: U => RIO[R1, T]): Serializer[R1, U] =
+  def contramapZIO[R1 <: R, U](f: U => RIO[R1, A]): Serializer[R1, U] =
     Serializer((topic, headers, u) => f(u).flatMap(serialize(topic, headers, _)))
 
   /**
    * Returns a new serializer that executes its serialization function on the blocking threadpool.
    */
-  def blocking: Serializer[R, T] =
+  def blocking: Serializer[R, A] =
     Serializer((topic, headers, t) => ZIO.blocking(serialize(topic, headers, t)))
 
   /**
    * Returns a new serializer that handles optional values and serializes them as nulls.
    */
-  def asOption[U <: T]: Serializer[R, Option[U]] =
+  def asOption[U <: A]: Serializer[R, Option[U]] =
     Serializer { (topic, headers, valueOpt) =>
       valueOpt match {
         case None        => ZIO.succeed(null)
@@ -51,22 +51,25 @@ object Serializer extends Serdes {
   /**
    * Create a serializer from a function
    */
-  def apply[R, T](ser: (String, Headers, T) => RIO[R, Array[Byte]]): Serializer[R, T] =
-    (topic: String, headers: Headers, value: T) => ser(topic, headers, value)
+  def apply[R, A](ser: (String, Headers, A) => RIO[R, Array[Byte]]): Serializer[R, A] =
+    new Serializer[R, A] {
+      override def serialize(topic: String, headers: Headers, value: A)(implicit trace: Trace): RIO[R, Array[Byte]] =
+        ser(topic, headers, value)
+    }
 
   /**
    * Create a Serializer from a Kafka Serializer
    */
-  def fromKafkaSerializer[T](
-    serializer: KafkaSerializer[T],
+  def fromKafkaSerializer[A](
+    serializer: KafkaSerializer[A],
     props: Map[String, AnyRef],
     isKey: Boolean
-  ): Task[Serializer[Any, T]] =
+  )(implicit trace: Trace): Task[Serializer[Any, A]] =
     ZIO
       .attempt(serializer.configure(props.asJava, isKey))
       .as(
-        new Serializer[Any, T] {
-          override def serialize(topic: String, headers: Headers, value: T): Task[Array[Byte]] =
+        new Serializer[Any, A] {
+          override def serialize(topic: String, headers: Headers, value: A)(implicit trace: Trace): Task[Array[Byte]] =
             ZIO.attempt(serializer.serialize(topic, headers, value))
         }
       )

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -3,6 +3,7 @@ package zio.kafka.serde
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.{ Serializer => KafkaSerializer }
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.jdk.CollectionConverters._
 

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -19,25 +19,25 @@ trait Serializer[-R, -A] {
   /**
    * Create a serializer for a type U based on the serializer for type T and a mapping function
    */
-  def contramap[U](f: U => A): Serializer[R, U] =
+  def contramap[U](f: U => A)(implicit trace: Trace): Serializer[R, U] =
     Serializer((topic, headers, u) => serialize(topic, headers, f(u)))
 
   /**
    * Create a serializer for a type U based on the serializer for type T and an effectful mapping function
    */
-  def contramapZIO[R1 <: R, U](f: U => RIO[R1, A]): Serializer[R1, U] =
+  def contramapZIO[R1 <: R, U](f: U => RIO[R1, A])(implicit trace: Trace): Serializer[R1, U] =
     Serializer((topic, headers, u) => f(u).flatMap(serialize(topic, headers, _)))
 
   /**
    * Returns a new serializer that executes its serialization function on the blocking threadpool.
    */
-  def blocking: Serializer[R, A] =
+  def blocking(implicit trace: Trace): Serializer[R, A] =
     Serializer((topic, headers, t) => ZIO.blocking(serialize(topic, headers, t)))
 
   /**
    * Returns a new serializer that handles optional values and serializes them as nulls.
    */
-  def asOption[U <: A]: Serializer[R, Option[U]] =
+  def asOption[U <: A](implicit trace: Trace): Serializer[R, Option[U]] =
     Serializer { (topic, headers, valueOpt) =>
       valueOpt match {
         case None        => ZIO.succeed(null)

--- a/zio-kafka/src/main/scala/zio/kafka/utils/SslHelper.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/SslHelper.scala
@@ -32,7 +32,7 @@ object SslHelper {
   private final case class ConnectionError(cause: Throwable) extends NoStackTrace
 
   // ⚠️ Must not do anything else than calling `doValidateEndpoint`. The algorithm of this function must be completely contained in `doValidateEndpoint`.
-  def validateEndpoint(props: Map[String, AnyRef]): IO[KafkaException, Unit] =
+  def validateEndpoint(props: Map[String, AnyRef])(implicit trace: Trace): IO[KafkaException, Unit] =
     doValidateEndpoint(SocketChannel.open)(props)
 
   /**
@@ -40,7 +40,7 @@ object SslHelper {
    */
   private[utils] def doValidateEndpoint(
     unsafeOpenSocket: InetSocketAddress => SocketChannel // Handy for unit-tests
-  )(props: Map[String, AnyRef]): IO[KafkaException, Unit] = {
+  )(props: Map[String, AnyRef])(implicit trace: Trace): IO[KafkaException, Unit] = {
     @inline def `request.timeout.ms`: Duration = {
       val defaultValue = 30.seconds
 
@@ -166,7 +166,7 @@ object SslHelper {
   private def validateSslConfigOf(
     unsafeOpenSocket: InetSocketAddress => SocketChannel,
     socketTimeout: Duration
-  )(address: InetSocketAddress): Task[Unit] = {
+  )(address: InetSocketAddress)(implicit trace: Trace): Task[Unit] = {
     @inline def unexpectedSslPacketError: IO[IllegalArgumentException, Nothing] =
       ZIO.fail(
         new IllegalArgumentException(

--- a/zio-kafka/src/main/scala/zio/kafka/utils/SslHelper.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/utils/SslHelper.scala
@@ -6,6 +6,7 @@ import org.apache.kafka.common.network.TransferableChannel
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.{ ApiVersionsRequest, RequestHeader }
 import zio._
+//import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer


### PR DESCRIPTION
Add an implicit trace parameter to all public and private methods that use ZIO, as recommended by the [guidlines for library author](https://zio.dev/guides/migrate/zio-2.x-migration-guide#guidelines-for-library-authors).

Warning: this change is not binary, nor source compatible.

Source compatibility is only broken when a trait of zio-kafka is implemented by the user. The following traits are affected:

- `Diagnostics`
- `FetchStrategy`
- `Serde` (`Deserializer` and `Serializer`)