### PR TITLE
Rename `offsetBatches` to `collectOffsets`, improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ object ReadmeExample extends ZIOAppDefault {
           .plainStream(Subscription.topics("random"), Serde.long, Serde.string)
           .tap(r => Console.printLine(r.value))
           .map(_.offset)
-          .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+          .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
           .mapZIO(_.commit)
           .runDrain
       } yield ()

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Kafka has a mature Java client for producing and consuming events, but it has a 
 
 ## Getting started
 
-See the [zio-kafka tutorial](https://zio.dev/guides/tutorials/producing-consuming-data-from-kafka-topics/) for a grand tour of the different ways you can use zio-kafka.
+See the [zio-kafka tutorial](docs/tutorial.md) for a grand tour of the different ways you can use zio-kafka.
 
 In order to use this library, we need to add the following line in our `build.sbt` file:
 
@@ -142,7 +142,7 @@ object ReadmeExample extends ZIOAppDefault {
           .plainStream(Subscription.topics("random"), Serde.long, Serde.string)
           .tap(r => Console.printLine(r.value))
           .map(_.offset)
-          .aggregateAsync(Consumer.offsetBatches)
+          .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
           .mapZIO(_.commit)
           .runDrain
       } yield ()
@@ -152,6 +152,8 @@ object ReadmeExample extends ZIOAppDefault {
     ZIO.raceFirst(producerRun, List(consumerRun))
 }
 ```
+
+Read the [ZIO Kafka tutorial](docs/tutorial.md) for a more gentle introduction.
 
 ## Documentation
 
@@ -165,7 +167,6 @@ If you are reading this from GitHub, the documentation can be found in
 
 ### Articles
 
-- [ZIO Kafka tutorial](https://zio.dev/guides/tutorials/producing-consuming-data-from-kafka-topics/) by the zio-kafka team
 - [ZIO Kafka faster than Java Kafka](https://day-to-day-stuff.blogspot.com/2024/12/zio-kafka-faster-than-java-kafka.html) by Erik van Oosten (December 2024)
 - [Introduction to zio-kafka](https://www.baeldung.com/scala/zio-kafka-intro) by Stefanos Georgakis, Baeldung (January 2023)
 - [How to implement streaming microservices with ZIO 2 and Kafka](https://scalac.io/blog/streaming-microservices-with-zio-and-kafka/) by Jorge Vasquez, Scalac (June 2023)

--- a/build.sbt
+++ b/build.sbt
@@ -215,8 +215,8 @@ lazy val docs = project
   .in(file("zio-kafka-docs"))
   .settings(
     moduleName := "zio-kafka-docs",
-    scalacOptions -= "-Yno-imports",
-    scalacOptions -= "-Xfatal-warnings",
+    // Reset scala options, warning are okay in the docs
+    scalacOptions := Seq("--encoding", "utf8", "--feature"),
     projectName                                := "ZIO Kafka",
     mainModuleName                             := (zioKafka / moduleName).value,
     projectStage                               := ProjectStage.ProductionReady,

--- a/build.sbt
+++ b/build.sbt
@@ -225,7 +225,8 @@ lazy val docs = project
       "This library is heavily inspired and made possible by the research and implementation done in " +
         "[Alpakka Kafka](https://github.com/akka/alpakka-kafka), a library maintained by the Akka team and originally " +
         "written as Reactive Kafka by SoftwareMill.",
-    readmeLicense += s"\n\nCopyright 2021-${java.time.Year.now()} Itamar Ravid and the zio-kafka contributors."
+    readmeLicense += s"\n\nCopyright 2021-${java.time.Year.now()} Itamar Ravid and the zio-kafka contributors.",
+    libraryDependencies += "dev.zio" %% "zio-json" % "0.9.1"
   )
   .enablePlugins(WebsitePlugin)
   .dependsOn(zioKafka, zioKafkaTestkit)

--- a/build.sbt
+++ b/build.sbt
@@ -224,7 +224,8 @@ lazy val docs = project
       "This library is heavily inspired and made possible by the research and implementation done in " +
         "[Alpakka Kafka](https://github.com/akka/alpakka-kafka), a library maintained by the Akka team and originally " +
         "written as Reactive Kafka by SoftwareMill.",
-    readmeLicense += s"\n\nCopyright 2021-${java.time.Year.now()} Itamar Ravid and the zio-kafka contributors."
+    readmeLicense += s"\n\nCopyright 2021-${java.time.Year.now()} Itamar Ravid and the zio-kafka contributors.",
+    libraryDependencies += "dev.zio" %% "zio-json" % "0.9.1"
   )
   .enablePlugins(WebsitePlugin)
   .dependsOn(zioKafka, zioKafkaTestkit)

--- a/build.sbt
+++ b/build.sbt
@@ -214,8 +214,8 @@ lazy val docs = project
   .in(file("zio-kafka-docs"))
   .settings(
     moduleName := "zio-kafka-docs",
-    scalacOptions -= "-Yno-imports",
-    scalacOptions -= "-Xfatal-warnings",
+    // Reset scala options, warning are okay in the docs
+    scalacOptions := Seq("--encoding", "utf8", "--feature"),
     projectName                                := "ZIO Kafka",
     mainModuleName                             := (zioKafka / moduleName).value,
     projectStage                               := ProjectStage.ProductionReady,

--- a/docs/consuming-kafka-topics-using-zio-streams.md
+++ b/docs/consuming-kafka-topics-using-zio-streams.md
@@ -6,6 +6,7 @@ title: "Consuming Kafka topics using ZIO Streams"
 You can stream data from Kafka using the `plainStream` method:
 
 ```scala
+import zio._
 import zio.Console.printLine
 import zio.kafka.consumer._
 
@@ -13,7 +14,7 @@ consumer
   .plainStream(Subscription.topics("topic150"), Serde.string, Serde.string) // (1)
   .tap(cr => printLine(s"key: ${cr.record.key}, value: ${cr.record.value}")) // (2)
   .map(_.offset) // (3)
-  .aggregateAsync(Consumer.offsetBatches) // (4)
+  .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis)) // (4)
   .mapZIO(_.commit) // (5)
   .runDrain
 ```
@@ -32,10 +33,25 @@ throughput. See [avoiding chunk-breakers](avoiding-chunk-breakers.md) for more i
 (3) Here we get the offset of the record, so we now have a stream of offsets.
 
 (4) The offsets are aggregated into an `OffsetBatch`. The offset batch keeps the highest seen offset per partition.
+ZStream operator `aggregateAsyncWithin` runs upstream in a separate fiber, allowing consuming and committing to run in
+parallel.
+
+For applications that only see a few records per second or less, you can remove line (4) and commit the offset for each
+record separately.
+
+If on the other hand you wish to commit continuously (start a new commit, as soon as the previous completed), replace
+line (4) with `.aggregateAsync(Consumer.offsetBatches)`. Be aware that if many applications do this, the kafka broker
+can get overloaded.
+
+The offset batches are emitted every 100 milliseconds. The delay should be longer than the typical commit-duration in
+your system. For example, lets assume the delay is set to 2ms and a commit operation takes 10ms. Then, when some records
+are consumed, 2ms later `aggregateAsyncWithin` emits an offset batch and starts collecting offsets for the next batch.
+In addition, the commit operation starts. Again 2ms later `aggregateAsyncWithin` tries to emit the next batch. However,
+this will block because the commit is still ongoing. Since `aggregateAsyncWithin` is now blocked, it stops accepting
+offsets from upstream, halting the consumer until the commit completes.
 
 (5) All offsets in the `OffsetBatch` are committed. As soon as the commit is done, the next offset batch is pulled
-from the stream. Because the aggregation in (4) is asynchronous, this application is continuously committing while
-concurrently processing records.
+from upstream.
 
 ## Consuming with more parallelism
 
@@ -43,6 +59,7 @@ To process partitions (assigned to the consumer) in parallel, you may use the `p
 a nested stream of partitions:
 
 ```scala
+import zio._
 import zio.Console.printLine
 import zio.kafka.consumer._
 
@@ -56,10 +73,12 @@ consumer
         .tap(record => printLine(s"key: ${record.key}, value: ${record.value}")) // (2)
         .map(_.offset) // (3)
   }
-  .aggregateAsync(Consumer.offsetBatches) // (4)
-  .mapZIO(_.commit)
+  .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis)) // (4)
+  .mapZIO(_.commit)  // (5)
   .runDrain
 ```
+
+In this example, each partition is processed in parallel on separate fibers, while a single fiber is doing commits.
 
 (1) When using partitionedStream with `flatMapPar(n)`, it is recommended to set n to `Int.MaxValue`. N must be equal to
 or greater than the number of partitions your consumer subscribes to otherwise there will be unhandled partitions and
@@ -70,20 +89,28 @@ Each time a new partition is assigned to the consumer, a new partition stream is
 
 (2) As before, here we process the received `CommittableRecord`.
 
-(3) and (4) Note how the offsets from all the sub-streams are merged into a single stream of `OffsetBatch`es. This
-ensures only a single stream is doing commits.
+(3) Note how the offsets from all the sub-streams are merged into a single stream of `Offset`s. This ensures only a
+single stream is doing commits.
 
-In this example, each partition is processed in parallel, on separate fibers, while a single fiber is doing commits.
+(4) and (5) The offsets are aggregated into an `OffsetBatch` and committed as in the previous section.
 
 ## Controlled shutdown (experimental)
 
-The examples above will keep processing records forever, or until the fiber is interrupted, typically at application shutdown. When interrupted, some records may be 'in-flight', e.g. being processed by one of the stages of your consumer stream user code. Those records will be processed partly and their offsets may not be committed. For fast shutdown in an at-least-once processing scenario this is fine.
+The examples above will keep processing records forever, or until the fiber is interrupted, typically at application
+shutdown. When interrupted, some records may be 'in-flight', e.g. being processed by one of the stages of your consumer
+stream user code. Those records will be processed partly and their offsets may not be committed. For fast shutdown in an
+at-least-once processing scenario this is fine.
 
-zio-kafka also supports a _graceful shutdown_, where the fetching of records for the subscribed topics/partitions is stopped, the streams are ended and all downstream stages are completed, allowing in-flight records to be fully processed.
+zio-kafka also supports a _graceful shutdown_, where the fetching of records for the subscribed topics/partitions is
+stopped, the streams are ended and all downstream stages are completed, allowing in-flight records to be fully
+processed.
 
-Use the `*StreamWithControl` variants of `plainStream`, `partitionedStream` and `partitionedAssignmentStream` for this purpose. These methods return a `StreamControl` object allowing you to stop fetching records and terminate the execution of the stream gracefully.
+Use the `*StreamWithControl` variants of `plainStream`, `partitionedStream` and `partitionedAssignmentStream` for this
+purpose. These methods return a `StreamControl` object allowing you to stop fetching records and terminate the execution
+of the stream gracefully.
 
-The `StreamControl` can be used with `Consumer.runWithGracefulShutdown`, which can gracefully terminate the stream upon fiber interruption. This is useful for a controlled shutdown when your application is terminated:
+The `StreamControl` can be used with `Consumer.runWithGracefulShutdown`, which can gracefully terminate the stream upon
+fiber interruption. This is useful for a controlled shutdown when your application is terminated:
 
 ```scala
 import zio.Console.printLine
@@ -103,7 +130,7 @@ ZIO.scoped {
             .tap(record => printLine(s"key: ${record.key}, value: ${record.value}"))
             .map(_.offset)
         }
-        .aggregateAsync(Consumer.offsetBatches)
+        .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
         .mapZIO(_.commit)
         .runDrain
       }
@@ -129,7 +156,7 @@ ZIO.scoped {
               .tap(record => printLine(s"key: ${record.key}, value: ${record.value}"))
               .map(_.offset)
           }
-          .aggregateAsync(Consumer.offsetBatches)
+          .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
           .mapZIO(_.commit)
           .runDrain
           .forkScoped
@@ -140,4 +167,5 @@ ZIO.scoped {
 }
 ```
 
-As of zio-kafka 3.0, this functionality is experimental. If no issues are reported and the API has good usability, it will eventually be marked as stable.
+As of zio-kafka 3.0, this functionality is experimental. If no issues are reported and the API has good usability, it
+will eventually be marked as stable.

--- a/docs/consuming-kafka-topics-using-zio-streams.md
+++ b/docs/consuming-kafka-topics-using-zio-streams.md
@@ -14,7 +14,7 @@ consumer
   .plainStream(Subscription.topics("topic150"), Serde.string, Serde.string) // (1)
   .tap(cr => printLine(s"key: ${cr.record.key}, value: ${cr.record.value}")) // (2)
   .map(_.offset) // (3)
-  .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis)) // (4)
+  .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis)) // (4)
   .mapZIO(_.commit) // (5)
   .runDrain
 ```
@@ -48,7 +48,7 @@ record separately. In this approach the commit executes on the same fiber as the
 throughput. Explicitly committing every record is therefore almost never the best approach.
 
 To get the lowest commit latency you can commit continuously; a new commit is started as soon as the previous completes.
-This is done by replacing line (4) with `.aggregateAsync(Consumer.offsetBatches)`. Be aware that registering commits is
+This is done by replacing line (4) with `.aggregateAsync(Consumer.collectOffsets)`. Be aware that registering commits is
 an intensive operation for the kafka brokers. With dozens of consumers continuously committing, the high load may slow
 down everything.
 
@@ -75,7 +75,7 @@ consumer
         .tap(record => printLine(s"key: ${record.key}, value: ${record.value}")) // (2)
         .map(_.offset) // (3)
   }
-  .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis)) // (4)
+  .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis)) // (4)
   .mapZIO(_.commit)  // (5)
   .runDrain
 ```
@@ -132,7 +132,7 @@ ZIO.scoped {
             .tap(record => printLine(s"key: ${record.key}, value: ${record.value}"))
             .map(_.offset)
         }
-        .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+        .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
         .mapZIO(_.commit)
         .runDrain
       }
@@ -158,7 +158,7 @@ ZIO.scoped {
               .tap(record => printLine(s"key: ${record.key}, value: ${record.value}"))
               .map(_.offset)
           }
-          .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+          .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
           .mapZIO(_.commit)
           .runDrain
           .forkScoped

--- a/docs/consuming-kafka-topics-using-zio-streams.md
+++ b/docs/consuming-kafka-topics-using-zio-streams.md
@@ -36,19 +36,21 @@ throughput. See [avoiding chunk-breakers](avoiding-chunk-breakers.md) for more i
 ZStream operator `aggregateAsyncWithin` runs upstream in a separate fiber, allowing consuming and committing to run in
 parallel.
 
-For applications that only see a few records per second or less, you can remove line (4) and commit the offset for each
-record separately.
-
-If on the other hand you wish to commit continuously (start a new commit, as soon as the previous completed), replace
-line (4) with `.aggregateAsync(Consumer.offsetBatches)`. Be aware that if many applications do this, the kafka broker
-can get overloaded.
-
 The offset batches are emitted every 100 milliseconds. The delay should be longer than the typical commit-duration in
 your system. For example, lets assume the delay is set to 2ms and a commit operation takes 10ms. Then, when some records
 are consumed, 2ms later `aggregateAsyncWithin` emits an offset batch and starts collecting offsets for the next batch.
 In addition, the commit operation starts. Again 2ms later `aggregateAsyncWithin` tries to emit the next batch. However,
 this will block because the commit is still ongoing. Since `aggregateAsyncWithin` is now blocked, it stops accepting
 offsets from upstream, halting the consumer until the commit completes.
+
+For applications that only see a few records per second or less, you can remove line (4) and commit the offset for each
+record separately. In this approach the commit executes on the same fiber as the rest of the stream. This lowers
+throughput. Explicitly committing every record is therefore almost never the best approach.
+
+To get the lowest commit latency you can commit continuously; a new commit is started as soon as the previous completes.
+This is done by replacing line (4) with `.aggregateAsync(Consumer.offsetBatches)`. Be aware that registering commits is
+an intensive operation for the kafka brokers. With dozens of consumers continuously committing, the high load may slow
+down everything.
 
 (5) All offsets in the `OffsetBatch` are committed. As soon as the commit is done, the next offset batch is pulled
 from upstream.

--- a/docs/consuming-producing-and-committing-offsets.md
+++ b/docs/consuming-producing-and-committing-offsets.md
@@ -88,11 +88,11 @@ Let's zoom in on the consumer part of the example program.
 
 Method `plainStream` produces a single stream, and chunks from different partitions are processed serially. At the
 cost of making the program more complex, we can increase throughput with per-partition parallel processing. See
-[consuming with more parallelism](consuming-kafka-topics-using-zio-streams#consuming-with-more-parallelism) for more
+[consuming with more parallelism](consuming-kafka-topics-using-zio-streams.md#consuming-with-more-parallelism) for more
 details. On this page, we do not explore this optimization further.
 
 Zio-kafka's prefetching automatically adapts and is usually as good as it can be. Only for very small/large records, or
-for large amounts of topics, you may need to configure it better. Please see [consumer tuning](consumer-tuning) to find
+for large amounts of topics, you may need to configure it better. Please see [consumer tuning](consumer-tuning.md) to find
 out how.
 
 ### Optimizing producer throughput
@@ -174,7 +174,7 @@ stream
 
 Commiting offsets can become the bottleneck in highly optimized zio-kafka programs. This is because high commit rates
 can put a high strain on the broker. Next up, we split off committing to its own fiber as well by using
-`aggregateAsyncWithin`. See [consuming with zio-streams](consuming-kafka-topics-using-zio-streams) to learn how this
+`aggregateAsyncWithin`. See [consuming with zio-streams](consuming-kafka-topics-using-zio-streams.md) to learn how this
 works.
 
 Replace the part after `.buffer()` with:

--- a/docs/consuming-producing-and-committing-offsets.md
+++ b/docs/consuming-producing-and-committing-offsets.md
@@ -1,17 +1,25 @@
 ---
-id: example-of-consuming-producing-and-committing-offsets
-title: "Example of Consuming, Producing and Committing Offsets"
+id: consuming-producing-and-committing-offsets
+title: "Consuming, Producing and Committing Offsets"
 ---
 
-This example shows how to:
+Consuming from Kafka and then producing a transformed message back to Kafka, is a regular pattern in systems that use
+Kafka. This page shows an example of an application that does this. Next we discuss how throughput can be improved.
 
-1. consume messages from topic `topic_a`,
-2. transform the received records,
-3. produce the transformed records to topic `topic_b`,
-4. commit the consumer offsets.
+This page is also useful as a deep dive into producing to Kafka with data from other streaming sources.
 
-Note that we need to explicitly commit offsets; with zio-kafka we process records asynchronously with the consumer, and
-therefore, committing offsets automatically is not straightforward.
+# Example application
+
+This is what the example application does:
+
+1. consumes messages from topic `topic_a`,
+2. transforms the received records,
+3. produces the transformed records to topic `topic_b`,
+4. commits the consumer offsets.
+
+The application uses the zio-kafka streaming APIs. We need to explicitly commit offsets; applications that use the
+streaming API process records asynchronously with the consumer, and therefore, committing offsets automatically is not
+possible.
 
 ```scala
 import zio.kafka.consumer._
@@ -44,8 +52,8 @@ for {
       // For every chunk of producerRecords and offsets
       .mapChunksZIO { chunk =>
         val records = chunk.map(_._1)
-        val offsetBatch = OffsetBatch(chunk.map(_._2).toSeq)
-  
+        val offsetBatch = OffsetBatch(chunk.map(_._2))
+
         // produce the chunk of records, when acked by kafka, commit the consumed offsets,
         // returning an empty chunk (`mapChunksZIO` requires this function to return a ZIO[Chunk])
         producer.produceChunk[Any, Int, String](records) *>
@@ -120,7 +128,7 @@ And now in code. Replace the `mapChunksZIO` operator with the following code:
   // For every exposed chunk
   .mapZIO { chunk =>
     val records = chunk.map(_._1)
-    val offsetBatch = OffsetBatch(chunk.map(_._2).toSeq)
+    val offsetBatch = OffsetBatch(chunk.map(_._2))
     // Produce asynchronously
     producer.produceChunkAsync(records, Serde.int, Serde.string)
       .map(await => (await, offsetBatch))
@@ -134,7 +142,7 @@ And now in code. Replace the `mapChunksZIO` operator with the following code:
     // 'await' is a ZIO, run it, and then commit offsets
     await *> offsetBatch.commit
   }               // ZStream[_, _, Unit]
-`````
+```
 
 Method `producer.produceChunkAsync` returns a `Task[Task[]]`. The outer task completes when the records have been sent.
 Completion gives us the inner task, which completes when the acknowledgements are received.
@@ -142,19 +150,43 @@ Completion gives us the inner task, which completes when the acknowledgements ar
 In the code we use `buffer(4)` which allows the program to produce up to 4 extra chunk of records while awaiting
 acknowledgements.
 
-### Optimizing committing consumer offset
+#### Aside, when commits are not needed
+
+When commits are not needed, we can simplify the code a bit:
+
+```scala
+val stream: ZStream[_, _, ProducerRecord] = ???
+
+stream
+  // Expose the chunking structure of the stream
+  .chunks         // ZStream[_, _, Chunk[ProducerRecord]]
+  // Every chunk gets produced asynchronously
+  .mapZIO { records =>
+    producer.produceChunkAsync(records, Serde.int, Serde.string)
+  }               // ZStream[_, _, Task[Chunk[RecordMetadata]]]
+  // Allow the producer to run ahead, producing up to 4 extra chunks
+  .buffer(4)      // ZStream[_, _, Task[Chunk[RecordMetadata]]]
+  // Await acknowledgements per chunk
+  .flattenZIO     // ZStream[_, _, Chunk[RecordMetadata]]
+```
+
+### Optimizing committing consumer offsets
 
 Commiting offsets can become the bottleneck in highly optimized zio-kafka programs. This is because high commit rates
 can put a high strain on the broker. Next up, we split off committing to its own fiber as well by using
-`aggregateAsync`. See [consuming with zio-streams](consuming-kafka-topics-using-zio-streams) to learn how this works.
+`aggregateAsyncWithin`. See [consuming with zio-streams](consuming-kafka-topics-using-zio-streams) to learn how this
+works.
+
+Replace the part after `.buffer()` with:
 
 ```scala
   // Await acknowledgements for a chunk 
   .mapZIO { case (await, offsetBatch) =>
     // 'await' is a ZIO, run it, and then return the offsets
     await.as(offsetBatch)
-  }
-  .aggregateAsync(Consumer.offsetBatches)
-  .mapZIO(_.commit)
+  }                   // ZStream[_, _, OffsetBatch]
+  .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+                      // ZStream[_, _, OffsetBatch]
+  .mapZIO(_.commit)   // ZStream[_, _, Unit]
 ```
 

--- a/docs/consuming-producing-and-committing-offsets.md
+++ b/docs/consuming-producing-and-committing-offsets.md
@@ -185,7 +185,7 @@ Replace the part after `.buffer()` with:
     // 'await' is a ZIO, run it, and then return the offsets
     await.as(offsetBatch)
   }                   // ZStream[_, _, OffsetBatch]
-  .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+  .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
                       // ZStream[_, _, OffsetBatch]
   .mapZIO(_.commit)   // ZStream[_, _, Unit]
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,7 +142,7 @@ object ReadmeExample extends ZIOAppDefault {
           .plainStream(Subscription.topics("random"), Serde.long, Serde.string)
           .tap(r => Console.printLine(r.value))
           .map(_.offset)
-          .aggregateAsync(Consumer.offsetBatches)
+          .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
           .mapZIO(_.commit)
           .runDrain
       } yield ()
@@ -152,6 +152,8 @@ object ReadmeExample extends ZIOAppDefault {
     ZIO.raceFirst(producerRun, List(consumerRun))
 }
 ```
+
+Go to the [ZIO Kafka tutorial](https://zio.dev/zio-kafka/tutorial/) for a more gentle introduction.
 
 ## Documentation
 
@@ -165,7 +167,6 @@ If you are reading this from GitHub, the documentation can be found in
 
 ### Articles
 
-- [ZIO Kafka tutorial](https://zio.dev/guides/tutorials/producing-consuming-data-from-kafka-topics/) by the zio-kafka team
 - [ZIO Kafka faster than Java Kafka](https://day-to-day-stuff.blogspot.com/2024/12/zio-kafka-faster-than-java-kafka.html) by Erik van Oosten (December 2024)
 - [Introduction to zio-kafka](https://www.baeldung.com/scala/zio-kafka-intro) by Stefanos Georgakis, Baeldung (January 2023)
 - [How to implement streaming microservices with ZIO 2 and Kafka](https://scalac.io/blog/streaming-microservices-with-zio-and-kafka/) by Jorge Vasquez, Scalac (June 2023)

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,7 +142,7 @@ object ReadmeExample extends ZIOAppDefault {
           .plainStream(Subscription.topics("random"), Serde.long, Serde.string)
           .tap(r => Console.printLine(r.value))
           .map(_.offset)
-          .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+          .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
           .mapZIO(_.commit)
           .runDrain
       } yield ()

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ Kafka has a mature Java client for producing and consuming events, but it has a 
 
 ## Getting started
 
-See the [zio-kafka tutorial](https://zio.dev/guides/tutorials/producing-consuming-data-from-kafka-topics/) for a grand tour of the different ways you can use zio-kafka.
+See the [zio-kafka tutorial](docs/tutorial.md) for a grand tour of the different ways you can use zio-kafka.
 
 In order to use this library, we need to add the following line in our `build.sbt` file:
 
@@ -153,7 +153,7 @@ object ReadmeExample extends ZIOAppDefault {
 }
 ```
 
-Go to the [ZIO Kafka tutorial](https://zio.dev/zio-kafka/tutorial/) for a more gentle introduction.
+Read the [ZIO Kafka tutorial](docs/tutorial.md) for a more gentle introduction.
 
 ## Documentation
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,10 +1,5 @@
 {
   "name": "@zio.dev/zio-kafka",
   "description": "ZIO Kafka Documentation",
-  "license": "Apache-2.0",
-  "overrides": {
-    "@docusaurus/bundler": {
-      "webpackbar": "^7.0.0"
-    }
-  }
+  "license": "Apache-2.0"
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@zio.dev/zio-kafka",
   "description": "ZIO Kafka Documentation",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "overrides": {
+    "@docusaurus/bundler": {
+      "webpackbar": "^7.0.0"
+    }
+  }
 }

--- a/docs/serialization-and-deserialization.md
+++ b/docs/serialization-and-deserialization.md
@@ -83,7 +83,7 @@ Consumer.make(consumerSettings).flatMap { consumer =>
           ZIO.succeed(offset)
       }
     }
-    .aggregateAsync(Consumer.offsetBatches)
+    .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
     .mapZIO(_.commit)
     .runDrain
 }
@@ -119,7 +119,7 @@ Consumer.make(consumerSettings).flatMap { consumer =>
         .flatMap(processMessage)
         .as(offset)
     }
-    .aggregateAsync(Consumer.offsetBatches)
+    .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
     .mapZIO(_.commit)
     .runDrain
 }

--- a/docs/serialization-and-deserialization.md
+++ b/docs/serialization-and-deserialization.md
@@ -83,7 +83,7 @@ Consumer.make(consumerSettings).flatMap { consumer =>
           ZIO.succeed(offset)
       }
     }
-    .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+    .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
     .mapZIO(_.commit)
     .runDrain
 }
@@ -119,7 +119,7 @@ Consumer.make(consumerSettings).flatMap { consumer =>
         .flatMap(processMessage)
         .as(offset)
     }
-    .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+    .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
     .mapZIO(_.commit)
     .runDrain
 }

--- a/docs/sharing-consumer.md
+++ b/docs/sharing-consumer.md
@@ -21,7 +21,7 @@ val stream1 = ZIO.serviceWithZIO[Consumer] { consumer =>
   consumer.plainStream(Subscription.topics("topic1"), Serde.string, Serde.string)
     .tap(cr => printLine(s"For topic1, got key: ${cr.record.key}, value: ${cr.record.value}"))
     .map(_.offset)
-    .aggregateAsync(Consumer.offsetBatches)
+    .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
     .mapZIO(_.commit)
     .runDrain
 }
@@ -30,7 +30,7 @@ val stream2 = ZIO.serviceWithZIO[Consumer] { consumer =>
   consumer.plainStream(Subscription.topics("topic2"), Serde.uuid, Serde.int)
     .tap(cr => printLine(s"For topic2, got key: ${cr.record.key}, value: ${cr.record.value}"))
     .map(_.offset)
-    .aggregateAsync(Consumer.offsetBatches)
+    .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
     .mapZIO(_.commit)
     .runDrain
 }

--- a/docs/sharing-consumer.md
+++ b/docs/sharing-consumer.md
@@ -21,7 +21,7 @@ val stream1 = ZIO.serviceWithZIO[Consumer] { consumer =>
   consumer.plainStream(Subscription.topics("topic1"), Serde.string, Serde.string)
     .tap(cr => printLine(s"For topic1, got key: ${cr.record.key}, value: ${cr.record.value}"))
     .map(_.offset)
-    .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+    .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
     .mapZIO(_.commit)
     .runDrain
 }
@@ -30,7 +30,7 @@ val stream2 = ZIO.serviceWithZIO[Consumer] { consumer =>
   consumer.plainStream(Subscription.topics("topic2"), Serde.uuid, Serde.int)
     .tap(cr => printLine(s"For topic2, got key: ${cr.record.key}, value: ${cr.record.value}"))
     .map(_.offset)
-    .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+    .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
     .mapZIO(_.commit)
     .runDrain
 }

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -6,9 +6,10 @@ const sidebars = {
       collapsed: false,
       link: { type: "doc", id: "index" },
       items: [
+        "tutorial",
         "creating-a-consumer",
         "consuming-kafka-topics-using-zio-streams",
-        "example-of-consuming-producing-and-committing-offsets",
+        "consuming-producing-and-committing-offsets",
         "partition-assignment-and-offset-retrieval",
         "metrics",
         "consumer-tuning",

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -187,7 +187,7 @@ def consumeAndPrintEvents(consumer: Consumer, groupId: String, topic: String, to
 
 For performance reasons, records are always consumed in batches. The `consumeWith` method commits the offsets of consumed records, as soon all records of a batch have been processed.
 
-For more options see [consumer tuning](consumer-tuning).
+For more options see [consumer tuning](consumer-tuning.md).
 
 ### 5. The Complete Example
 
@@ -302,7 +302,7 @@ val consumer: ZIO[Scope, Throwable, Consumer] =
 Notice that the consumer requires a `Scope` in the environment. When this scope closes, the consumer closes its
 connection with the Kafka cluster. An explicit scope can be created with the `ZIO.scoped` method.
 
-For more options see [creating a consumer](creating-a-consumer) and [consumer tuning](consumer-tuning).
+For more options see [creating a consumer](creating-a-consumer.md) and [consumer tuning](consumer-tuning.md).
 
 ### 3. Streaming Consumer API
 
@@ -373,10 +373,10 @@ Notice that because we are using `aggregateAsyncWithin`, the commits run asynchr
 :::caution
 Keeping the chunking structure intact is important.
 
-In the example so far we have used `tap` to print the records as they are consumed. Unfortunately, methods like `tap` and `mapZIO` destroy the chunking structure and lead to much lower throughput. Please read [a warning about mapZIO](avoiding-chunk-breakers) for more details and alternatives.
+In the example so far we have used `tap` to print the records as they are consumed. Unfortunately, methods like `tap` and `mapZIO` destroy the chunking structure and lead to much lower throughput. Please read [a warning about mapZIO](avoiding-chunk-breakers.md) for more details and alternatives.
 :::
 
-For more details see [consuming Kafka topics using ZIO Streams](consuming-kafka-topics-using-zio-streams).
+For more details see [consuming Kafka topics using ZIO Streams](consuming-kafka-topics-using-zio-streams.md).
 
 ### 4. The Complete Streaming Example
 
@@ -514,7 +514,7 @@ object EventKafkaSerde {
 
 As we can see, we use the `String#fromJson` to convert the string to an `Event` object, and we also encode any parsing failure with a `RuntimeException` in the `ZIO` workflow.
 
-See [zio-kafka serialization and deserialization](serialization-and-deserialization) for more details.
+See [zio-kafka serialization and deserialization](serialization-and-deserialization.md) for more details.
 
 ### 2. The Complete JSON Streaming Example
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,622 @@
+---
+id: tutorial
+title: "Tutorial: How to Produce/Consume Data To/From Kafka Topics?"
+sidebar_label: "Tutorial"
+---
+
+## Introduction
+
+Kafka is a distributed, fault-tolerant, message-oriented event-store platform. It is used as a message broker for distributed applications. Zio-kafka is a library that provides a way to consume and produce data from Kafka topics, and it also supports the ability to have streaming consumers and producers.
+
+In this tutorial, we will learn how to use zio-streams and zio-kafka to produce and consume data from Kafka topics.
+
+## Running Examples
+
+To access the code examples, you can clone the [ZIO Quickstarts](http://github.com/zio/zio-quickstarts) project:
+
+```bash
+$ git clone https://github.com/zio/zio-quickstarts.git
+$ cd zio-quickstarts/zio-quickstart-kafka
+```
+
+And finally, run the application using sbt:
+
+```bash
+$ sbt run
+```
+
+## Adding Dependencies to The Project
+
+In this tutorial, we will be using the following dependencies. So, let's add them to the `build.sbt` file:
+
+```scala
+libraryDependencies += Seq(
+  "dev.zio" %% "zio"         % "2.1.25",
+  "dev.zio" %% "zio-streams" % "2.1.25",
+  "dev.zio" %% "zio-kafka"   % "3.3.0",
+  "dev.zio" %% "zio-json"    % "0.9.1"
+)
+```
+
+1. **Zio-kafka** is a ZIO native client for Apache Kafka. It provides a high-level streaming API on top of the Java client. So we can produce and consume events using the declarative concurrency model of zio-streams.
+
+2. **Zio-streams** introduces a high-level API for working with streams of values. It is designated to work in a highly concurrent environment. It has seamless integration with ZIO, so we have the ability to use all the features of the ZIO along with the streams, e.g. `Scope`, `Schedule`, `ZLayer`, `Queue`, `Hub` etc. To learn more about zio-stream, there is a comprehensive section on that [here](https://zio.dev/reference/stream/).
+
+3. **Zio-json** is a library to serialize and deserialize data from/to JSON data type. We will be using this library to serialize and deserialize data when reading and writing JSON data from/to Kafka topics.
+
+## Setting Up The Kafka Cluster
+
+Before we start, we need to set up a Kafka cluster. To start a kafka cluster for testing purposes we can use the following `docker-compose.yml` file:
+
+```docker-compose
+services:
+  broker:
+    image: apache/kafka:3.9.0
+    container_name: broker
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_BROKER_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://broker:29092,CONTROLLER://broker:29093,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker:29093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+```
+
+Now we can run the `docker compose up -d` command to start the Kafka cluster:
+
+```bash
+$ docker compose up -d
+```
+
+## Writing a Simple Producer and Consumer Using ZIO Workflows
+
+To write producers and consumers, using the zio-kafka library, we have two choices:
+
+1. Using ZIO workflows
+2. Using zio-streams workflows
+
+In this section, we will try the first option.
+
+### 1. Serializing and Deserializing Data
+
+Before we can write a producer and consumer, let's talk about how data is stored in Kafka. Kafka is an event-store platform that stores records, records are key-value pairs as raw bytes. So a Kafka broker knows nothing about its records, it just appends the records to its internal log file.
+
+To produce and consume data from Kafka, we need a way to serialize our data to a byte array and deserialize byte arrays to our data types. This is where the `Serde` data type comes in handy. A `Serde[R, A]` is a `Serializer` and `Deserializer` for values of type `A`, which can use the environment `R` to serialize and deserialize values.
+
+Here is the simplified definition of the `Serde` data type:
+
+```scala
+trait Serde[-R, A] {
+  def deserialize(data: Array[Byte]): RIO[R, A]
+  def serialize(value: A)           : RIO[R, Array[Byte]]
+}
+```
+
+The companion object of `Serde` trait contains a set of built-in serializers and deserializers for primitive types:
+
+- `Serde.long`
+- `Serde.int`
+- `Serde.short`
+- `Serde.float`
+- `Serde.double`
+- `Serde.boolean`
+- `Serde.string`
+- `Serde.byteArray`
+- `Serde.byteBuffer`
+- `Serde.uuid`
+
+In this example, the type of the `key` is `Int` and the type of the `value` is `String`. So we can use the `Serde.int` for the `key` and the `Serde.string` for the `value`.
+
+### 2. Creating a Producer
+
+Now we can create a `Producer`:
+
+```scala mdoc:compile-only
+import zio._
+import zio.kafka._
+import zio.kafka.producer._
+
+val producer: ZIO[Scope, Throwable, Producer] =
+  Producer.make(
+    ProducerSettings(List("localhost:9092"))
+  )
+```
+
+The `ProducerSettings` as constructed in this code fragment is already sufficient for many applications. However, more configuration options are available on `ProducerSettings`.
+
+Notice that the created producer requires a `Scope` in the environment. When this scope closes, the producer closes its
+connection with the Kafka cluster. An explicit scope can be created with the `ZIO.scoped` method.
+
+### 3. Producing records
+
+Zio-kafka has several producers that can be used to produce data on Kafka topics. In this example, we will be using the `Producer.produce` method:
+
+```scala
+trait Producer {
+  def produce[R, K, V](
+    topic: String,
+    key: K,
+    value: V,
+    keySerializer: Serializer[R, K],
+    valueSerializer: Serializer[R, V]
+  ): RIO[R, RecordMetadata]
+}
+```
+
+Notice how the type parameters of `produce` method ensure that the value's type, corresponds to the type produced by the value's `Serializer` (and the same for the key and the `Serializer` for the key).
+
+Here is a helper function that shows how we could use the `produce` method:
+
+```scala
+def produceRecord(producer: Producer, topic: String, key: Long, value: String): RIO[Any, RecordMetadata] =
+  producer.produce[Any, Long, String](
+    topic = topic,
+    key = key,
+    value = value,
+    keySerializer = Serde.long,
+    valueSerializer = Serde.string
+  )
+```
+
+### 4. Creating a Consumer
+
+Zio-kafka provides several ways to consume data from Kafka topics. In this example, we will use the `Consumer.consumeWith` function.
+
+The following helper function creates a ZIO workflow that if we run it, runs forever and consumes records from the given topic and prints them to the console, and then commits the offsets of the consumed records:
+
+```scala
+def consumeAndPrintEvents(consumer: Consumer, groupId: String, topic: String, topics: String*): RIO[Any, Unit] =
+  consumer.consumeWith(
+    settings = ConsumerSettings(BOOSTRAP_SERVERS).withGroupId(groupId),
+    subscription = Subscription.topics(topic, topics: _*),
+    keyDeserializer = Serde.long,
+    valueDeserializer = Serde.string,
+  ) { (k, v) =>
+    Console.printLine(s"Consumed key: $k, value: $v").orDie
+  }
+```
+
+For performance reasons, records are always consumed in batches. The `consumeWith` method commits the offsets of consumed records, as soon all records of a batch have been processed.
+
+For more options see [consumer tuning](consumer-tuning).
+
+### 5. The Complete Example
+
+Now it's time to combine all the above steps to create a ZIO workflow that will produce and consume data from the Kafka cluster:
+
+```scala mdoc:compile-only
+import zio._
+import zio.kafka.consumer._
+import zio.kafka.producer.{Producer, ProducerSettings}
+import zio.kafka.serde._
+
+/** A simple app that produces and consumes messages from a kafka cluster
+ * without using ZIO Streams.
+ */
+object SimpleKafkaApp extends ZIOAppDefault {
+  private val BOOSTRAP_SERVERS = List("localhost:9092")
+  private val KAFKA_TOPIC      = "hello"
+
+  def run: ZIO[Scope, Throwable, Unit] = {
+    for {
+      c <- Consumer
+        .consumeWith(
+          settings =
+            ConsumerSettings(BOOSTRAP_SERVERS).withGroupId("simple-kafka-app"),
+          subscription = Subscription.topics(KAFKA_TOPIC),
+          keyDeserializer = Serde.long,
+          valueDeserializer = Serde.string
+        ) { record =>
+          Console.printLine(s"Consumed ${record.key()}, ${record.value()}").orDie
+        }
+        .fork
+
+      producer <- Producer.make(ProducerSettings(BOOSTRAP_SERVERS))
+      p <- Clock.currentDateTime
+        .flatMap { time =>
+          producer.produce[Any, Long, String](
+            topic = KAFKA_TOPIC,
+            key = time.getHour.toLong,
+            value = s"$time -- Hello, World!",
+            keySerializer = Serde.long,
+            valueSerializer = Serde.string
+          )
+        }
+        .schedule(Schedule.spaced(1.second))
+        .fork
+
+      _ <- (c <*> p).join
+    } yield ()
+  }
+
+}
+```
+
+## Zio-kafka With Zio-streams
+
+As we said before, to write producers and consumers using the zio-kafka library, we have two choices:
+
+1. Using ZIO workflows
+2. Using zio-streams workflows
+
+In this section we show zio-kafka's seamless integration with zio-streams.
+
+### 1. Streaming Producer API
+
+With zio-kafka's `Producer.produceAll` we get a `ZPipeline`. It takes streams of `ProducerRecord[K, V]`, produces these records to a Kafka topic, and then returns a stream of `RecordMetadata`:
+
+```scala
+trait Producer {
+  def produceAll[R, K, V](
+    keySerializer: Serializer[R, K],
+    valueSerializer: Serializer[R, V]
+  ): ZPipeline[R, Throwable, ProducerRecord[K, V], RecordMetadata]
+}
+```
+
+Here is an example that uses `Producer.produceAll`:
+
+```scala
+ZStream
+  .fromIterator(Iterator.from(0), maxChunkSize = 50)
+           // ZStream[Any, Throwable, Int]
+  .mapChunksZIO { chunk =>
+    chunk.map { i =>
+      new ProducerRecord(topic, key = i, value = s"record $i") 
+    }
+  }        // ZStream[Any, Throwable, ProducerRecord]
+  .via(producer.produceAll(Serde.int, Serde.string))
+           // ZStream[Any, Throwable, RecordMetadata]
+  .runDrain
+```
+
+For performance reasons, method `produceAll` produces records in batches, every chunk of the input stream results in a batch. Once all acknowledges are received, the next batch is produced.
+
+See [this page](consuming-producing-and-committing-offsets.md) for tips that can increase producing throughput.
+
+### 2. Creating a Consumer
+
+When we use the streaming API we need to construct a Consumer:
+
+```scala mdoc:compile-only
+import zio._
+import zio.kafka._
+import zio.kafka.consumer._
+
+val consumer: ZIO[Scope, Throwable, Consumer] =
+  Consumer.make(
+    ConsumerSettings(List("localhost:9092"))
+      .withGroupId("streaming-kafka-app")
+  )
+```
+
+Notice that the consumer requires a `Scope` in the environment. When this scope closes, the consumer closes its
+connection with the Kafka cluster. An explicit scope can be created with the `ZIO.scoped` method.
+
+For more options see [creating a consumer](creating-a-consumer) and [consumer tuning](consumer-tuning).
+
+### 3. Streaming Consumer API
+
+The `Consumer.plainStream` method gives a `ZStream` that, when run, consumes records from a Kafka topic and gives a stream of `CommittableRecord[K, V]`:
+
+```scala
+trait Consumer {
+  def plainStream[R, K, V](
+    subscription: Subscription,
+    keyDeserializer: Deserializer[R, K],
+    valueDeserializer: Deserializer[R, V]
+  ): ZStream[R, Throwable, CommittableRecord[K, V]]
+}
+```
+
+Parameter `subscription` indicates which topics and partitions should be consumed from. For example `Subscription.topics("events")` to consume from the `events` topic.
+
+Parameters `keyDeserializer` and `valueDeserializer` are the `Serde` that will be used to deserialize the raw record bytes to whatever type you want them to be in.
+
+To indicate that a record has been consumed successfully, and make sure that no other consumer in the same group will consume this record again (even when the application crashes and restarts), we need to commit the offset of the record. This is how it works: first get the `Offset` of the `CommittableRecord` with the `offset` method, then call `commit` on the returned `Offset`.
+
+Here is an example:
+
+```scala mdoc:compile-only
+import zio._
+import zio.stream._
+import zio.kafka._
+import zio.kafka.consumer._
+import zio.kafka.serde._
+
+val KAFKA_TOPIC = "my-topic"
+val consumer: Consumer = ???
+
+val c: ZIO[Any, Throwable, Unit] =
+  consumer
+    .plainStream(Subscription.topics(KAFKA_TOPIC), Serde.int, Serde.string)
+    .tap(e => Console.printLine(e.value))
+    .map(_.offset)      // Get the offset of the record
+    .mapZIO(_.commit)   // Commit the offset
+    .runDrain
+```
+
+While this works, it is not very performant. The problem with this approach is that we are committing offsets for each record separately. This causes a lot of overhead and slows down the consumption of records. To avoid this, we can aggregate offsets into batches and commit them all at once. This can be done by using the `ZStream#aggregateAsyncWithin` along with the `Consumer.offsetBatches` sink:
+
+```scala mdoc:compile-only
+import zio._
+import zio.stream._
+import zio.kafka._
+import zio.kafka.consumer._
+import zio.kafka.serde._
+
+val KAFKA_TOPIC = "my-topic"
+val consumer: Consumer = ???
+
+val c: ZIO[Any, Throwable, Unit] =
+  consumer
+    .plainStream(Subscription.topics(KAFKA_TOPIC), Serde.int, Serde.string)
+    .tap(e => Console.printLine(e.value))
+    .map(_.offset)                           // Get the offset of the record
+                                             // Group offsets in an OffsetBatch
+    .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+    .mapZIO(_.commit)                        // Commit the batch of offsets
+    .runDrain
+```
+
+Notice that because we are using `aggregateAsyncWithin`, the commits run asynchronously with the upstream of `aggregateAsyncWithin`. Every 100 milliseconds the next `OffsetBatch` is committed.
+
+:::caution
+Keeping the chunking structure intact is important.
+
+In the example so far we have used `tap` to print the records as they are consumed. Unfortunately, methods like `tap` and `mapZIO` destroy the chunking structure and lead to much lower throughput. Please read [a warning about mapZIO](avoiding-chunk-breakers) for more details and alternatives.
+:::
+
+For more details see [consuming Kafka topics using ZIO Streams](consuming-kafka-topics-using-zio-streams).
+
+### 4. The Complete Streaming Example
+
+It's time to create a full working example of zio-kafka with zio-streams:
+
+```scala mdoc:compile-only
+import org.apache.kafka.clients.producer.ProducerRecord
+import zio._
+import zio.kafka.consumer._
+import zio.kafka.producer.{Producer, ProducerSettings}
+import zio.kafka.serde._
+import zio.stream.ZStream
+
+object StreamingKafkaApp extends ZIOAppDefault {
+  private val BOOSTRAP_SERVERS = List("localhost:9092")
+  private val KAFKA_TOPIC      = "streaming-hello"
+
+  private val producerSettings = ProducerSettings(BOOSTRAP_SERVERS)
+  private val consumerSettings =
+    ConsumerSettings(BOOSTRAP_SERVERS).withGroupId("streaming-kafka-app")
+
+  def run: ZIO[Any, Throwable, Unit] = {
+    val p: ZIO[Any, Throwable, Unit] =
+      ZIO.scoped {
+        for {
+          producer <- Producer.make(producerSettings)
+          _ <- ZStream
+            .repeatZIO(Clock.currentDateTime)
+            .schedule(Schedule.spaced(1.second))
+            .map { time =>
+              new ProducerRecord(
+                KAFKA_TOPIC,
+                time.getMinute,
+                s"$time -- Hello, World!"
+              )
+            }
+            .via(producer.produceAll(Serde.int, Serde.string))
+            .runDrain
+        } yield ()
+      }
+
+    val c: ZIO[Any, Throwable, Unit] =
+      ZIO.scoped {
+        for {
+          consumer <- Consumer.make(consumerSettings)
+          _ <- consumer
+            .plainStream(
+              Subscription.topics(KAFKA_TOPIC),
+              Serde.int,
+              Serde.string
+            )
+            // Do not use `tap` in throughput sensitive applications because it
+            // destroys the chunking structure and leads to lower performance.
+            // See the previous section for more info.
+            .tap(r => Console.printLine("Consumed: " + r.value))
+            .map(_.offset)
+            .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+            .mapZIO(_.commit)
+            .runDrain
+        } yield ()
+      }
+
+    p <&> c
+  }
+
+}
+```
+
+## Producing and Consuming JSON Data
+
+Until now, we learned how to work with simple types like `Int`, `String`, and how to use their `Serde` instances to serialize and deserialize the data.
+
+In this section, we are going to learn how to serialize/deserialize user-defined data types (like case classes), and in particular how to use the JSON format. We also will learn how to use the `Serde` built-in instances to create more complex `Serde` instances.
+
+### 1. Writing Custom Serializer and Deserializer
+
+In zio-kafka all the built-in serializers/deserializers are instances of the `Serde` trait. All `Serde`s offers several combinators with which we can create new `Serde`s. We take a closer look at 2 of them:
+
+- Method `inmap` transforms the `Serde` with pure transformations from the source type to the target type and back.
+- Method `inmapZIO` transforms the `Serde` with effectful transformations from the source type to the target type and back. As it accepts effectful transformations, we can encode any parsing failure with a `ZIO` workflow.
+
+In this example, we use `inmap` to transform the build-in `Serde.long` to a `Serde[Any, Instant]`. The `inmap` method gets 2 pure functions, the first converts from `Long` to `Instant`, the second from `Instant` to `Long`:
+
+```scala
+import java.time.Instant
+
+val instantSerde: Serde[Any, Instant] =
+  Serde.long.inmap[Instant](Instant.ofEpochMilli)(_.toEpochMilli)
+```
+
+In the following example, we will use `inmapZIO` to transform the built-in `Serde.string` to a `Serde[Any, Event]` where `Event` is a case class that is serialized to/deserialized from a String containing JSON.
+
+Let's say we have the `Event` case class with the following fields:
+
+```scala mdoc:silent
+import java.time.OffsetDateTime
+import java.util.UUID
+
+case class Event(
+  uuid: UUID,
+  timestamp: OffsetDateTime,
+  message: String
+)
+```
+
+First, we need to define a JSON decoder and encoder for it:
+
+```scala mdoc:silent
+import zio.json._
+
+object Event {
+  implicit val encoder: JsonEncoder[Event] =
+    DeriveJsonEncoder.gen[Event]
+
+  implicit val decoder: JsonDecoder[Event] =
+    DeriveJsonDecoder.gen[Event]
+}
+```
+
+Then we need to create a `Serde` for the `Event` type. To convert `Event` to JSON and back, we will use the zio-json library. To define a `Serde` for the `Event` type, we will use the `Serde.string.inmapZIO` combinator:
+
+```scala mdoc:silent
+import zio._
+import zio.kafka.serde._
+
+object EventKafkaSerde {
+  val event: Serde[Any, Event] =
+    Serde.string.inmapZIO[Any, Event](s =>
+      ZIO
+        .fromEither(s.fromJson[Event])
+        .mapError(e => new RuntimeException(e))
+    )(r => ZIO.succeed(r.toJson))
+}
+```
+
+As we can see, we use the `String#fromJson` to convert the string to an `Event` object, and we also encode any parsing failure with a `RuntimeException` in the `ZIO` workflow.
+
+See [zio-kafka serialization and deserialization](serialization-and-deserialization) for more details.
+
+### 2. The Complete JSON Streaming Example
+
+Here is a full working example of producing and consuming JSON data with zio-kafka, zio-streams and zio-json:
+
+```scala mdoc:compile-only
+import org.apache.kafka.clients.producer.ProducerRecord
+import zio._
+import zio.json._
+import zio.kafka.consumer._
+import zio.kafka.producer.{Producer, ProducerSettings}
+import zio.kafka.serde._
+import zio.stream.ZStream
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/** This is the data we will be sending to Kafka in JSON format. */
+case class Event(uuid: UUID, timestamp: OffsetDateTime, message: String)
+
+/** A zio-json encoder/decoder for [[Event]]. */
+object Event {
+  implicit val encoder: JsonEncoder[Event] =
+    DeriveJsonEncoder.gen[Event]
+
+  implicit val decoder: JsonDecoder[Event] =
+    DeriveJsonDecoder.gen[Event]
+}
+
+/** A zio-kafka serializer/deserializer for [[Event]]. */
+object EventKafkaSerde {
+  val event: Serde[Any, Event] =
+    Serde.string.inmapZIO[Any, Event](s =>
+      ZIO
+        .fromEither(s.fromJson[Event])
+        .mapError(e => new RuntimeException(e))
+    )(r => ZIO.succeed(r.toJson))
+}
+
+object JsonStreamingKafkaApp extends ZIOAppDefault {
+  private val BOOSTRAP_SERVERS = List("localhost:9092")
+  private val KAFKA_TOPIC      = "json-streaming-hello"
+
+  def run: ZIO[Any, Throwable, Unit] = {
+    val p: ZIO[Any, Throwable, Unit] =
+      ZIO.scoped {
+        for {
+          producer <- Producer.make(ProducerSettings(BOOSTRAP_SERVERS))
+          _ <- ZStream
+            .repeatZIO(Random.nextUUID <*> Clock.currentDateTime)
+            .schedule(Schedule.spaced(1.second))
+            .map { case (uuid, time) =>
+              new ProducerRecord(
+                KAFKA_TOPIC,
+                time.getMinute,
+                Event(uuid, time, "Hello, World!")
+              )
+            }
+            .via(producer.produceAll(Serde.int, EventKafkaSerde.event))
+            .runDrain
+        } yield ()
+      }
+
+    val c: ZIO[Any, Throwable, Unit] =
+      ZIO.scoped {
+        for {
+          consumer <- Consumer.make(
+            ConsumerSettings(BOOSTRAP_SERVERS).withGroupId("streaming-kafka-app")
+          )
+          _ <- consumer
+            .plainStream(
+              Subscription.topics(KAFKA_TOPIC),
+              Serde.int,
+              EventKafkaSerde.event
+            )
+            .tap { r =>
+              val event: Event = r.value
+              Console.printLine(
+                s"Event ${event.uuid} was sent at ${event.timestamp} with message ${event.message}"
+              )
+            }
+            .map(_.offset)
+            .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+            .mapZIO(_.commit)
+            .runDrain
+        } yield ()
+      }
+
+    p <&> c
+  }
+
+}
+```
+
+## Conclusion
+
+In this tutorial we first learned how to create a producer and consumer for Kafka using the ZIO workflow with zio-kafka. Then we learned how to do the same with zio-streams. We also learned how to create a custom serializer and deserializer for the Kafka records and how to produce and consume JSON data using the zio-json library.
+
+All the source code associated with this article is available on the [ZIO Quickstart](http://github.com/zio/zio-quickstarts) project on GitHub.
+
+More information:
+
+- [zio-kafka](https://zio.dev/zio-kafka/)
+- [zio-streams](https://zio.dev/reference/stream/)
+- [zio-json](https://zio.dev/zio-json/)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -345,7 +345,7 @@ val c: ZIO[Any, Throwable, Unit] =
     .runDrain
 ```
 
-While this works, it is not very performant. The problem with this approach is that we are committing offsets for each record separately. This causes a lot of overhead and slows down the consumption of records. To avoid this, we can aggregate offsets into batches and commit them all at once. This can be done by using the `ZStream#aggregateAsyncWithin` along with the `Consumer.offsetBatches` sink:
+While this works, it is not very performant. The problem with this approach is that we are committing offsets for each record separately. This causes a lot of overhead and slows down the consumption of records. To avoid this, we can aggregate offsets into batches and commit them all at once. This can be done by using the `ZStream#aggregateAsyncWithin` along with the `Consumer.collectOffsets` sink:
 
 ```scala mdoc:compile-only
 import zio._
@@ -363,7 +363,7 @@ val c: ZIO[Any, Throwable, Unit] =
     .tap(e => Console.printLine(e.value))
     .map(_.offset)                           // Get the offset of the record
                                              // Group offsets in an OffsetBatch
-    .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+    .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
     .mapZIO(_.commit)                        // Commit the batch of offsets
     .runDrain
 ```
@@ -433,7 +433,7 @@ object StreamingKafkaApp extends ZIOAppDefault {
             // See the previous section for more info.
             .tap(r => Console.printLine("Consumed: " + r.value))
             .map(_.offset)
-            .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+            .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
             .mapZIO(_.commit)
             .runDrain
         } yield ()
@@ -597,7 +597,7 @@ object JsonStreamingKafkaApp extends ZIOAppDefault {
               )
             }
             .map(_.offset)
-            .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+            .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
             .mapZIO(_.commit)
             .runDrain
         } yield ()

--- a/zio-kafka-example/src/main/scala/zio/kafka/example/ReadmeExample.scala
+++ b/zio-kafka-example/src/main/scala/zio/kafka/example/ReadmeExample.scala
@@ -45,7 +45,7 @@ object ReadmeExample extends ZIOAppDefault {
           .plainStream(Subscription.topics("random"), Serde.long, Serde.string)
           .tap(r => Console.printLine(r.value))
           .map(_.offset)
-          .aggregateAsync(Consumer.offsetBatches)
+          .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
           .mapZIO(_.commit)
           .runDrain
       } yield ()

--- a/zio-kafka-example/src/main/scala/zio/kafka/example/ReadmeExample.scala
+++ b/zio-kafka-example/src/main/scala/zio/kafka/example/ReadmeExample.scala
@@ -45,7 +45,7 @@ object ReadmeExample extends ZIOAppDefault {
           .plainStream(Subscription.topics("random"), Serde.long, Serde.string)
           .tap(r => Console.printLine(r.value))
           .map(_.offset)
-          .aggregateAsyncWithin(Consumer.offsetBatches, Schedule.fixed(100.millis))
+          .aggregateAsyncWithin(Consumer.collectOffsets, Schedule.fixed(100.millis))
           .mapZIO(_.commit)
           .runDrain
       } yield ()

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -359,7 +359,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                             _  <- consumer.stopConsumption.when(nr == 10)
                           } yield if (nr < 10) Seq(record.offset) else Seq.empty
                         }
-                        .transduce(Consumer.offsetBatches)
+                        .transduce(Consumer.collectOffsets)
                         .mapZIO(_.commit)
                         .runDrain *>
                         consumer.committed(Set(new TopicPartition(topic, 0))).map(_.values.head)
@@ -392,7 +392,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                             _  <- consumer.stopConsumption.when(nr == 10)
                           } yield record.offset
                         }
-                        .aggregateAsync(Consumer.offsetBatches)
+                        .aggregateAsync(Consumer.collectOffsets)
                         .mapZIO(_.commit)
                         .runDrain *>
                         consumer.committed(Set(new TopicPartition(topic, 0))).map(_.values.head)
@@ -439,7 +439,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                                           } yield Seq(record.offset)
                                         }
                                       }
-                                      .aggregateAsync(Consumer.offsetBatches)
+                                      .aggregateAsync(Consumer.collectOffsets)
                                       .mapZIO(batch =>
                                         ZIO.logDebug("Starting batch commit") *> batch.commit
                                           .tapErrorCause(
@@ -514,7 +514,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                                               } yield Seq(record.offset)
                                             }
                                           }
-                                          .transduce(Consumer.offsetBatches)
+                                          .transduce(Consumer.collectOffsets)
                                           .mapZIO(batch =>
                                             ZIO.logDebug("Starting batch commit") *> batch.commit
                                               .tapErrorCause(
@@ -767,7 +767,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                         ZStream.fromZIO(stream1PartitionsAssigned.update(_ + 1)) *>
                           partitionStream.map(_.offset)
                       }
-                      .aggregateAsync(Consumer.offsetBatches)
+                      .aggregateAsync(Consumer.collectOffsets)
                       .mapZIO(offsetBatch =>
                         stream1Started.succeed(()) *>
                           offsetBatch.commit.repeatUntilZIO(_ =>
@@ -918,7 +918,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                  .partitionedStream(subscription, Serde.string, Serde.string)
                  .flatMapPar(partitionCount)(_._2.map(_.offset))
                  .take(nrMessages.toLong)
-                 .transduce(Consumer.offsetBatches)
+                 .transduce(Consumer.collectOffsets)
                  .take(1)
                  .mapZIO(_.commit)
                  .runDrain
@@ -943,7 +943,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                        .partitionedStream(subscription, Serde.string, Serde.string)
                        .flatMap(_._2.map(_.offset.withMetadata(metadata)))
                        .take(1)
-                       .transduce(Consumer.offsetBatches)
+                       .transduce(Consumer.collectOffsets)
                        .take(1)
                        .mapZIO(_.commit)
                        .runDrain *>
@@ -1897,7 +1897,7 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                       .plainStream(Subscription.Topics(Set(topic)), Serde.string, Serde.string)
                       .take(11)
                       .map(_.offset)
-                      .aggregateAsync(Consumer.offsetBatches)
+                      .aggregateAsync(Consumer.collectOffsets)
                       .mapZIO(_.commit) // Hangs without timeout
                       .runDrain
                       .exit

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/SubscriptionsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/SubscriptionsSpec.scala
@@ -272,7 +272,7 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                    .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
                    .take(40)
                    .transduce(
-                     Consumer.offsetBatches.contramap[CommittableRecord[String, String]](_.offset) <&>
+                     Consumer.collectOffsets.contramap[CommittableRecord[String, String]](_.offset) <&>
                        ZSink.collectAll[CommittableRecord[String, String]]
                    )
                    .mapZIO { case (offsetBatch, records) => offsetBatch.commit.as(records) }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -251,11 +251,14 @@ object Consumer {
 
   case object CommitTimeout extends RuntimeException("Commit timeout") with NoStackTrace
 
-  /** A [[ZSink]] that collects [[Offset]]s into an [[OffsetBatch]]. */
+  /** A [[zio.stream.ZSink]] that collects [[zio.kafka.consumer.Offset]]s into an [[zio.kafka.consumer.OffsetBatch]]. */
   val offsetBatches: ZSink[Any, Nothing, Offset, Nothing, OffsetBatch] =
     ZSink.foldLeft[Offset, OffsetBatch](OffsetBatch.empty)(_ add _)
 
-  /** A [[ZSink]] that merges multiple [[OffsetBatch]]es into a single [[OffsetBatch]]. */
+  /**
+   * A [[zio.stream.ZSink]] that merges multiple [[zio.kafka.consumer.OffsetBatch]]es into a single
+   * [[zio.kafka.consumer.OffsetBatch]].
+   */
   val offsetBatchesSink: ZSink[Any, Nothing, OffsetBatch, Nothing, OffsetBatch] =
     ZSink.foldLeft[OffsetBatch, OffsetBatch](OffsetBatch.empty)(_ merge _)
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -251,8 +251,13 @@ object Consumer {
 
   case object CommitTimeout extends RuntimeException("Commit timeout") with NoStackTrace
 
+  /** A [[ZSink]] that collects [[Offset]]s into an [[OffsetBatch]]. */
   val offsetBatches: ZSink[Any, Nothing, Offset, Nothing, OffsetBatch] =
     ZSink.foldLeft[Offset, OffsetBatch](OffsetBatch.empty)(_ add _)
+
+  /** A [[ZSink]] that merges multiple [[OffsetBatch]]es into a single [[OffsetBatch]]. */
+  val offsetBatchesSink: ZSink[Any, Nothing, OffsetBatch, Nothing, OffsetBatch] =
+    ZSink.foldLeft[OffsetBatch, OffsetBatch](OffsetBatch.empty)(_ merge _)
 
   def live: RLayer[ConsumerSettings, Consumer] =
     ZLayer.scoped {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -252,14 +252,17 @@ object Consumer {
   case object CommitTimeout extends RuntimeException("Commit timeout") with NoStackTrace
 
   /** A [[zio.stream.ZSink]] that collects [[zio.kafka.consumer.Offset]]s into an [[zio.kafka.consumer.OffsetBatch]]. */
-  val offsetBatches: ZSink[Any, Nothing, Offset, Nothing, OffsetBatch] =
+  val collectOffsets: ZSink[Any, Nothing, Offset, Nothing, OffsetBatch] =
     ZSink.foldLeft[Offset, OffsetBatch](OffsetBatch.empty)(_ add _)
 
+  /** Use `collectOffsets` instead. */
+  val offsetBatches: ZSink[Any, Nothing, Offset, Nothing, OffsetBatch] = collectOffsets
+
   /**
-   * A [[zio.stream.ZSink]] that merges multiple [[zio.kafka.consumer.OffsetBatch]]es into a single
+   * A [[zio.stream.ZSink]] that collects multiple [[zio.kafka.consumer.OffsetBatch]]es by merging them into a single
    * [[zio.kafka.consumer.OffsetBatch]].
    */
-  val offsetBatchesSink: ZSink[Any, Nothing, OffsetBatch, Nothing, OffsetBatch] =
+  val collectBatches: ZSink[Any, Nothing, OffsetBatch, Nothing, OffsetBatch] =
     ZSink.foldLeft[OffsetBatch, OffsetBatch](OffsetBatch.empty)(_ merge _)
 
   def live: RLayer[ConsumerSettings, Consumer] =
@@ -627,7 +630,7 @@ private[consumer] final class ConsumerLive private[consumer] (
                partitionStream.mapChunksZIO(_.mapZIO((c: CommittableRecord[K, V]) => f(c.record).as(c.offset)))
              }
              .provideEnvironment(r)
-             .aggregateAsync(offsetBatches)
+             .aggregateAsync(collectOffsets)
              .mapZIO(_.commitOrRetry(commitRetryPolicy))
              .runDrain
     } yield ()


### PR DESCRIPTION
Changes:
- Rename `offsetBatches` to `collectOffsets` (old name still available).
- Add `collectBatches`, a Sink to collects `OffsetBatch`es.
- Move over the zio-kafka tutorial from the main zio repo to here.
- Recommend `aggregateAsyncWithin` iso `aggregateAsync` to collect offsets.
- Extend the producer throughput docs.