### PR TITLE
micro optimization: use Exit instead of ZIO

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -273,7 +273,7 @@ object Producer {
   private[producer] def makeConcurrentDiagnostics(
     diagnostics: ProducerDiagnostics
   ): ZIO[Scope, Nothing, ProducerDiagnostics] =
-    if (diagnostics == Diagnostics.NoOp) ZIO.succeed(diagnostics)
+    if (diagnostics == Diagnostics.NoOp) Exit.succeed(diagnostics)
     else ConcurrentDiagnostics.make(diagnostics, ProducerEvent.ProducerFinalized)
 
 }
@@ -398,7 +398,7 @@ private[producer] final class ProducerLive(
       val (errors, success) = chunkResults.partitionMap(identity)
       errors.headOption match {
         case Some(error) => ZIO.fail(error) // Only the first failure is returned.
-        case None        => ZIO.succeed(success)
+        case None        => Exit.succeed(success)
       }
     })
 
@@ -415,7 +415,7 @@ private[producer] final class ProducerLive(
   override def produceChunkAsyncWithFailures(
     records: Chunk[ByteRecord]
   ): UIO[UIO[Chunk[Either[Throwable, RecordMetadata]]]] =
-    if (records.isEmpty) ZIO.succeed(ZIO.succeed(Chunk.empty))
+    if (records.isEmpty) Exit.succeed(Exit.succeed(Chunk.empty))
     else {
       val totalRecordCount = records.size
       val diagEm           = diagnosticsEmitterMaker.makeDiagnosticsEmitter(records)

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serdes.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serdes.scala
@@ -3,7 +3,7 @@ package zio.kafka.serde
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.{ Serde => KafkaSerde, Serdes => KafkaSerdes }
 import org.apache.kafka.common.utils.Bytes
-import zio.{ RIO, ZIO }
+import zio.{ Exit, RIO, ZIO }
 
 import java.nio.ByteBuffer
 import java.util.UUID
@@ -25,15 +25,15 @@ private[zio] trait Serdes {
    * Here, we're not using `KafkaSerdes.ByteArray()` because the underlying deserializer and serializer implementations
    * are just identity functions.
    *
-   * That allows us to use [[ZIO.succeed]] instead of [[ZIO.attempt]].
+   * That allows us to use [[Exit.succeed]] instead of [[ZIO.attempt]].
    */
   val byteArray: Serde[Any, Array[Byte]] =
     new Serde[Any, Array[Byte]] {
       override final def serialize(topic: String, headers: Headers, value: Array[Byte]): RIO[Any, Array[Byte]] =
-        ZIO.succeed(value)
+        Exit.succeed(value)
 
       override final def deserialize(topic: String, headers: Headers, data: Array[Byte]): RIO[Any, Array[Byte]] =
-        ZIO.succeed(data)
+        Exit.succeed(data)
     }
 
   private[this] def convertPrimitiveSerde[A](serde: KafkaSerde[A]): Serde[Any, A] =

--- a/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/serde/Serializer.scala
@@ -40,7 +40,7 @@ trait Serializer[-R, -A] {
   def asOption[A1 <: A]: Serializer[R, Option[A1]] =
     Serializer { (topic, headers, valueOpt) =>
       valueOpt match {
-        case None        => ZIO.succeed(null)
+        case None        => Exit.succeed(null)
         case Some(value) => serialize(topic, headers, value)
       }
     }


### PR DESCRIPTION
For preformance reasons,use `Exit.succeed` instead of `ZIO.succeed` when we're constructing a pure value.