### PR TITLE
Reduce concurrent admin operations

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClientSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClientSettings.scala
@@ -60,7 +60,7 @@ object AdminClientSettings {
   def apply(bootstrapServers: List[String]): AdminClientSettings =
     AdminClientSettings(
       closeTimeout = 30.seconds,
-      maxConcurrentWriteOperations = 5,
+      maxConcurrentWriteOperations = 1,
       properties = Map.empty
     ).withBootstrapServers(bootstrapServers)
 }


### PR DESCRIPTION
Reduce the default number of concurrent admin operations from 5 to 1 for all admin clients.

This is a follow-up of #1667.