### PR TITLE
Test improvements

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/SubscriptionsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/SubscriptionsSpec.scala
@@ -17,271 +17,272 @@ import java.util.concurrent.atomic.AtomicInteger
 object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
   override val kafkaPrefix: String = "subscriptionsspec"
 
-  override def spec: Spec[TestEnvironment with Scope, Throwable] = suite("Consumer subscriptions")(
-    test("consumes from two topic subscriptions") {
-      val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
-      for {
-        topic1 <- randomTopic
-        topic2 <- randomTopic
-        client <- randomClient
-        group  <- randomGroup
+  override def spec: Spec[TestEnvironment with Scope, Throwable] =
+    suite("Consumer subscriptions")(
+      test("consumes from two topic subscriptions") {
+        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          topic1 <- randomTopic
+          topic2 <- randomTopic
+          client <- randomClient
+          group  <- randomGroup
 
-        producer <- KafkaTestUtils.makeProducer
-        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
-        _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
+          producer <- KafkaTestUtils.makeProducer
+          _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+          _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
 
-        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
-        records <-
-          consumer
-            .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-            .take(5)
-            .runCollect <&>
+          consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+          records <-
             consumer
-              .plainStream(Subscription.topics(topic2), Serde.string, Serde.string)
+              .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
               .take(5)
-              .runCollect
-        (records1, records2) = records
-        kvOut1               = records1.map(r => (r.record.key, r.record.value)).toList
-        kvOut2               = records2.map(r => (r.record.key, r.record.value)).toList
-      } yield assertTrue(kvOut1 == kvs) &&
-        assertTrue(kvOut2 == kvs) &&
-        assertTrue(records1.map(_.record.topic()).forall(_ == topic1)) &&
-        assertTrue(records2.map(_.record.topic()).forall(_ == topic2))
-    },
-    test("consumes from two pattern subscriptions") {
-      val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
-      for {
-        topic1 <- randomTopic
-        topic2 <- randomTopic
-        client <- randomClient
-        group  <- randomGroup
-
-        producer <- KafkaTestUtils.makeProducer
-        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
-        _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
-
-        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
-        records <-
-          consumer
-            .plainStream(Subscription.Pattern(s"$topic1".r), Serde.string, Serde.string)
-            .take(5)
-            .runCollect <&>
-            consumer
-              .plainStream(Subscription.Pattern(s"$topic2".r), Serde.string, Serde.string)
-              .take(5)
-              .runCollect
-        (records1, records2) = records
-        kvOut1               = records1.map(r => (r.record.key, r.record.value)).toList
-        kvOut2               = records2.map(r => (r.record.key, r.record.value)).toList
-      } yield assertTrue(kvOut1 == kvs) &&
-        assertTrue(kvOut2 == kvs) &&
-        assertTrue(records1.map(_.record.topic()).forall(_ == topic1)) &&
-        assertTrue(records2.map(_.record.topic()).forall(_ == topic2))
-    },
-    test(
-      "gives an error when attempting to subscribe using a manual subscription when there is already a topic subscription"
-    ) {
-      val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
-      for {
-        topic1 <- randomTopic
-        topic2 <- randomTopic
-        client <- randomClient
-        group  <- randomGroup
-
-        producer <- KafkaTestUtils.makeProducer
-        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
-        _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
-
-        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
-        consumer0 =
-          consumer
-            .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-            .runCollect
-
-        consumer1 =
-          consumer
-            .plainStream(
-              Subscription.manual(topic2, 1), // invalid with the previous subscription
-              Serde.string,
-              Serde.string
-            )
-            .runCollect
-
-        result <- (consumer0 <&> consumer1).unit.exit
-      } yield assert(result)(fails(isSubtype[InvalidSubscriptionUnion](anything)))
-    },
-    test(
-      "gives an error when attempting to subscribe using a manual subscription when there is already a topic subscription and doesn't fail the already running consuming session"
-    ) {
-      val numberOfMessages = 20
-      val kvs              = (0 to numberOfMessages).toList.map(i => (s"key$i", s"msg$i"))
-      for {
-        topic1 <- randomTopic
-        client <- randomClient
-        group  <- randomGroup
-
-        producer <- KafkaTestUtils.makeProducer
-        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
-
-        counter = new AtomicInteger(1)
-
-        firstMessagesRef <- Ref.make(("", ""))
-        finalizersRef    <- Ref.make(Chunk.empty[String])
-
-        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
-
-        c1Fib <- consumer
-                   .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-                   // Here we delay each message to be sure that `consumer1` will fail while `consumer0` is still running
-                   .mapZIO { r =>
-                     firstMessagesRef.updateSome { case ("", v) => ("First consumer0 message", v) } *>
-                       ZIO
-                         .logDebug(s"Consumed ${counter.getAndIncrement()} records")
-                         .delay(10.millis)
-                         .as(r)
-                   }
-                   .take(numberOfMessages.toLong)
-                   .runCollect
-                   .exit
-                   .zipLeft(finalizersRef.update(_ :+ "consumer0 finalized"))
-                   .fork
-
-        _ <- ZIO.sleep(100.millis) // Wait to be sure that `consumer0` is running
-
-        c2Fib <- consumer
-                   .plainStream(
-                     Subscription.manual(topic1, 1), // invalid with the previous subscription
-                     Serde.string,
-                     Serde.string
-                   )
-                   .tapError { _ =>
-                     firstMessagesRef.updateSome { case (v, "") =>
-                       (v, "consumer1 error")
-                     }
-                   }
-                   .runCollect
-                   .exit
-                   .zipLeft(finalizersRef.update(_ :+ "consumer1 finalized"))
-                   .fork
-
-        result1 <- c1Fib.join
-        result2 <- c2Fib.join
-
-        finalizingOrder <- finalizersRef.get
-        firstMessages   <- firstMessagesRef.get
-      } yield assert(result1)(succeeds(hasSize(equalTo(numberOfMessages)))) &&
-        assert(result2)(fails(isSubtype[InvalidSubscriptionUnion](anything))) &&
-        // Here we check that `consumer0` was running when `consumer1` failed
-        assert(firstMessages)(equalTo(("First consumer0 message", "consumer1 error"))) &&
-        assert(finalizingOrder)(equalTo(Chunk("consumer1 finalized", "consumer0 finalized")))
-    } @@ nonFlaky(5),
-    test("distributes records (randomly) from overlapping subscriptions over all subscribers") {
-      val kvs = (1 to 500).toList.map(i => (s"key$i", s"msg$i"))
-      for {
-        topic1 <- randomTopic
-        client <- randomClient
-        group  <- randomGroup
-
-        producer <- KafkaTestUtils.makeProducer
-        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
-
-        consumer1GotMessage <- Promise.make[Nothing, Unit]
-        consumer2GotMessage <- Promise.make[Nothing, Unit]
-        consumer <- KafkaTestUtils.makeConsumer(
-                      client,
-                      Some(group),
-                      properties = Map(ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> "10")
-                    )
-        _ <- consumer
-               .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-               .tap(_ => consumer1GotMessage.succeed(()))
-               .merge(
-                 consumer
-                   .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-                   .tap(_ => consumer2GotMessage.succeed(()))
-               )
-               .interruptWhen(consumer1GotMessage.await *> consumer2GotMessage.await)
-               .runCollect
-      } yield assertCompletes
-    } @@ TestAspect.nonFlaky(5),
-    test("can handle unsubscribing during the lifetime of other streams") {
-      val kvs = (1 to 50).toList.map(i => (s"key$i", s"msg$i"))
-      for {
-        topic1 <- randomTopic
-        topic2 <- randomTopic
-        client <- randomClient
-        group  <- randomGroup
-
-        producer <- KafkaTestUtils.makeProducer
-        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
-        _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
-
-        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
-        _ <-
-          consumer
-            .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-            .take(100)
-            .merge(
+              .runCollect <&>
               consumer
                 .plainStream(Subscription.topics(topic2), Serde.string, Serde.string)
-                .take(50) *> ZStream.fromZIO(KafkaTestUtils.produceMany(producer, topic1, kvs))
-            )
-            .runCollect
-      } yield assertCompletes
-    },
-    test("can restart a stream for the same subscription") {
-      val kvs = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
-      for {
-        topic1 <- randomTopic
-        client <- randomClient
-        group  <- randomGroup
+                .take(5)
+                .runCollect
+          (records1, records2) = records
+          kvOut1               = records1.map(r => (r.record.key, r.record.value)).toList
+          kvOut2               = records2.map(r => (r.record.key, r.record.value)).toList
+        } yield assertTrue(kvOut1 == kvs) &&
+          assertTrue(kvOut2 == kvs) &&
+          assertTrue(records1.map(_.record.topic()).forall(_ == topic1)) &&
+          assertTrue(records2.map(_.record.topic()).forall(_ == topic2))
+      },
+      test("consumes from two pattern subscriptions") {
+        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          topic1 <- randomTopic
+          topic2 <- randomTopic
+          client <- randomClient
+          group  <- randomGroup
 
-        producer <- KafkaTestUtils.makeProducer
-        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+          producer <- KafkaTestUtils.makeProducer
+          _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+          _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
 
-        errored  <- Ref.make(false)
-        consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
-        _ <- consumer
-               .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-               .take(5)
-               .tap(_ => ZIO.unlessZIO(errored.getAndSet(true))(ZIO.fail(new RuntimeException("Stream failure 1"))))
-               .runCollect
-               .retryN(1)
-      } yield assertCompletes
-    },
-    test("can resume a stream for the same subscription") {
-      val kvs = (1 to 1000).toList.map(i => (s"key$i", s"msg$i"))
-      for {
-        topic1 <- randomTopic
-        client <- randomClient
-        group  <- randomGroup
+          consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+          records <-
+            consumer
+              .plainStream(Subscription.Pattern(s"$topic1".r), Serde.string, Serde.string)
+              .take(5)
+              .runCollect <&>
+              consumer
+                .plainStream(Subscription.Pattern(s"$topic2".r), Serde.string, Serde.string)
+                .take(5)
+                .runCollect
+          (records1, records2) = records
+          kvOut1               = records1.map(r => (r.record.key, r.record.value)).toList
+          kvOut2               = records2.map(r => (r.record.key, r.record.value)).toList
+        } yield assertTrue(kvOut1 == kvs) &&
+          assertTrue(kvOut2 == kvs) &&
+          assertTrue(records1.map(_.record.topic()).forall(_ == topic1)) &&
+          assertTrue(records2.map(_.record.topic()).forall(_ == topic2))
+      },
+      test(
+        "gives an error when attempting to subscribe using a manual subscription when there is already a topic subscription"
+      ) {
+        val kvs = (1 to 5).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          topic1 <- randomTopic
+          topic2 <- randomTopic
+          client <- randomClient
+          group  <- randomGroup
 
-        _ <- KafkaTestUtils.createCustomTopic(topic1, partitionCount = 48) // Large number of partitions
+          producer <- KafkaTestUtils.makeProducer
+          _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+          _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
 
-        producer <- KafkaTestUtils.makeProducer
-        _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+          consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+          consumer0 =
+            consumer
+              .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
+              .runCollect
 
-        recordsConsumed <- Ref.make(Chunk.empty[CommittableRecord[String, String]])
-        consumer        <- KafkaTestUtils.makeConsumer(client, Some(group))
-        _ <- ZIO.scoped {
-               consumer
+          consumer1 =
+            consumer
+              .plainStream(
+                Subscription.manual(topic2, 1), // invalid with the previous subscription
+                Serde.string,
+                Serde.string
+              )
+              .runCollect
+
+          result <- (consumer0 <&> consumer1).unit.exit
+        } yield assert(result)(fails(isSubtype[InvalidSubscriptionUnion](anything)))
+      },
+      test(
+        "gives an error when attempting to subscribe using a manual subscription when there is already a topic subscription and doesn't fail the already running consuming session"
+      ) {
+        val numberOfMessages = 20
+        val kvs              = (0 to numberOfMessages).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          topic1 <- randomTopic
+          client <- randomClient
+          group  <- randomGroup
+
+          producer <- KafkaTestUtils.makeProducer
+          _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+
+          counter = new AtomicInteger(1)
+
+          firstMessagesRef <- Ref.make(("", ""))
+          finalizersRef    <- Ref.make(Chunk.empty[String])
+
+          consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+
+          c1Fib <- consumer
+                     .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
+                     // Here we delay each message to be sure that `consumer1` will fail while `consumer0` is still running
+                     .mapZIO { r =>
+                       firstMessagesRef.updateSome { case ("", v) => ("First consumer0 message", v) } *>
+                         ZIO
+                           .logDebug(s"Consumed ${counter.getAndIncrement()} records")
+                           .delay(10.millis)
+                           .as(r)
+                     }
+                     .take(numberOfMessages.toLong)
+                     .runCollect
+                     .exit
+                     .zipLeft(finalizersRef.update(_ :+ "consumer0 finalized"))
+                     .fork
+
+          _ <- ZIO.sleep(100.millis) // Wait to be sure that `consumer0` is running
+
+          c2Fib <- consumer
+                     .plainStream(
+                       Subscription.manual(topic1, 1), // invalid with the previous subscription
+                       Serde.string,
+                       Serde.string
+                     )
+                     .tapError { _ =>
+                       firstMessagesRef.updateSome { case (v, "") =>
+                         (v, "consumer1 error")
+                       }
+                     }
+                     .runCollect
+                     .exit
+                     .zipLeft(finalizersRef.update(_ :+ "consumer1 finalized"))
+                     .fork
+
+          result1 <- c1Fib.join
+          result2 <- c2Fib.join
+
+          finalizingOrder <- finalizersRef.get
+          firstMessages   <- firstMessagesRef.get
+        } yield assert(result1)(succeeds(hasSize(equalTo(numberOfMessages)))) &&
+          assert(result2)(fails(isSubtype[InvalidSubscriptionUnion](anything))) &&
+          // Here we check that `consumer0` was running when `consumer1` failed
+          assert(firstMessages)(equalTo(("First consumer0 message", "consumer1 error"))) &&
+          assert(finalizingOrder)(equalTo(Chunk("consumer1 finalized", "consumer0 finalized")))
+      } @@ nonFlaky(5),
+      test("distributes records (randomly) from overlapping subscriptions over all subscribers") {
+        val kvs = (1 to 500).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          topic1 <- randomTopic
+          client <- randomClient
+          group  <- randomGroup
+
+          producer <- KafkaTestUtils.makeProducer
+          _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+
+          consumer1GotMessage <- Promise.make[Nothing, Unit]
+          consumer2GotMessage <- Promise.make[Nothing, Unit]
+          consumer <- KafkaTestUtils.makeConsumer(
+                        client,
+                        Some(group),
+                        properties = Map(ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> "10")
+                      )
+          _ <- consumer
                  .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
-                 .take(40)
-                 .transduce(
-                   Consumer.offsetBatches.contramap[CommittableRecord[String, String]](_.offset) <&>
-                     ZSink.collectAll[CommittableRecord[String, String]]
+                 .tap(_ => consumer1GotMessage.succeed(()))
+                 .merge(
+                   consumer
+                     .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
+                     .tap(_ => consumer2GotMessage.succeed(()))
                  )
-                 .mapZIO { case (offsetBatch, records) => offsetBatch.commit.as(records) }
-                 .flattenChunks
+                 .interruptWhen(consumer1GotMessage.await *> consumer2GotMessage.await)
                  .runCollect
-                 .tap(records => recordsConsumed.update(_ ++ records))
-             }
-               .repeatN(24)
-        consumed <- recordsConsumed.get
-      } yield assert(consumed.map(r => r.value))(hasSameElements(Chunk.fromIterable(kvs.map(_._2))))
-    } @@ TestAspect.nonFlaky(2)
-  )
-    .provideSomeShared[Scope](
-      Kafka.embedded
-    ) @@ withLiveClock @@ TestAspect.sequential @@ timeout(2.minutes)
+        } yield assertCompletes
+      } @@ TestAspect.nonFlaky(5),
+      test("can handle unsubscribing during the lifetime of other streams") {
+        val kvs = (1 to 50).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          topic1 <- randomTopic
+          topic2 <- randomTopic
+          client <- randomClient
+          group  <- randomGroup
+
+          producer <- KafkaTestUtils.makeProducer
+          _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+          _        <- KafkaTestUtils.produceMany(producer, topic2, kvs)
+
+          consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+          _ <-
+            consumer
+              .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
+              .take(100)
+              .merge(
+                consumer
+                  .plainStream(Subscription.topics(topic2), Serde.string, Serde.string)
+                  .take(50) *> ZStream.fromZIO(KafkaTestUtils.produceMany(producer, topic1, kvs))
+              )
+              .runCollect
+        } yield assertCompletes
+      },
+      test("can restart a stream for the same subscription") {
+        val kvs = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          topic1 <- randomTopic
+          client <- randomClient
+          group  <- randomGroup
+
+          producer <- KafkaTestUtils.makeProducer
+          _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+
+          errored  <- Ref.make(false)
+          consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
+          _ <- consumer
+                 .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
+                 .take(5)
+                 .tap(_ => ZIO.unlessZIO(errored.getAndSet(true))(ZIO.fail(new RuntimeException("Stream failure 1"))))
+                 .runCollect
+                 .retryN(1)
+        } yield assertCompletes
+      },
+      test("can resume a stream for the same subscription") {
+        val kvs = (1 to 1000).toList.map(i => (s"key$i", s"msg$i"))
+        for {
+          topic1 <- randomTopic
+          client <- randomClient
+          group  <- randomGroup
+
+          _ <- KafkaTestUtils.createCustomTopic(topic1, partitionCount = 48) // Large number of partitions
+
+          producer <- KafkaTestUtils.makeProducer
+          _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
+
+          recordsConsumed <- Ref.make(Chunk.empty[CommittableRecord[String, String]])
+          consumer        <- KafkaTestUtils.makeConsumer(client, Some(group))
+          _ <- ZIO.scoped {
+                 consumer
+                   .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
+                   .take(40)
+                   .transduce(
+                     Consumer.offsetBatches.contramap[CommittableRecord[String, String]](_.offset) <&>
+                       ZSink.collectAll[CommittableRecord[String, String]]
+                   )
+                   .mapZIO { case (offsetBatch, records) => offsetBatch.commit.as(records) }
+                   .flattenChunks
+                   .runCollect
+                   .tap(records => recordsConsumed.update(_ ++ records))
+               }
+                 .repeatN(24)
+          consumed <- recordsConsumed.get
+        } yield assert(consumed.map(r => r.value))(hasSameElements(Chunk.fromIterable(kvs.map(_._2))))
+      } @@ TestAspect.nonFlaky(2)
+    )
+      .provideSomeShared[Scope](
+        Kafka.embedded
+      ) @@ withLiveClock @@ timeout(2.minutes)
 }

--- a/zio-kafka-test/src/test/scala/zio/kafka/serde/DeserializerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/serde/DeserializerSpec.scala
@@ -7,24 +7,27 @@ import zio.test._
 import zio.kafka.ZIOSpecDefaultSlf4j
 
 object DeserializerSpec extends ZIOSpecDefaultSlf4j {
-  override def spec: Spec[ZAny with Any, Throwable] = suite("Deserializer")(
-    suite("asOption")(
-      test("deserialize to None when value is null") {
-        assertZIO(stringDeserializer.asOption.deserialize("topic1", new RecordHeaders, null))(isNone)
-      },
-      test("deserialize to None when value is null also when underlying deserializer fails on null values") {
-        val deserializer = Deserializer[Any, Nothing]((_, _, _) => ZIO.fail(new RuntimeException("cannot handle null")))
-        assertZIO(deserializer.asOption.deserialize("topic1", new RecordHeaders, null))(isNone)
-      },
-      test("deserialize to Some when value is not null") {
-        check(Gen.string) { string =>
-          assertZIO(stringDeserializer.asOption.deserialize("topic1", new RecordHeaders, string.getBytes("UTF-8")))(
-            isSome(equalTo(string))
-          )
-        }
-      }
-    )
-  )
+  private val stringDeserializer: Deserializer[Any, String] = Serde.string
 
-  private lazy val stringDeserializer: Deserializer[Any, String] = Serde.string
+  override def spec: Spec[ZAny with Any, Throwable] =
+    suite("Deserializer")(
+      suite("asOption")(
+        test("deserialize to None when value is null") {
+          assertZIO(stringDeserializer.asOption.deserialize("topic1", new RecordHeaders, null))(isNone)
+        },
+        test("deserialize to None when value is null also when underlying deserializer fails on null values") {
+          val deserializer =
+            Deserializer[Any, Nothing]((_, _, _) => ZIO.fail(new RuntimeException("cannot handle null")))
+          assertZIO(deserializer.asOption.deserialize("topic1", new RecordHeaders, null))(isNone)
+        },
+        test("deserialize to Some when value is not null") {
+          check(Gen.string) { string =>
+            assertZIO(stringDeserializer.asOption.deserialize("topic1", new RecordHeaders, string.getBytes("UTF-8")))(
+              isSome(equalTo(string))
+            )
+          }
+        }
+      )
+    )
+
 }


### PR DESCRIPTION
While trying to run the unit tests will Mill some interesting patterns were found. Mill runs more tests in parallel, and presumable uses some class loader tricks, because singletons were initialized multiple times. These changes prevent issues with that pattern.

- Avoid hang when using Mill to run tests.
- Use much safer free port detection.
- Run SubscriptionsSpec in parallel.