### PR TITLE
Stabilize tests

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -266,8 +266,9 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           standardTopic  <- randomTopic
 
           adminClient <- KafkaTestUtils.makeAdminClient
-          _ <- adminClient.createTopic(NewTopic(compactedTopic, 1, 1, Map(TopicConfig.CLEANUP_POLICY_CONFIG -> "compact")))
-          _ <- KafkaTestUtils.createCustomTopic(standardTopic)
+          _ <-
+            adminClient.createTopic(NewTopic(compactedTopic, 1, 1, Map(TopicConfig.CLEANUP_POLICY_CONFIG -> "compact")))
+          _      <- KafkaTestUtils.createCustomTopic(standardTopic)
           group  <- randomGroup
           client <- randomClient
           chunk = makeChunk(standardTopic, compactedTopic)

--- a/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -40,6 +40,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                       )
           producer <- KafkaTestUtils.makeProducer
           topic    <- randomTopic
+          _        <- KafkaTestUtils.createCustomTopic(topic)
           firstMessage  = "toto"
           secondMessage = "tata"
           consume = (n: Int) =>
@@ -72,6 +73,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                       )
           producer <- KafkaTestUtils.makeProducer
           topic    <- randomTopic
+          _        <- KafkaTestUtils.createCustomTopic(topic)
           firstMessage  = "toto"
           secondMessage = "tata"
           consume = (n: Int) =>
@@ -102,12 +104,10 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
     suite("::produceChunkAsync(records: Chunk[ProducerRecord[Array[Byte], Array[Byte]]])")(
       test("produces messages") {
         for {
-          consumer <- KafkaTestUtils.makeConsumer(
-                        clientId = "producer-spec-consumer",
-                        groupId = Some("group-0")
-                      )
+          consumer <- KafkaTestUtils.makeConsumer(clientId = "producer-spec-consumer", groupId = Some("group-0"))
           producer <- KafkaTestUtils.makeProducer
           topic    <- randomTopic
+          _        <- KafkaTestUtils.createCustomTopic(topic)
           firstMessage  = "toto"
           secondMessage = "tata"
           consume = (n: Int) =>
@@ -150,6 +150,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                       )
           producer <- KafkaTestUtils.makeProducer
           topic    <- randomTopic
+          _        <- KafkaTestUtils.createCustomTopic(topic)
           firstMessage  = "toto"
           secondMessage = "tata"
           consume = (n: Int) =>
@@ -186,6 +187,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         for {
           producer <- KafkaTestUtils.makeProducer
           topic    <- randomTopic
+          _        <- KafkaTestUtils.createCustomTopic(topic)
           _        <- producer.produce(new ProducerRecord(topic, "boo", "baa"), Serde.string, Serde.string)
         } yield assertCompletes
       },
@@ -202,6 +204,8 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           topic2 <- randomTopic
           group  <- randomGroup
           client <- randomClient
+          _      <- KafkaTestUtils.createCustomTopic(topic1)
+          _      <- KafkaTestUtils.createCustomTopic(topic2)
           key1   = "boo"
           value1 = "baa"
           key2   = "baa"
@@ -260,9 +264,10 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         for {
           compactedTopic <- randomTopic
           standardTopic  <- randomTopic
-          adminClient    <- KafkaTestUtils.makeAdminClient
-          _ <- adminClient
-                 .createTopic(NewTopic(compactedTopic, 1, 1, Map(TopicConfig.CLEANUP_POLICY_CONFIG -> "compact")))
+
+          adminClient <- KafkaTestUtils.makeAdminClient
+          _ <- adminClient.createTopic(NewTopic(compactedTopic, 1, 1, Map(TopicConfig.CLEANUP_POLICY_CONFIG -> "compact")))
+          _ <- KafkaTestUtils.createCustomTopic(standardTopic)
           group  <- randomGroup
           client <- randomClient
           chunk = makeChunk(standardTopic, compactedTopic)
@@ -283,10 +288,9 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         )
       },
       test("an empty chunk of records") {
-        val chunks = Chunk.fromIterable(List.empty)
         for {
           producer <- KafkaTestUtils.makeProducer
-          outcome  <- producer.produceChunk(chunks, Serde.string, Serde.string)
+          outcome  <- producer.produceChunk(Chunk.empty, Serde.string, Serde.string)
         } yield assertTrue(outcome.isEmpty)
       },
       test("export metrics") {
@@ -299,6 +303,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
         for {
           producer <- KafkaTestUtils.makeProducer
           topic    <- randomTopic
+          _        <- KafkaTestUtils.createCustomTopic(topic)
           info     <- producer.partitionsFor(topic).debug
         } yield assertTrue(info.headOption.map(_.topic()).contains(topic))
       },
@@ -309,6 +314,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             group   <- randomGroup
             client1 <- randomClient
             client2 <- randomClient
+            _       <- KafkaTestUtils.createCustomTopic(topic)
             initialAliceAccount = new ProducerRecord(topic, "alice", 20)
             initialBobAccount   = new ProducerRecord(topic, "bob", 0)
 
@@ -342,6 +348,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             group   <- randomGroup
             client1 <- randomClient
             client2 <- randomClient
+            _       <- KafkaTestUtils.createCustomTopic(topic)
             initialAliceAccount = new ProducerRecord(topic, "alice", 20)
             initialBobAccount   = new ProducerRecord(topic, "bob", 0)
             aliceGives20        = new ProducerRecord(topic, "alice", 0)
@@ -389,6 +396,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             group   <- randomGroup
             client1 <- randomClient
             client2 <- randomClient
+            _       <- KafkaTestUtils.createCustomTopic(topic)
             initialAliceAccount = new ProducerRecord(topic, "alice", 20)
             initialBobAccount   = new ProducerRecord(topic, "bob", 0)
 
@@ -425,6 +433,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           for {
             topic   <- randomTopic
             client1 <- randomClient
+            _       <- KafkaTestUtils.createCustomTopic(topic)
             initialBobAccount = new ProducerRecord(topic, "bob", 0)
 
             consumer1             <- KafkaTestUtils.makeConsumer(client1, rebalanceSafeCommits = true)
@@ -448,6 +457,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             group   <- randomGroup
             client1 <- randomClient
             client2 <- randomClient
+            _       <- KafkaTestUtils.createCustomTopic(topic)
 
             initialAliceAccount = new ProducerRecord(topic, "alice", 20)
             initialBobAccount   = new ProducerRecord(topic, "bob", 0)
@@ -492,6 +502,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             group   <- randomGroup
             client1 <- randomClient
             client2 <- randomClient
+            _       <- KafkaTestUtils.createCustomTopic(topic)
 
             initialAliceAccount = new ProducerRecord(topic, "alice", 20)
             initialBobAccount   = new ProducerRecord(topic, "bob", 0)
@@ -535,6 +546,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             group   <- randomGroup
             client1 <- randomClient
             client2 <- randomClient
+            _       <- KafkaTestUtils.createCustomTopic(topic)
 
             initialAliceAccount = new ProducerRecord(topic, "alice", 20)
             initialBobAccount   = new ProducerRecord(topic, "bob", 0)
@@ -583,6 +595,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             group2  <- randomGroup
             client1 <- randomClient
             client2 <- randomClient
+            _       <- KafkaTestUtils.createCustomTopic(topic)
 
             initialAliceAccount  = new ProducerRecord(topic, "alice", 20)
             aliceAccountFeesPaid = new ProducerRecord(topic, "alice", 0)
@@ -624,6 +637,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             group2  <- randomGroup
             client1 <- randomClient
             client2 <- randomClient
+            _       <- KafkaTestUtils.createCustomTopic(topic)
 
             initialAliceAccount  = new ProducerRecord(topic, "alice", 20)
             aliceAccountFeesPaid = new ProducerRecord(topic, "alice", 0)
@@ -664,6 +678,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           val test = for {
             topic            <- randomTopic
             client1          <- randomClient
+            _                <- KafkaTestUtils.createCustomTopic(topic)
             transactionThief <- Ref.make(Option.empty[Transaction])
 
             consumer1             <- KafkaTestUtils.makeConsumer(client1, rebalanceSafeCommits = true)
@@ -682,6 +697,7 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           val test = for {
             topic            <- randomTopic
             client1          <- randomClient
+            _                <- KafkaTestUtils.createCustomTopic(topic)
             transactionThief <- Ref.make(Option.empty[Transaction])
 
             consumer1             <- KafkaTestUtils.makeConsumer(client1, rebalanceSafeCommits = true)

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -118,24 +118,6 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           kvOut = records.map(r => (r.record.key, r.record.value)).toList
         } yield assert(kvOut)(equalTo(kvs))
       },
-      test("Consuming+provideCustomLayer") {
-        val kvs = (1 to 100).toList.map(i => (s"key$i", s"msg$i"))
-        for {
-          topic  <- randomTopic
-          client <- randomClient
-          group  <- randomGroup
-
-          producer <- KafkaTestUtils.makeProducer
-          _        <- KafkaTestUtils.produceMany(producer, topic, kvs)
-
-          consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
-          records <- consumer
-                       .plainStream(Subscription.Topics(Set(topic)), Serde.string, Serde.string)
-                       .take(100)
-                       .runCollect
-          kvOut = records.map(r => (r.record.key, r.record.value)).toList
-        } yield assert(kvOut)(equalTo(kvs))
-      },
       test("plainStream receives messages for a pattern subscription") {
         val topic = "pattern" + (1000 + scala.util.Random.nextInt(9000))
         for {

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -127,10 +127,10 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           producer <- KafkaTestUtils.makeProducer
           _        <- KafkaTestUtils.scheduledProduce(producer, topic, Schedule.recurs(100)).runDrain.forkScoped
           consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
-          _        <- consumer
-                       .plainStream(Subscription.Pattern("pattern[0-9]+".r), Serde.string, Serde.string)
-                       .take(5)
-                       .runCollect
+          _ <- consumer
+                 .plainStream(Subscription.Pattern("pattern[0-9]+".r), Serde.string, Serde.string)
+                 .take(5)
+                 .runCollect
           _ <- ZIO.logError("end of test")
         } yield assertCompletes
       },

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -1545,6 +1545,8 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           producer <- KafkaTestUtils.makeProducer
           _ <- KafkaTestUtils
                  .produceMany(producer, topic, kvs = (0 until nrMessages).map(n => s"key-$n" -> s"value->$n"))
+                 .repeat(Schedule.spaced(10.millis))
+                 .forkScoped
 
           allAssignments <- Ref.make(Map.empty[Int, List[Int]])
           check = checkAssignments(allAssignments)(_)


### PR DESCRIPTION
Make the unit tests more stable by:

- removing tests that don't do what their description says
- explicitly create topics
- relax assertions when they are not relevant for the test