### PR TITLE
Stabilize test

### DIFF
--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -115,7 +115,7 @@ object KafkaTestUtils {
    *
    * See also [[https://issues.apache.org/jira/browse/KAFKA-19811 KAFKA-19811]].
    */
-  val kafka19811Workaround: UIO[Unit] = ZIO.sleep(5.millis)
+  val kafka19811Workaround: UIO[Unit] = ZIO.sleep(10.millis)
 
   /**
    * Produce a single message to a topic.


### PR DESCRIPTION
Increase sleep as a workaround for KAFKA-19811 from 5 to 10ms.