### PR TITLE
Link zio-json serde tutorial

### DIFF
--- a/docs/serialization-and-deserialization.md
+++ b/docs/serialization-and-deserialization.md
@@ -48,6 +48,9 @@ val instantSerde: Serde[Any, Instant] =
   Serdes.long.inmap(java.time.Instant.ofEpochMilli)(_.toEpochMilli)
 ```
 
+For a complete example of creating a custom serde with zio-json, see the
+[Producing and Consuming JSON Data](tutorial.md#producing-and-consuming-json-data) section in the tutorial.
+
 To handle missing data (an empty key or value), you can use the `Serde.asOption` transformer. For example:
 `Serdes.string.asOption`. This results in a `None` if the key or value is empty, and in a `Some(string)` otherwise.
 


### PR DESCRIPTION
## Summary
- Link the serialization docs to the existing zio-json serde example in the tutorial.
- Keep the docs focused on a pointer instead of duplicating the tutorial example.

Fixes #1339

## Verification
- git diff --check