### PR TITLE
Limit size of consumer batches to max.poll.records

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/PartitionStreamControlSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/PartitionStreamControlSpec.scala
@@ -171,6 +171,7 @@ object PartitionStreamControlSpec extends ZIOSpecDefault {
       tp,
       requestData.unit,
       diagnostics,
+      500,
       Duration.fromSeconds(30)
     )
   }

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RebalanceCoordinatorSpec.scala
@@ -224,7 +224,7 @@ object RebalanceCoordinatorSpec extends ZIOSpecDefaultSlf4j {
     ) @@ TestAspect.withLiveClock
 
   private def makeStreamControl(tp: TopicPartition): UIO[PartitionStreamControl] =
-    PartitionStreamControl.newPartitionStream(tp, ZIO.unit, Diagnostics.NoOp, 30.seconds)
+    PartitionStreamControl.newPartitionStream(tp, ZIO.unit, Diagnostics.NoOp, 500, 30.seconds)
 
   private def makeCoordinator(
     lastEvent: Ref.Synchronized[RebalanceEvent],

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopConfigSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopConfigSpec.scala
@@ -1,0 +1,60 @@
+package zio.kafka.consumer.internal
+
+import zio._
+import zio.kafka.ZIOSpecDefaultSlf4j
+import zio.kafka.consumer.ConsumerSettings
+import zio.test._
+
+object RunloopConfigSpec extends ZIOSpecDefaultSlf4j {
+
+  private val consumerSettings = ConsumerSettings(List("bootstrap"))
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("RunloopConfigSpec")(
+      test("uses defaults from java-kafka") {
+        for {
+          runloopConfig <- RunloopConfig(consumerSettings)
+        } yield assertTrue(
+          runloopConfig.maxPollRecords == 500,
+          runloopConfig.maxPollInterval == 5.minutes,
+          runloopConfig.maxStreamPullInterval == 5.minutes,
+          runloopConfig.maxRebalanceDuration == 3.minutes
+        )
+      },
+      test("maxStreamPullInterval defaults to maxPollInterval") {
+        for {
+          runloopConfig <- RunloopConfig(
+                             consumerSettings.withMaxPollInterval(1.minute)
+                           )
+        } yield assertTrue(
+          runloopConfig.maxStreamPullInterval == 1.minute
+        )
+      },
+      test("maxRebalanceDuration defaults to 3/5 of maxPollInterval") {
+        for {
+          runloopConfig <- RunloopConfig(
+                             consumerSettings.withMaxPollInterval(50.seconds)
+                           )
+        } yield assertTrue(
+          runloopConfig.maxRebalanceDuration == 30.seconds
+        )
+      },
+      test("each config can be overridden separately") {
+        for {
+          runloopConfig <- RunloopConfig(
+                             consumerSettings
+                               .withMaxPollRecords(100)
+                               .withMaxPollInterval(1.minute)
+                               .withMaxStreamPullInterval(2.minutes)
+                               .withMaxRebalanceDuration(90.seconds)
+                           )
+        } yield assertTrue(
+          runloopConfig.maxPollRecords == 100,
+          runloopConfig.maxPollInterval == 1.minute,
+          runloopConfig.maxStreamPullInterval == 2.minutes,
+          runloopConfig.maxRebalanceDuration == 90.seconds
+        )
+      }
+    )
+
+}

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -198,10 +198,10 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
         partitionsHub <- ZIO
                            .acquireRelease(Hub.unbounded[Take[Throwable, PartitionAssignment]])(_.shutdown)
                            .provide(ZLayer.succeed(consumerScope))
+        runloopConfig <- RunloopConfig(consumerSettings)
         runloop <- Runloop.make(
                      consumerSettings,
-                     100.millis,
-                     100.millis,
+                     runloopConfig,
                      diagnostics,
                      consumerAccess,
                      partitionsHub

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -18,13 +18,13 @@ import scala.jdk.CollectionConverters._
 //noinspection SimplifyWhenInspection,SimplifyUnlessInspection
 private[consumer] final class Runloop private (
   settings: ConsumerSettings,
+  runloopConfig: RunloopConfig,
   topLevelExecutor: Executor,
   sameThreadRuntime: Runtime[Any],
   consumer: ConsumerAccess,
   commandQueue: Queue[RunloopCommand],
   partitionsHub: Hub[Take[Throwable, PartitionAssignment]],
   diagnostics: ConsumerDiagnostics,
-  maxStreamPullInterval: Duration,
   currentStateRef: Ref[State],
   rebalanceCoordinator: RebalanceCoordinator,
   consumerMetrics: ConsumerMetrics,
@@ -36,7 +36,8 @@ private[consumer] final class Runloop private (
       tp,
       commandQueue.offer(RunloopCommand.Request(tp)).unit,
       diagnostics,
-      maxStreamPullInterval
+      runloopConfig.maxPollRecords,
+      runloopConfig.maxStreamPullInterval
     )
 
   def stopConsumption: UIO[Unit] =
@@ -373,9 +374,9 @@ private[consumer] final class Runloop private (
   private def checkStreamPullInterval(streams: Chunk[PartitionStreamControl]): ZIO[Any, Nothing, Unit] = {
     def logShutdown(stream: PartitionStreamControl): ZIO[Any, Nothing, Unit] =
       ZIO.logError(
-        s"Stream for ${stream.tp} has not pulled chunks for more than $maxStreamPullInterval, shutting down. " +
-          "Use ConsumerSettings.withMaxPollInterval or .withMaxStreamPullInterval to set a longer interval when " +
-          "processing a batch of records needs more time."
+        s"Stream for ${stream.tp} has not pulled chunks for more than ${runloopConfig.maxStreamPullInterval}, " +
+          "shutting down. Use ConsumerSettings.withMaxPollInterval or .withMaxStreamPullInterval to set a longer " +
+          "interval when processing a batch of records needs more time."
       )
 
     for {
@@ -620,8 +621,7 @@ object Runloop {
 
   private[consumer] def make(
     settings: ConsumerSettings,
-    maxStreamPullInterval: Duration,
-    maxRebalanceDuration: Duration,
+    runloopConfig: RunloopConfig,
     diagnostics: ConsumerDiagnostics,
     consumer: ConsumerAccess,
     partitionsHub: Hub[Take[Throwable, PartitionAssignment]]
@@ -647,19 +647,19 @@ object Runloop {
                                lastRebalanceEvent,
                                settings,
                                consumer,
-                               maxRebalanceDuration,
+                               runloopConfig.maxRebalanceDuration,
                                currentStateRef.get.map(_.assignedStreams),
                                committer
                              )
       runloop = new Runloop(
                   settings = settings,
+                  runloopConfig = runloopConfig,
                   topLevelExecutor = executor,
                   sameThreadRuntime = sameThreadRuntime,
                   consumer = consumer,
                   commandQueue = commandQueue,
                   partitionsHub = partitionsHub,
                   diagnostics = diagnostics,
-                  maxStreamPullInterval = maxStreamPullInterval,
                   currentStateRef = currentStateRef,
                   consumerMetrics = metrics,
                   rebalanceCoordinator = rebalanceCoordinator,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopConfig.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopConfig.scala
@@ -1,0 +1,54 @@
+package zio.kafka.consumer.internal
+
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import zio._
+import zio.kafka.consumer.ConsumerSettings
+
+import java.util.{ Map => JavaMap }
+
+/**
+ * Configuration for the [[Runloop]].
+ *
+ * See [[ConsumerSettings]] for a description of each config.
+ */
+final case class RunloopConfig(
+  maxPollRecords: Int,
+  maxPollInterval: Duration,
+  maxStreamPullInterval: Duration,
+  maxRebalanceDuration: Duration
+)
+
+object RunloopConfig {
+  def apply(settings: ConsumerSettings): Task[RunloopConfig] = ZIO.attempt {
+    // Give an Int config value as overridden by the user, or else None.
+    // Note: it is safe to ignore invalid values, they will lead to an exception
+    // in the java Kafka consumer anyway.
+    def overriddenConfigInt(configName: String): Option[Int] =
+      settings.properties
+        .get(configName)
+        .flatMap(_.toString.toIntOption) // Ignore invalid
+
+    // Some Kafka configs that are needed by the runloop have a default in Kafka and can be overridden via
+    // [[ConsumerSettings]]. Unfortunately the Kafka consumer does not expose its actual config. Therefore, we mimic
+    // what Kafka does: get the config value from the consumer properties and if it is not present, use the default
+    // value.
+    lazy val defaultConfigs: JavaMap[String, AnyRef] = ConsumerConfig.configDef().defaultValues()
+    def defaultConfigInt(configName: String): Int    = defaultConfigs.get(configName).asInstanceOf[Integer]
+
+    val maxPollInterval = {
+      val configName = ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG
+      overriddenConfigInt(configName).getOrElse(defaultConfigInt(configName)).millis
+    }
+
+    val maxPollRecords = {
+      val configName = ConsumerConfig.MAX_POLL_RECORDS_CONFIG
+      overriddenConfigInt(configName).getOrElse(defaultConfigInt(configName))
+    }
+
+    val maxStreamPullInterval = settings.maxStreamPullIntervalOption.getOrElse(maxPollInterval)
+    // See scaladoc of [[ConsumerSettings.withMaxRebalanceDuration]]:
+    val maxRebalanceDuration = settings.maxRebalanceDuration.getOrElse(((maxPollInterval.toNanos / 5L) * 3L).nanos)
+
+    RunloopConfig(maxPollRecords, maxPollInterval, maxStreamPullInterval, maxRebalanceDuration)
+  }
+}


### PR DESCRIPTION
During shutdown, when rebalanceSafeCommits is enabled, we wait until the consumer has processed all records that were pulled from the partition queue. Before this change, the consumer would pull all available (pre-fetched) records. We now put an upper limit on the amount of records that can be pulled. This decreases the time we need to wait, while it doesn't hurt throughput too much.

**Note:** this does mean we zio-kafka can no longer guarantee that all records (for a given partition) fetched together from the broker are grouped into one chunk.

This change also extracts collecting the runloop configuration to a separate class. This has the additional advantage that it can be tested better.