### PR TITLE
Increase workaround timeout

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -337,7 +337,7 @@ object AdminClient {
 
     // workaround for https://issues.apache.org/jira/browse/KAFKA-18818
     private val kafka18818Workaround: ZIO[Any, Nothing, Unit] =
-      ZIO.sleep(550.millis).unit
+      ZIO.sleep(650.millis).unit
 
     /**
      * Create multiple topics.

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -337,7 +337,7 @@ object AdminClient {
 
     // workaround for https://issues.apache.org/jira/browse/KAFKA-18818
     private val kafka18818Workaround: ZIO[Any, Nothing, Unit] =
-      ZIO.sleep(650.millis).unit
+      ZIO.sleep(1000.millis).unit
 
     /**
      * Create multiple topics.


### PR DESCRIPTION
Increase timeout for the workaround for https://issues.apache.org/jira/browse/KAFKA-18818 from 550 to 650ms in an attempt to reduce flaky tests.