### PR TITLE
Simplify code, use uniform type names

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -298,8 +298,8 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
 }
 
 abstract private class MockCommitter extends Committer {
-  override val commit: Map[TopicPartition, OffsetAndMetadata] => Task[Unit]                  = _ => ZIO.unit
-  override val registerExternalCommits: Map[TopicPartition, OffsetAndMetadata] => Task[Unit] = _ => ZIO.unit
+  override def commit(offsets: Map[TopicPartition, OffsetAndMetadata]): Task[Unit]                  = ZIO.unit
+  override def registerExternalCommits(offsets: Map[TopicPartition, OffsetAndMetadata]): Task[Unit] = ZIO.unit
 
   override def processQueuedCommits(consumer: ByteArrayKafkaConsumer, executeOnEmpty: Boolean): Task[Unit] = ZIO.unit
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Committer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Committer.scala
@@ -12,11 +12,11 @@ import scala.collection.mutable
 
 private[internal] trait Committer {
 
-  /** A function to commit offsets. */
-  val commit: Map[TopicPartition, OffsetAndMetadata] => Task[Unit]
+  /** Commits offsets. */
+  def commit(offsets: Map[TopicPartition, OffsetAndMetadata]): Task[Unit]
 
-  /** A function to register offsets that have been committed externally. */
-  val registerExternalCommits: Map[TopicPartition, OffsetAndMetadata] => Task[Unit]
+  /** Registers offsets that have been committed externally. */
+  def registerExternalCommits(offsets: Map[TopicPartition, OffsetAndMetadata]): Task[Unit]
 
   /**
    * Takes commits from the queue, commits them and adds them to pending commits

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -358,12 +358,13 @@ private[consumer] final class Runloop private (
   private def verifyAssignedStreamsMatchesAssignment(
     assignedStreams: Chunk[PartitionStreamControl],
     currentAssigned: Set[TopicPartition]
-  ) =
+  ): ZIO[Any, Nothing, Unit] =
     ZIO
       .logWarning(
         s"Not all assigned partitions have a (single) stream or vice versa. Assigned: ${currentAssigned.mkString(",")}, streams: ${assignedStreams.map(_.tp).mkString(",")}"
       )
       .when(currentAssigned != assignedStreams.map(_.tp).toSet || currentAssigned.size != assignedStreams.size)
+      .unit
 
   /**
    * Check each stream to see if it exceeded its pull interval. If so, halt it. In addition, if any stream has exceeded

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopExecutor.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopExecutor.scala
@@ -9,7 +9,7 @@ private[consumer] object RunloopExecutor {
 
   private val counter: AtomicLong = new AtomicLong(0)
 
-  private val newSingleThreadedExecutor: URIO[Scope, Executor] =
+  private def newSingleThreadedExecutor: URIO[Scope, Executor] =
     ZIO.acquireRelease {
       ZIO.succeed {
         val javaExecutor =

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
@@ -8,78 +8,78 @@ import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success, Try }
 
 /**
- * Deserializer from byte array to a value of some type T
+ * Deserializer from byte array to a value of some type A.
  *
  * @tparam R
  *   Environment available to the deserializer
- * @tparam T
+ * @tparam A
  *   Value type
  */
-trait Deserializer[-R, +T] {
-  def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[R, T]
+trait Deserializer[-R, +A] {
+  def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[R, A]
 
   /**
-   * Returns a new deserializer that executes its deserialization function on the blocking threadpool.
+   * Returns a new deserializer that executes its deserialization function on the blocking thread pool.
    */
-  def blocking: Deserializer[R, T] =
+  def blocking: Deserializer[R, A] =
     Deserializer((topic, headers, data) => ZIO.blocking(deserialize(topic, headers, data)))
 
   /**
-   * Create a deserializer for a type U based on the deserializer for type T and a mapping function
+   * Create a deserializer for a type U based on the deserializer for type A and a mapping function.
    */
-  def map[U](f: T => U): Deserializer[R, U] = Deserializer(deserialize(_, _, _).map(f))
+  def map[U](f: A => U): Deserializer[R, U] = Deserializer(deserialize(_, _, _).map(f))
 
   /**
-   * Create a deserializer for a type U based on the deserializer for type T and an effectful mapping function
+   * Create a deserializer for a type U based on the deserializer for type A and an effectful mapping function.
    */
-  def mapZIO[R1 <: R, U](f: T => RIO[R1, U]): Deserializer[R1, U] = Deserializer(deserialize(_, _, _).flatMap(f))
+  def mapZIO[R1 <: R, U](f: A => RIO[R1, U]): Deserializer[R1, U] = Deserializer(deserialize(_, _, _).flatMap(f))
 
   /**
-   * When this serializer fails, attempt to deserialize with the alternative
+   * When this serializer fails, attempt to deserialize with the alternative.
    *
    * If both deserializers fail, the error will be the last deserializer's exception.
    */
-  def orElse[R1 <: R, U >: T](alternative: Deserializer[R1, U]): Deserializer[R1, U] =
+  def orElse[R1 <: R, U >: A](alternative: Deserializer[R1, U]): Deserializer[R1, U] =
     Deserializer { (topic, headers, data) =>
       deserialize(topic, headers, data) orElse alternative.deserialize(topic, headers, data)
     }
 
   /**
-   * Serde that handles deserialization failures by returning a Task
+   * Serde that handles deserialization failures by returning a Task.
    *
    * This is useful for explicitly handling deserialization failures.
    */
-  def asTry: Deserializer[R, Try[T]] =
+  def asTry: Deserializer[R, Try[A]] =
     Deserializer(deserialize(_, _, _).fold(e => Failure(e), v => Success(v)))
 
   /**
    * Returns a new deserializer that deserializes values as Option values, mapping null data to None values.
    */
-  def asOption: Deserializer[R, Option[T]] =
+  def asOption: Deserializer[R, Option[A]] =
     Deserializer((topic, headers, data) => ZIO.foreach(Option(data))(deserialize(topic, headers, _)))
 }
 
 object Deserializer extends Serdes {
 
   /**
-   * Create a deserializer from a function
+   * Create a deserializer from a function.
    */
-  def apply[R, T](deser: (String, Headers, Array[Byte]) => RIO[R, T]): Deserializer[R, T] =
+  def apply[R, A](deser: (String, Headers, Array[Byte]) => RIO[R, A]): Deserializer[R, A] =
     (topic: String, headers: Headers, data: Array[Byte]) => deser(topic, headers, data)
 
   /**
-   * Create a Deserializer from a Kafka Deserializer
+   * Create a Deserializer from a Kafka Deserializer.
    */
-  def fromKafkaDeserializer[T](
-    deserializer: KafkaDeserializer[T],
+  def fromKafkaDeserializer[A](
+    deserializer: KafkaDeserializer[A],
     props: Map[String, AnyRef],
     isKey: Boolean
-  ): Task[Deserializer[Any, T]] =
+  ): Task[Deserializer[Any, A]] =
     ZIO
       .attempt(deserializer.configure(props.asJava, isKey))
       .as(
-        new Deserializer[Any, T] {
-          override def deserialize(topic: String, headers: Headers, data: Array[Byte]): Task[T] =
+        new Deserializer[Any, A] {
+          override def deserialize(topic: String, headers: Headers, data: Array[Byte]): Task[A] =
             ZIO.attempt(deserializer.deserialize(topic, headers, data))
         }
       )

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Deserializer.scala
@@ -25,21 +25,21 @@ trait Deserializer[-R, +A] {
     Deserializer((topic, headers, data) => ZIO.blocking(deserialize(topic, headers, data)))
 
   /**
-   * Create a deserializer for a type U based on the deserializer for type A and a mapping function.
+   * Create a deserializer for a type B based on the deserializer for type A and a mapping function.
    */
-  def map[U](f: A => U): Deserializer[R, U] = Deserializer(deserialize(_, _, _).map(f))
+  def map[B](f: A => B): Deserializer[R, B] = Deserializer(deserialize(_, _, _).map(f))
 
   /**
-   * Create a deserializer for a type U based on the deserializer for type A and an effectful mapping function.
+   * Create a deserializer for a type B based on the deserializer for type A and an effectful mapping function.
    */
-  def mapZIO[R1 <: R, U](f: A => RIO[R1, U]): Deserializer[R1, U] = Deserializer(deserialize(_, _, _).flatMap(f))
+  def mapZIO[R1 <: R, B](f: A => RIO[R1, B]): Deserializer[R1, B] = Deserializer(deserialize(_, _, _).flatMap(f))
 
   /**
    * When this serializer fails, attempt to deserialize with the alternative.
    *
    * If both deserializers fail, the error will be the last deserializer's exception.
    */
-  def orElse[R1 <: R, U >: A](alternative: Deserializer[R1, U]): Deserializer[R1, U] =
+  def orElse[R1 <: R, A1 >: A](alternative: Deserializer[R1, A1]): Deserializer[R1, A1] =
     Deserializer { (topic, headers, data) =>
       deserialize(topic, headers, data) orElse alternative.deserialize(topic, headers, data)
     }

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
@@ -30,15 +30,15 @@ trait Serde[-R, A] extends Deserializer[R, A] with Serializer[R, A] {
     Serde(super[Deserializer].blocking)(super[Serializer].blocking)
 
   /**
-   * Converts to a Serde of type U with pure transformations.
+   * Converts to a Serde of type B with pure transformations.
    */
-  def inmap[U](f: A => U)(g: U => A): Serde[R, U] =
+  def inmap[B](f: A => B)(g: B => A): Serde[R, B] =
     Serde(map(f))(contramap(g))
 
   /**
-   * Convert to a Serde of type U with effectful transformations.
+   * Convert to a Serde of type B with effectful transformations.
    */
-  def inmapZIO[R1 <: R, U](f: A => RIO[R1, U])(g: U => RIO[R1, A]): Serde[R1, U] =
+  def inmapZIO[R1 <: R, B](f: A => RIO[R1, B])(g: B => RIO[R1, A]): Serde[R1, B] =
     Serde(mapZIO(f))(contramapZIO(g))
 }
 

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serde.scala
@@ -8,87 +8,87 @@ import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 /**
- * A serializer and deserializer for values of type T
+ * A serializer and deserializer for values of type A.
  *
  * @tparam R
  *   Environment available to the deserializer
- * @tparam T
+ * @tparam A
  *   Value type
  */
-trait Serde[-R, T] extends Deserializer[R, T] with Serializer[R, T] {
+trait Serde[-R, A] extends Deserializer[R, A] with Serializer[R, A] {
 
   /**
    * Creates a new Serde that uses optional values. Null data will be mapped to None values.
    */
-  override def asOption: Serde[R, Option[T]] =
+  override def asOption: Serde[R, Option[A]] =
     Serde(super[Deserializer].asOption)(super[Serializer].asOption)
 
   /**
-   * Creates a new Serde that executes its serialization and deserialization functions on the blocking threadpool.
+   * Creates a new Serde that executes its serialization and deserialization functions on the blocking thread pool.
    */
-  override def blocking: Serde[R, T] =
+  override def blocking: Serde[R, A] =
     Serde(super[Deserializer].blocking)(super[Serializer].blocking)
 
   /**
-   * Converts to a Serde of type U with pure transformations
+   * Converts to a Serde of type U with pure transformations.
    */
-  def inmap[U](f: T => U)(g: U => T): Serde[R, U] =
+  def inmap[U](f: A => U)(g: U => A): Serde[R, U] =
     Serde(map(f))(contramap(g))
 
   /**
-   * Convert to a Serde of type U with effectful transformations
+   * Convert to a Serde of type U with effectful transformations.
    */
-  def inmapZIO[R1 <: R, U](f: T => RIO[R1, U])(g: U => RIO[R1, T]): Serde[R1, U] =
+  def inmapZIO[R1 <: R, U](f: A => RIO[R1, U])(g: U => RIO[R1, A]): Serde[R1, U] =
     Serde(mapZIO(f))(contramapZIO(g))
 }
 
 object Serde extends Serdes {
 
   /**
-   * Create a Serde from a deserializer and serializer function
+   * Create a Serde from a deserializer and serializer function.
    *
-   * The (de)serializer functions can returned a failure ZIO with a Throwable to indicate (de)serialization failure
+   * The (de)serializer functions can return a failure ZIO with a Throwable to indicate (de)serialization failure.
    */
-  def apply[R, T](
-    deser: (String, Headers, Array[Byte]) => RIO[R, T]
-  )(ser: (String, Headers, T) => RIO[R, Array[Byte]]): Serde[R, T] =
-    new Serde[R, T] {
-      override final def serialize(topic: String, headers: Headers, value: T): RIO[R, Array[Byte]] =
+  def apply[R, A](
+    deser: (String, Headers, Array[Byte]) => RIO[R, A]
+  )(ser: (String, Headers, A) => RIO[R, Array[Byte]]): Serde[R, A] =
+    new Serde[R, A] {
+      override final def serialize(topic: String, headers: Headers, value: A): RIO[R, Array[Byte]] =
         ser(topic, headers, value)
-      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[R, T] =
+      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[R, A] =
         deser(topic, headers, data)
     }
 
   /**
-   * Create a Serde from a deserializer and serializer function
+   * Create a Serde from a deserializer and serializer function.
    */
-  def apply[R, T](deser: Deserializer[R, T])(ser: Serializer[R, T]): Serde[R, T] =
-    new Serde[R, T] {
-      override final def serialize(topic: String, headers: Headers, value: T): RIO[R, Array[Byte]] =
+  def apply[R, A](deser: Deserializer[R, A])(ser: Serializer[R, A]): Serde[R, A] =
+    new Serde[R, A] {
+      override final def serialize(topic: String, headers: Headers, value: A): RIO[R, Array[Byte]] =
         ser.serialize(topic, headers, value)
-      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[R, T] =
+      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[R, A] =
         deser.deserialize(topic, headers, data)
     }
 
   /**
-   * Create a Serde from a Kafka Serde
+   * Create a Serde from a Kafka Serde.
    */
-  def fromKafkaSerde[T](serde: KafkaSerde[T], props: Map[String, AnyRef], isKey: Boolean): Task[Serde[Any, T]] =
+  def fromKafkaSerde[A](serde: KafkaSerde[A], props: Map[String, AnyRef], isKey: Boolean): Task[Serde[Any, A]] =
     ZIO
       .attempt(serde.configure(props.asJava, isKey))
       .as(
-        new Serde[Any, T] {
+        new Serde[Any, A] {
           private final val serializer   = serde.serializer()
           private final val deserializer = serde.deserializer()
 
-          override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): Task[T] =
+          override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): Task[A] =
             ZIO.attempt(deserializer.deserialize(topic, headers, data))
 
-          override final def serialize(topic: String, headers: Headers, value: T): Task[Array[Byte]] =
+          override final def serialize(topic: String, headers: Headers, value: A): Task[Array[Byte]] =
             ZIO.attempt(serializer.serialize(topic, headers, value))
         }
       )
 
-  implicit def deserializerWithError[R, T](implicit deser: Deserializer[R, T]): Deserializer[R, Try[T]] =
+  implicit def deserializerWithError[R, A](implicit deser: Deserializer[R, A]): Deserializer[R, Try[A]] =
     deser.asTry
 }

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serdes.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serdes.scala
@@ -36,15 +36,15 @@ private[zio] trait Serdes {
         ZIO.succeed(data)
     }
 
-  private[this] def convertPrimitiveSerde[T](serde: KafkaSerde[T]): Serde[Any, T] =
-    new Serde[Any, T] {
+  private[this] def convertPrimitiveSerde[A](serde: KafkaSerde[A]): Serde[Any, A] =
+    new Serde[Any, A] {
       private final val serializer   = serde.serializer()
       private final val deserializer = serde.deserializer()
 
-      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[Any, T] =
+      override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[Any, A] =
         ZIO.attempt(deserializer.deserialize(topic, headers, data))
 
-      override final def serialize(topic: String, headers: Headers, value: T): RIO[Any, Array[Byte]] =
+      override final def serialize(topic: String, headers: Headers, value: A): RIO[Any, Array[Byte]] =
         ZIO.attempt(serializer.serialize(topic, headers, value))
     }
 }

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -17,15 +17,15 @@ trait Serializer[-R, -A] {
   def serialize(topic: String, headers: Headers, value: A): RIO[R, Array[Byte]]
 
   /**
-   * Create a serializer for a type U based on the serializer for type A and a mapping function.
+   * Create a serializer for a type B based on the serializer for type A and a mapping function.
    */
-  def contramap[U](f: U => A): Serializer[R, U] =
+  def contramap[B](f: B => A): Serializer[R, B] =
     Serializer((topic, headers, u) => serialize(topic, headers, f(u)))
 
   /**
-   * Create a serializer for a type U based on the serializer for type A and an effectful mapping function.
+   * Create a serializer for a type B based on the serializer for type A and an effectful mapping function.
    */
-  def contramapZIO[R1 <: R, U](f: U => RIO[R1, A]): Serializer[R1, U] =
+  def contramapZIO[R1 <: R, B](f: B => RIO[R1, A]): Serializer[R1, B] =
     Serializer((topic, headers, u) => f(u).flatMap(serialize(topic, headers, _)))
 
   /**
@@ -37,7 +37,7 @@ trait Serializer[-R, -A] {
   /**
    * Returns a new serializer that handles optional values and serializes them as nulls.
    */
-  def asOption[U <: A]: Serializer[R, Option[U]] =
+  def asOption[A1 <: A]: Serializer[R, Option[A1]] =
     Serializer { (topic, headers, valueOpt) =>
       valueOpt match {
         case None        => ZIO.succeed(null)

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -7,37 +7,37 @@ import zio._
 import scala.jdk.CollectionConverters._
 
 /**
- * Serializer from values of some type T to a byte array
+ * Serializer from values of some type A to a byte array.
  *
  * @tparam R
  *   Environment available to the serializer
- * @tparam T
+ * @tparam A
  */
-trait Serializer[-R, -T] {
-  def serialize(topic: String, headers: Headers, value: T): RIO[R, Array[Byte]]
+trait Serializer[-R, -A] {
+  def serialize(topic: String, headers: Headers, value: A): RIO[R, Array[Byte]]
 
   /**
-   * Create a serializer for a type U based on the serializer for type T and a mapping function
+   * Create a serializer for a type U based on the serializer for type A and a mapping function.
    */
-  def contramap[U](f: U => T): Serializer[R, U] =
+  def contramap[U](f: U => A): Serializer[R, U] =
     Serializer((topic, headers, u) => serialize(topic, headers, f(u)))
 
   /**
-   * Create a serializer for a type U based on the serializer for type T and an effectful mapping function
+   * Create a serializer for a type U based on the serializer for type A and an effectful mapping function.
    */
-  def contramapZIO[R1 <: R, U](f: U => RIO[R1, T]): Serializer[R1, U] =
+  def contramapZIO[R1 <: R, U](f: U => RIO[R1, A]): Serializer[R1, U] =
     Serializer((topic, headers, u) => f(u).flatMap(serialize(topic, headers, _)))
 
   /**
-   * Returns a new serializer that executes its serialization function on the blocking threadpool.
+   * Returns a new serializer that executes its serialization function on the blocking thread pool.
    */
-  def blocking: Serializer[R, T] =
+  def blocking: Serializer[R, A] =
     Serializer((topic, headers, t) => ZIO.blocking(serialize(topic, headers, t)))
 
   /**
    * Returns a new serializer that handles optional values and serializes them as nulls.
    */
-  def asOption[U <: T]: Serializer[R, Option[U]] =
+  def asOption[U <: A]: Serializer[R, Option[U]] =
     Serializer { (topic, headers, valueOpt) =>
       valueOpt match {
         case None        => ZIO.succeed(null)
@@ -49,24 +49,24 @@ trait Serializer[-R, -T] {
 object Serializer extends Serdes {
 
   /**
-   * Create a serializer from a function
+   * Create a serializer from a function.
    */
-  def apply[R, T](ser: (String, Headers, T) => RIO[R, Array[Byte]]): Serializer[R, T] =
-    (topic: String, headers: Headers, value: T) => ser(topic, headers, value)
+  def apply[R, A](ser: (String, Headers, A) => RIO[R, Array[Byte]]): Serializer[R, A] =
+    (topic: String, headers: Headers, value: A) => ser(topic, headers, value)
 
   /**
-   * Create a Serializer from a Kafka Serializer
+   * Create a Serializer from a Kafka Serializer.
    */
-  def fromKafkaSerializer[T](
-    serializer: KafkaSerializer[T],
+  def fromKafkaSerializer[A](
+    serializer: KafkaSerializer[A],
     props: Map[String, AnyRef],
     isKey: Boolean
-  ): Task[Serializer[Any, T]] =
+  ): Task[Serializer[Any, A]] =
     ZIO
       .attempt(serializer.configure(props.asJava, isKey))
       .as(
-        new Serializer[Any, T] {
-          override def serialize(topic: String, headers: Headers, value: T): Task[Array[Byte]] =
+        new Serializer[Any, A] {
+          override def serialize(topic: String, headers: Headers, value: A): Task[Array[Byte]] =
             ZIO.attempt(serializer.serialize(topic, headers, value))
         }
       )


### PR DESCRIPTION
This collects a few small improvements that were made in the disbanded tracing PR:
- replace function `val`s with `def`
- use `A` instead of `T`
- small scaladoc fixes
- small type improvements