### PR TITLE
Replace one sleep with a Promise in SubscriptionsSpec

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/SubscriptionsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/SubscriptionsSpec.scala
@@ -134,8 +134,10 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
 
           consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
 
+          consumer0Started <- Promise.make[Nothing, Unit]
           c1Fib <- consumer
                      .plainStream(Subscription.topics(topic1), Serde.string, Serde.string)
+                     .tap(_ => consumer0Started.succeed(()))
                      // Here we delay each message to be sure that `consumer1` will fail while `consumer0` is still running
                      .mapZIO { r =>
                        firstMessagesRef.updateSome { case ("", v) => ("First consumer0 message", v) } *>
@@ -150,7 +152,7 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                      .zipLeft(finalizersRef.update(_ :+ "consumer0 finalized"))
                      .fork
 
-          _ <- ZIO.sleep(100.millis) // Wait to be sure that `consumer0` is running
+          _ <- consumer0Started.await // Wait until consumer0 is actively processing messages
 
           c2Fib <- consumer
                      .plainStream(


### PR DESCRIPTION
Towards #1389. Replaces the `ZIO.sleep(100.millis)` in SubscriptionsSpec's "gives an error when attempting to subscribe using a manual subscription when there is already a topic subscription and doesn't fail the already running consuming session" test with a Promise that signals when consumer0 has begun processing messages.

The pattern mirrors `stream1Started` in the maintainer-referenced "can stop one stream while keeping another one running" test (ConsumerSpec.scala:682) so review can pattern-match.

**Why just one sleep:** I surveyed all 9 `ZIO.sleep` usages in the test tree and only this one is a clear condition-wait. The others break down as:

- `ConsumerSpec.scala:632` — wait for stream to consume some messages. Plausible Promise candidate (signal on first record) but the surrounding `.scoped` lifecycle makes the conversion non-trivial. Happy to do as a follow-up if reviewers prefer.
- `ConsumerSpec.scala:1728` — `// wait for pollTimeout` — waiting for an internal Runloop state transition. Would need a diagnostic event or new public hook to signal cleanly.
- `ConsumerSpec.scala:641` (5s), `:1746` (1s) — waiting for Kafka broker / consumer-group state to settle externally, not a ZIO-internal condition. Not a Promise candidate.
- `ConsumerSpec.scala:848` (10s), `:1288` (parametric) — intentional slow-processing simulation, by design.
- `RebalanceCoordinatorSpec.scala:119, :205` — throttling within a stream tap, intentional pacing.

If the reviewer disagrees on any of those, happy to expand the PR.