### PR TITLE
Reduce concurrent admin operations

### DIFF
--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -475,8 +475,8 @@ object KafkaTestUtils {
         )
       }
 
-  /** At most 5 concurrently admin write operations over all tests. */
-  private val adminWriteSemaphore: Option[Semaphore] = Some(Semaphore.unsafe.make(5)(Unsafe))
+  /** At most 1 concurrent admin write operations over all tests. */
+  private val adminWriteSemaphore: Option[Semaphore] = Some(Semaphore.unsafe.make(1)(Unsafe))
 
   /**
    * Makes a `AdminClient` for use in tests.


### PR DESCRIPTION
Reduce the number of concurrent admin operations from 5 to 1 in another attempt to prevent flaky unit tests.

12 runs without any test failures 🥳