### PR TITLE
Fix scalafmt corrupted class path issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,6 @@ inThisBuild(
     // We only support Scala 2.13+ and 3+. See https://github.com/zio/zio-kafka/releases/tag/v2.7.0
     crossScalaVersions       := List(scala213.value, scala3.value),
     ciEnabledBranches        := Seq("master", "series/0.x"),
-    useCoursier              := false,
     Test / parallelExecution := false,
     Test / fork              := true,
     run / fork               := true,


### PR DESCRIPTION
Running `sbt fmt` causes `org.scalafmt.sbt.ScalafmtSbtReporter$ScalafmtSbtError: scalafmt: [v3.11.0] corrupted class path` errors. These are caused by a conflict between sbt's legacy dependency resolution (Ivy) and Scalafmt's dynamic loader which uses Coursier. For an unknown reason, Ivy resolution is still enabled in our builds. We resolve the problem by switching to the default resolution (Coursier). With this fix, the transitive dependencies for scalafmt are correctly resolved.