### PR TITLE
Validate consumer settings

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSettingsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSettingsSpec.scala
@@ -10,14 +10,72 @@ object ConsumerSettingsSpec extends ZIOSpecDefaultSlf4j {
   override def spec: Spec[TestEnvironment with Scope, Throwable] =
     suite("ConsumerSettingsSpec")(
       test("accepts no auto.commit") {
-        ZIO.attempt(ConsumerSettings(List("host"))) *> assertCompletesZIO
+        ConsumerSettings(List("host")).validate() *> assertCompletesZIO
       },
       test("accepts disabled auto.commit") {
-        ZIO.attempt(ConsumerSettings(List("host")).withProperty("enable.auto.commit", "false")) *> assertCompletesZIO
+        ConsumerSettings(List("host")).withProperty("enable.auto.commit", "false").validate() *> assertCompletesZIO
       },
       test("rejects auto.commit") {
-        val settings = ZIO.attempt(ConsumerSettings(List("host")).withProperty("enable.auto.commit", "true")).exit
-        assertZIO(settings)(failsWithA[IllegalArgumentException])
+        val settings = ConsumerSettings(List("host")).withProperty("enable.auto.commit", "true").validate().exit
+        assertZIO(settings)(
+          failsWithA[IllegalArgumentException] &&
+            fails(
+              hasMessage(
+                equalTo(
+                  "Invalid settings: Because zio-kafka does pre-fetching, auto commit is not supported. Please do not set config enable.auto.commit."
+                )
+              )
+            )
+        )
+      },
+      test("accepts commitTimeout > 2 * pollTimeout") {
+        Seq(2.minutes + 1.milli, 10.minutes).map { commitTimeout =>
+          ConsumerSettings(List("host"))
+            .withCommitTimeout(commitTimeout)
+            .withPollTimeout(1.minute)
+            .validate() *> assertCompletesZIO
+        }
+          .reduce(_ && _)
+      },
+      test("rejects commitTimeout <= 2 * pollTimeout") {
+        Seq(15.seconds, 2.minutes).map { commitTimeout =>
+          val settings = ConsumerSettings(List("host"))
+            .withCommitTimeout(commitTimeout)
+            .withPollTimeout(1.minute)
+            .validate()
+            .exit
+          assertZIO(settings)(
+            failsWithA[IllegalArgumentException] &&
+              fails(
+                hasMessage(
+                  equalTo(
+                    s"Invalid settings: Commit timeout must be larger than 2 * pollTimeout, saw commitTimeout ${commitTimeout} and pollTimeout PT1M."
+                  )
+                )
+              )
+          )
+        }
+          .reduce(_ && _)
+      },
+      test("rejects with multiple problems") {
+        val settings = ConsumerSettings(List("host"))
+          .withProperty("enable.auto.commit", "true")
+          .withCommitTimeout(15.seconds)
+          .withPollTimeout(1.minute)
+          .validate()
+          .exit
+        assertZIO(settings)(
+          failsWithA[IllegalArgumentException] &&
+            fails(
+              hasMessage(
+                equalTo(
+                  "Invalid settings: " +
+                    "Because zio-kafka does pre-fetching, auto commit is not supported. Please do not set config enable.auto.commit. " +
+                    "Commit timeout must be larger than 2 * pollTimeout, saw commitTimeout PT15S and pollTimeout PT1M."
+                )
+              )
+            )
+        )
       }
     )
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -31,7 +31,12 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
   override val kafkaPrefix: String = "consumespec"
 
   override def spec: Spec[TestEnvironment with Scope, Throwable] =
-    suite("Consumer Streaming")(
+    suite("ConsumerSpec")(
+      test("make validates ConsumerSettings") {
+        val settings = ConsumerSettings(List("host")).withProperty("enable.auto.commit", "true")
+        val consumer = Consumer.make(settings).exit
+        assertZIO(consumer)(failsWithA[IllegalArgumentException])
+      },
       test("export metrics") {
         for {
           client   <- randomClient

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -267,6 +267,7 @@ object Consumer {
    */
   def make(settings: ConsumerSettings): ZIO[Scope, Throwable, Consumer] =
     for {
+      _                  <- settings.validate()
       wrappedDiagnostics <- makeConcurrentDiagnostics(settings.diagnostics)
       _                  <- SslHelper.validateEndpoint(settings.driverSettings)
       consumerAccess     <- ConsumerAccess.make(settings)


### PR DESCRIPTION
Add new method `ConsumerSettings.validate` which checks a few illegal settings' values. The settings are checked when the consumer is created.

Fixes #1579