### PR TITLE
Make admin write ops self-verifying; drop the write semaphore

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/admin/AdminSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/admin/AdminSpec.scala
@@ -32,7 +32,6 @@ import zio.test.TestAspect._
 import zio.test._
 
 import java.util.UUID
-import java.util.concurrent.TimeoutException
 
 object AdminSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
 
@@ -555,18 +554,12 @@ object AdminSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
             )
           _ <- client.createAcls(bindings)
           createdAcls <-
-            client
-              .describeAcls(AclBindingFilter(ResourcePatternFilter.Any, AccessControlEntryFilter.Any))
-              .repeatWhile(_.isEmpty) // because the createAcls is executed async by the broker
-              .timeoutFail(new TimeoutException())(100.millis)
+            client.describeAcls(AclBindingFilter(ResourcePatternFilter.Any, AccessControlEntryFilter.Any))
           deletedAcls <-
             client
               .deleteAcls(Set(AclBindingFilter(ResourcePatternFilter.Any, AccessControlEntryFilter.Any)))
           remainingAcls <-
-            client
-              .describeAcls(AclBindingFilter(ResourcePatternFilter.Any, AccessControlEntryFilter.Any))
-              .repeatWhile(_.nonEmpty) // because the deleteAcls is executed async by the broker
-              .timeoutFail(new TimeoutException())(100.millis)
+            client.describeAcls(AclBindingFilter(ResourcePatternFilter.Any, AccessControlEntryFilter.Any))
 
         } yield assert(createdAcls)(equalTo(bindings)) &&
           assert(deletedAcls)(equalTo(bindings)) &&

--- a/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
+++ b/zio-kafka-testkit/src/main/scala/zio/kafka/testkit/KafkaTestUtils.scala
@@ -475,14 +475,11 @@ object KafkaTestUtils {
         )
       }
 
-  /** At most 1 concurrent admin write operations over all tests. */
-  private val adminWriteSemaphore: Option[Semaphore] = Some(Semaphore.unsafe.make(1)(Unsafe))
-
   /**
    * Makes a `AdminClient` for use in tests.
    */
   def makeAdminClient: ZIO[Scope & Kafka, Throwable, AdminClient] =
-    adminSettings.flatMap(settings => AdminClient.make(settings, adminWriteSemaphore))
+    adminSettings.flatMap(AdminClient.make)
 
   /**
    * Makes a `AdminClient` for use in tests, using the `SASL_PLAINTEXT` security protocol.
@@ -491,13 +488,13 @@ object KafkaTestUtils {
     username: String = "admin",
     password: String = "admin-secret"
   ): ZIO[Scope & Kafka.Sasl, Throwable, AdminClient] =
-    saslAdminSettings(username, password).flatMap(settings => AdminClient.make(settings, adminWriteSemaphore))
+    saslAdminSettings(username, password).flatMap(AdminClient.make)
 
   /**
    * Makes a `AdminClient` for use in tests, using the `SSL` security protocol.
    */
   def makeSslAdminClient: ZIO[Scope & Kafka, Throwable, AdminClient] =
-    sslAdminSettings.flatMap(settings => AdminClient.make(settings, adminWriteSemaphore))
+    sslAdminSettings.flatMap(AdminClient.make)
 
   // -----------------------------------------------------------------------------------------
   //

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -315,7 +315,7 @@ trait AdminClient {
    * Incrementally update the configuration for the specified resources. Only supported by brokers with version 2.3.0 or
    * higher. Use alterConfigs otherwise.
    *
-   * When `configs` contains an [[AlterConfigOpType.Append]] or an [[AlterConfigOpType.Subtract]], `visibilitySleep` is
+   * When `configs` contains an `AlterConfigOpType.Append` or an `AlterConfigOpType.Subtract`, `visibilitySleep` is
    * used. Otherwise, polling is used to wait until the operation completes.
    *
    * @param visibilitySleep
@@ -332,7 +332,7 @@ trait AdminClient {
    * Incrementally update the configuration for the specified resources async. Only supported by brokers with version
    * 2.3.0 or higher. Use alterConfigsAsync otherwise.
    *
-   * When `configs` contains an [[AlterConfigOpType.Append]] or an [[AlterConfigOpType.Subtract]], `visibilitySleep` is
+   * When `configs` contains an `AlterConfigOpType.Append` or an `AlterConfigOpType.Subtract`, `visibilitySleep` is
    * used. Otherwise, polling is used to wait until the operation completes. This method still returns immediately with
    * the outer task, sleeping/polling happens in the inner task.
    *

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -119,10 +119,15 @@ trait AdminClient {
 
   /**
    * Delete records.
+   *
+   * @param visibilitySleep
+   *   time to wait after getting a confirmation that the command was accepted by the kafka broker. This should be
+   *   enough time for the operation to complete. Set to `Duration.Zero` if you don't care when the operation completes.
    */
   def deleteRecords(
     recordsToDelete: Map[TopicPartition, RecordsToDelete],
-    deleteRecordsOptions: Option[DeleteRecordsOptions] = None
+    deleteRecordsOptions: Option[DeleteRecordsOptions] = None,
+    visibilitySleep: Duration = 1.second
   ): Task[Unit]
 
   /**
@@ -264,13 +269,33 @@ trait AdminClient {
 
   /**
    * Remove the specified members from a consumer group.
+   *
+   * @param visibilitySleep
+   *   time to wait after getting a confirmation that the command was accepted by the kafka broker. This should be
+   *   enough time for the operation to complete. Set to `Duration.Zero` if you don't care when the operation completes.
    */
-  def removeMembersFromConsumerGroup(groupId: String, membersToRemove: Set[String]): Task[Unit]
+  def removeMembersFromConsumerGroup(
+    groupId: String,
+    membersToRemove: Set[String],
+    visibilitySleep: Duration = 1.second
+  ): Task[Unit]
 
   /**
    * Remove all members from a consumer group.
+   *
+   * Alias for `removeAllMembersFromConsumerGroup` with the default `visibilitySleep`.
    */
-  def removeMembersFromConsumerGroup(groupId: String): Task[Unit]
+  def removeMembersFromConsumerGroup(groupId: String): Task[Unit] =
+    removeAllMembersFromConsumerGroup(groupId)
+
+  /**
+   * Remove all members from a consumer group.
+   *
+   * @param visibilitySleep
+   *   time to wait after getting a confirmation that the command was accepted by the kafka broker. This should be
+   *   enough time for the operation to complete. Set to `Duration.Zero` if you don't care when the operation completes.
+   */
+  def removeAllMembersFromConsumerGroup(groupId: String, visibilitySleep: Duration = 1.second): Task[Unit]
 
   /**
    * Describe the log directories of the specified brokers
@@ -289,19 +314,37 @@ trait AdminClient {
   /**
    * Incrementally update the configuration for the specified resources. Only supported by brokers with version 2.3.0 or
    * higher. Use alterConfigs otherwise.
+   *
+   * When `configs` contains an [[AlterConfigOpType.Append]] or an [[AlterConfigOpType.Subtract]], `visibilitySleep` is
+   * used. Otherwise, polling is used to wait until the operation completes.
+   *
+   * @param visibilitySleep
+   *   time to wait after getting a confirmation that the command was accepted by the kafka broker. This should be
+   *   enough time for the operation to complete. Set to `Duration.Zero` if you don't care when the operation completes.
    */
   def incrementalAlterConfigs(
     configs: Map[ConfigResource, Iterable[AlterConfigOp]],
-    options: AlterConfigsOptions
+    options: AlterConfigsOptions,
+    visibilitySleep: Duration = 1.second
   ): Task[Unit]
 
   /**
    * Incrementally update the configuration for the specified resources async. Only supported by brokers with version
    * 2.3.0 or higher. Use alterConfigsAsync otherwise.
+   *
+   * When `configs` contains an [[AlterConfigOpType.Append]] or an [[AlterConfigOpType.Subtract]], `visibilitySleep` is
+   * used. Otherwise, polling is used to wait until the operation completes. This method still returns immediately with
+   * the outer task, sleeping/polling happens in the inner task.
+   *
+   * @param visibilitySleep
+   *   time to wait (in the inner task) after getting a confirmation that the command was accepted by the kafka broker.
+   *   This should be enough time for the operation to complete. Set to `Duration.Zero` if you don't care when the
+   *   operation completes.
    */
   def incrementalAlterConfigsAsync(
     configs: Map[ConfigResource, Iterable[AlterConfigOp]],
-    options: AlterConfigsOptions
+    options: AlterConfigsOptions,
+    visibilitySleep: Duration = 1.second
   ): Task[Map[ConfigResource, Task[Unit]]]
 
   /*
@@ -351,11 +394,6 @@ object AdminClient {
   private final class LiveAdminClient(
     private val adminClient: JAdmin
   ) extends AdminClient {
-
-    /**
-     * Fixed sleep used for admin operations whose effect cannot be cheaply verified via a read-back.
-     */
-    private val visibilityFallbackSleep: Duration = 1.second
 
     override def createTopics(
       newTopics: Iterable[NewTopic],
@@ -425,7 +463,8 @@ object AdminClient {
 
     override def deleteRecords(
       recordsToDelete: Map[TopicPartition, RecordsToDelete],
-      deleteRecordsOptions: Option[DeleteRecordsOptions] = None
+      deleteRecordsOptions: Option[DeleteRecordsOptions] = None,
+      visibilitySleep: Duration = 1.second
     ): Task[Unit] = {
       val records = recordsToDelete.map { case (k, v) => k.asJava -> v }.asJava
       fromKafkaFutureVoid {
@@ -434,7 +473,7 @@ object AdminClient {
             .fold(adminClient.deleteRecords(records))(opts => adminClient.deleteRecords(records, opts.asJava))
             .all()
         }
-      } <* ZIO.sleep(visibilityFallbackSleep)
+      } <* ZIO.sleep(visibilitySleep)
     }
 
     override def listTopics(listTopicsOptions: Option[ListTopicsOptions] = None): Task[Map[String, TopicListing]] =
@@ -742,7 +781,11 @@ object AdminClient {
         }
       ).map(_.asScala.map { case (k, v) => k -> ConsumerGroupDescription.fromJava(v) }.toMap)
 
-    override def removeMembersFromConsumerGroup(groupId: String, membersToRemove: Set[String]): Task[Unit] = {
+    override def removeMembersFromConsumerGroup(
+      groupId: String,
+      membersToRemove: Set[String],
+      visibilitySleep: Duration = 1.second
+    ): Task[Unit] = {
       val options = new RemoveMembersFromConsumerGroupOptions(
         membersToRemove.map(new MemberToRemove(_)).asJavaCollection
       )
@@ -750,16 +793,19 @@ object AdminClient {
         ZIO.attempt {
           adminClient.removeMembersFromConsumerGroup(groupId, options).all()
         }
-      } <* ZIO.sleep(visibilityFallbackSleep)
+      } <* ZIO.sleep(visibilitySleep)
     }
 
-    override def removeMembersFromConsumerGroup(groupId: String): Task[Unit] = {
+    override def removeAllMembersFromConsumerGroup(
+      groupId: String,
+      visibilitySleep: Duration = 1.second
+    ): Task[Unit] = {
       val options = new RemoveMembersFromConsumerGroupOptions()
       fromKafkaFutureVoid {
         ZIO.attempt {
           adminClient.removeMembersFromConsumerGroup(groupId, options).all()
         }
-      } <* ZIO.sleep(visibilityFallbackSleep)
+      } <* ZIO.sleep(visibilitySleep)
     }
 
     override def describeLogDirs(
@@ -791,7 +837,8 @@ object AdminClient {
 
     override def incrementalAlterConfigs(
       configs: Map[ConfigResource, Iterable[AlterConfigOp]],
-      options: AlterConfigsOptions
+      options: AlterConfigsOptions,
+      visibilitySleep: Duration = 1.second
     ): Task[Unit] =
       fromKafkaFutureVoid {
         ZIO.attempt {
@@ -804,11 +851,12 @@ object AdminClient {
             )
             .all()
         }
-      } <* awaitConfigsVisible(configs)
+      } <* awaitConfigsVisible(configs, visibilitySleep)
 
     override def incrementalAlterConfigsAsync(
       configs: Map[ConfigResource, Iterable[AlterConfigOp]],
-      options: AlterConfigsOptions
+      options: AlterConfigsOptions,
+      visibilitySleep: Duration = 1.second
     ): Task[Map[ConfigResource, Task[Unit]]] =
       ZIO.attempt {
         adminClient
@@ -825,7 +873,10 @@ object AdminClient {
           val ops            = configs.getOrElse(configResource, Iterable.empty)
           (
             configResource,
-            ZIO.fromCompletionStage(kf.toCompletionStage).unit <* awaitConfigsVisible(Map(configResource -> ops))
+            ZIO.fromCompletionStage(kf.toCompletionStage).unit <* awaitConfigsVisible(
+              Map(configResource -> ops),
+              visibilitySleep
+            )
           )
         }.toMap
       }
@@ -938,13 +989,16 @@ object AdminClient {
     /**
      * Visibility check for `incrementalAlterConfigs`. For requests containing only Set and Delete ops it polls
      * `describeConfigs` until each op's effect is observable. Requests containing Append or Subtract fall back to
-     * `visibilityFallbackSleep` because verifying them would require comparing against pre-op state.
+     * `visibilitySleep` because verifying them would require comparing against pre-op state.
      */
-    private def awaitConfigsVisible(configs: Map[ConfigResource, Iterable[AlterConfigOp]]): Task[Unit] = {
+    private def awaitConfigsVisible(
+      configs: Map[ConfigResource, Iterable[AlterConfigOp]],
+      visibilitySleep: Duration
+    ): Task[Unit] = {
       val hasAppendOrSubtract = configs.valuesIterator.flatten.exists { op =>
-        op.opType == AlterConfigOpType.Append || op.opType == AlterConfigOpType.Substract
+        op.opType == AlterConfigOpType.Append || op.opType == AlterConfigOpType.Subtract
       }
-      if (hasAppendOrSubtract) ZIO.sleep(visibilityFallbackSleep)
+      if (hasAppendOrSubtract) ZIO.sleep(visibilitySleep)
       else {
         awaitVisible(
           describeConfigs(configs.keys.toList),
@@ -1271,9 +1325,12 @@ object AdminClient {
       override def asJava = JAlterConfigOp.OpType.APPEND
     }
 
-    case object Substract extends AlterConfigOpType {
+    case object Subtract extends AlterConfigOpType {
       override def asJava = JAlterConfigOp.OpType.SUBTRACT
     }
+
+    @deprecated("Use AlterConfigOpType.Subtract", since = "3.6.0")
+    val Substract: AlterConfigOpType.Subtract.type = AlterConfigOpType.Subtract
   }
 
   final case class MetricName(name: String, group: String, description: String, tags: Map[String, String])

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClient.scala
@@ -51,6 +51,7 @@ import org.apache.kafka.common.{
 }
 import zio._
 import zio.kafka.admin.acl._
+import zio.kafka.admin.resource.ResourcePatternFilter
 import zio.kafka.utils.SslHelper
 
 import java.util.Optional
@@ -63,7 +64,7 @@ import scala.util.{ Failure, Success, Try }
 /**
  * Kafka Admin client, can be used to create, list, and delete topics, get consumer groups, etc.
  *
- * This admin client is a light wrapper around the java Admin client. See the API of the
+ * This admin client is a wrapper around the java Admin client. See the API of the
  * [[org.apache.kafka.clients.admin.Admin java admin client]] for a full description of the provided operations.
  *
  * Typically constructed as:
@@ -71,6 +72,12 @@ import scala.util.{ Failure, Success, Try }
  *   val settings: AdminClientSettings = AdminClientSettings(bootstrapServers).withCredentials(...)
  *   val adminClient = AdminClient.make(settings)
  * }}}
+ *
+ * Unlike the java Admin client, this client waits until a write operation (e.g. creating or deleting a topic)
+ * completes. For most write operations this is done by polling the broker until we see the effect of the write
+ * operation. If after 5s the effect is still not seen, we assume the write operation succeeded but was undone by
+ * another write operation. For some operations where polling is difficult, we wait for 1s, assuming the operation
+ * completes within that time.
  */
 trait AdminClient {
 
@@ -340,15 +347,15 @@ object AdminClient {
    *
    * @param adminClient
    *   wrapped java admin client
-   * @param writeOperationSemaphore
-   *   semaphore to limit the number of concurrent admin write operations. Keep the number of permits low to prevent the
-   *   operation to be lost, or not being able to see the effect of the operation. Experimentally, we have established
-   *   that `5` is a good value.
    */
   private final class LiveAdminClient(
-    private val adminClient: JAdmin,
-    private val writeOperationSemaphore: Semaphore
+    private val adminClient: JAdmin
   ) extends AdminClient {
+
+    /**
+     * Fixed sleep used for admin operations whose effect cannot be cheaply verified via a read-back.
+     */
+    private val visibilityFallbackSleep: Duration = 1.second
 
     override def createTopics(
       newTopics: Iterable[NewTopic],
@@ -357,20 +364,16 @@ object AdminClient {
       val asJava     = newTopics.map(_.asJava).asJavaCollection
       val topicNames = asJava.asScala.map(_.name()).toIndexedSeq
 
-      withPermit {
-        fromKafkaFutureVoid {
-          ZIO.attempt {
-            options
-              .fold(adminClient.createTopics(asJava))(opts => adminClient.createTopics(asJava, opts.asJava))
-              .all()
-          }
+      fromKafkaFutureVoid {
+        ZIO.attempt {
+          options
+            .fold(adminClient.createTopics(asJava))(opts => adminClient.createTopics(asJava, opts.asJava))
+            .all()
         }
       } <*
-        ZIO.sleep(50.millis) <*
-        listTopics().repeat(
-          Schedule.exponential(50.millis) &&
-            Schedule.upTo(5.seconds) &&
-            Schedule.recurUntil(topics => topicNames.forall(topics.contains))
+        awaitVisible(
+          listTopics(),
+          (topics: Map[String, TopicListing]) => topicNames.forall(topics.contains)
         )
     }
 
@@ -381,18 +384,21 @@ object AdminClient {
       groupIds: Iterable[String],
       options: Option[DeleteConsumerGroupOptions]
     ): Task[Unit] = {
-      val asJava = groupIds.asJavaCollection
-      withPermit {
-        fromKafkaFutureVoid {
-          ZIO.attempt {
-            options
-              .fold(adminClient.deleteConsumerGroups(asJava))(opts =>
-                adminClient.deleteConsumerGroups(asJava, opts.asJava)
-              )
-              .all()
-          }
+      val asJava      = groupIds.asJavaCollection
+      val groupIdsSet = groupIds.toSet
+      fromKafkaFutureVoid {
+        ZIO.attempt {
+          options
+            .fold(adminClient.deleteConsumerGroups(asJava)) { opts =>
+              adminClient.deleteConsumerGroups(asJava, opts.asJava)
+            }
+            .all()
         }
-      }
+      } <*
+        awaitVisible(
+          listConsumerGroups(),
+          (current: List[ConsumerGroupListing]) => current.forall(g => !groupIdsSet.contains(g.groupId))
+        )
     }
 
     override def deleteTopics(
@@ -401,20 +407,16 @@ object AdminClient {
     ): Task[Unit] = {
       val asJava     = topics.asJavaCollection
       val topicNames = asJava.asScala.toIndexedSeq
-      withPermit {
-        fromKafkaFutureVoid {
-          ZIO.attempt {
-            options
-              .fold(adminClient.deleteTopics(asJava))(opts => adminClient.deleteTopics(asJava, opts.asJava))
-              .all()
-          }
+      fromKafkaFutureVoid {
+        ZIO.attempt {
+          options
+            .fold(adminClient.deleteTopics(asJava))(opts => adminClient.deleteTopics(asJava, opts.asJava))
+            .all()
         }
       } <*
-        ZIO.sleep(50.millis) <*
-        listTopics().repeat(
-          Schedule.exponential(50.millis) &&
-            Schedule.upTo(5.seconds) &&
-            Schedule.recurUntil(topics => topicNames.forall(name => !topics.contains(name)))
+        awaitVisible(
+          listTopics(),
+          (current: Map[String, TopicListing]) => topicNames.forall(name => !current.contains(name))
         )
     }
 
@@ -426,15 +428,13 @@ object AdminClient {
       deleteRecordsOptions: Option[DeleteRecordsOptions] = None
     ): Task[Unit] = {
       val records = recordsToDelete.map { case (k, v) => k.asJava -> v }.asJava
-      withPermit {
-        fromKafkaFutureVoid {
-          ZIO.attempt {
-            deleteRecordsOptions
-              .fold(adminClient.deleteRecords(records))(opts => adminClient.deleteRecords(records, opts.asJava))
-              .all()
-          }
+      fromKafkaFutureVoid {
+        ZIO.attempt {
+          deleteRecordsOptions
+            .fold(adminClient.deleteRecords(records))(opts => adminClient.deleteRecords(records, opts.asJava))
+            .all()
         }
-      }
+      } <* ZIO.sleep(visibilityFallbackSleep)
     }
 
     override def listTopics(listTopicsOptions: Option[ListTopicsOptions] = None): Task[Map[String, TopicListing]] =
@@ -550,16 +550,23 @@ object AdminClient {
       newPartitions: Map[String, NewPartitions],
       options: Option[CreatePartitionsOptions] = None
     ): Task[Unit] = {
-      val asJava = newPartitions.map { case (k, v) => k -> v.asJava }.asJava
-      withPermit {
-        fromKafkaFutureVoid {
-          ZIO.attempt {
-            options
-              .fold(adminClient.createPartitions(asJava))(opts => adminClient.createPartitions(asJava, opts.asJava))
-              .all()
-          }
+      val asJava        = newPartitions.map { case (k, v) => k -> v.asJava }.asJava
+      val topicNames    = Chunk.fromIterable(newPartitions.keys)
+      val expectedSizes = newPartitions.map { case (name, np) => name -> np.totalCount }
+      fromKafkaFutureVoid {
+        ZIO.attempt {
+          options
+            .fold(adminClient.createPartitions(asJava))(opts => adminClient.createPartitions(asJava, opts.asJava))
+            .all()
         }
-      }
+      } <*
+        awaitVisible(
+          describeTopics(topicNames),
+          (described: Map[String, TopicDescription]) =>
+            expectedSizes.forall { case (name, expected) =>
+              described.get(name).exists(_.partitions.size >= expected)
+            }
+        )
     }
 
     override def listOffsets(
@@ -662,18 +669,25 @@ object AdminClient {
       offsets: Map[TopicPartition, OffsetAndMetadata],
       options: Option[AlterConsumerGroupOffsetsOptions] = None
     ): Task[Unit] = {
-      val asJava = offsets.bimap(_.asJava, _.asJava).asJava
-      withPermit {
-        fromKafkaFutureVoid {
-          ZIO.attempt {
-            options
-              .fold(adminClient.alterConsumerGroupOffsets(groupId, asJava))(opts =>
-                adminClient.alterConsumerGroupOffsets(groupId, asJava, opts.asJava)
-              )
-              .all()
-          }
+      val asJava     = offsets.bimap(_.asJava, _.asJava).asJava
+      val groupSpecs = Map(groupId -> ListConsumerGroupOffsetsSpec(Chunk.fromIterable(offsets.keySet)))
+      val expected   = offsets.view.mapValues(_.offset).toMap
+      fromKafkaFutureVoid {
+        ZIO.attempt {
+          options
+            .fold(adminClient.alterConsumerGroupOffsets(groupId, asJava)) { opts =>
+              adminClient.alterConsumerGroupOffsets(groupId, asJava, opts.asJava)
+            }
+            .all()
         }
-      }
+      } <*
+        awaitVisible(
+          listConsumerGroupOffsets(groupSpecs),
+          (current: Map[String, Map[TopicPartition, OffsetAndMetadata]]) =>
+            expected.forall { case (tp, expectedOffset) =>
+              current.get(groupId).flatMap(_.get(tp)).exists(_.offset == expectedOffset)
+            }
+        )
     }
 
     override def metrics: Task[Map[MetricName, Metric]] =
@@ -732,24 +746,20 @@ object AdminClient {
       val options = new RemoveMembersFromConsumerGroupOptions(
         membersToRemove.map(new MemberToRemove(_)).asJavaCollection
       )
-      withPermit {
-        fromKafkaFuture {
-          ZIO.attempt {
-            adminClient.removeMembersFromConsumerGroup(groupId, options).all()
-          }
+      fromKafkaFutureVoid {
+        ZIO.attempt {
+          adminClient.removeMembersFromConsumerGroup(groupId, options).all()
         }
-      }.unit
+      } <* ZIO.sleep(visibilityFallbackSleep)
     }
 
     override def removeMembersFromConsumerGroup(groupId: String): Task[Unit] = {
       val options = new RemoveMembersFromConsumerGroupOptions()
-      withPermit {
-        fromKafkaFuture {
-          ZIO.attempt {
-            adminClient.removeMembersFromConsumerGroup(groupId, options).all()
-          }
+      fromKafkaFutureVoid {
+        ZIO.attempt {
+          adminClient.removeMembersFromConsumerGroup(groupId, options).all()
         }
-      }.unit
+      } <* ZIO.sleep(visibilityFallbackSleep)
     }
 
     override def describeLogDirs(
@@ -783,26 +793,7 @@ object AdminClient {
       configs: Map[ConfigResource, Iterable[AlterConfigOp]],
       options: AlterConfigsOptions
     ): Task[Unit] =
-      withPermit {
-        fromKafkaFutureVoid {
-          ZIO.attempt {
-            adminClient
-              .incrementalAlterConfigs(
-                configs.map { case (configResource, alterConfigOps) =>
-                  (configResource.asJava, alterConfigOps.map(_.asJava).asJavaCollection)
-                }.asJava,
-                options.asJava
-              )
-              .all()
-          }
-        }
-      }
-
-    override def incrementalAlterConfigsAsync(
-      configs: Map[ConfigResource, Iterable[AlterConfigOp]],
-      options: AlterConfigsOptions
-    ): Task[Map[ConfigResource, Task[Unit]]] =
-      withPermit {
+      fromKafkaFutureVoid {
         ZIO.attempt {
           adminClient
             .incrementalAlterConfigs(
@@ -811,11 +802,31 @@ object AdminClient {
               }.asJava,
               options.asJava
             )
-            .values()
+            .all()
         }
+      } <* awaitConfigsVisible(configs)
+
+    override def incrementalAlterConfigsAsync(
+      configs: Map[ConfigResource, Iterable[AlterConfigOp]],
+      options: AlterConfigsOptions
+    ): Task[Map[ConfigResource, Task[Unit]]] =
+      ZIO.attempt {
+        adminClient
+          .incrementalAlterConfigs(
+            configs.map { case (configResource, alterConfigOps) =>
+              (configResource.asJava, alterConfigOps.map(_.asJava).asJavaCollection)
+            }.asJava,
+            options.asJava
+          )
+          .values()
       }.map {
-        _.asScala.map { case (configResource, kf) =>
-          (ConfigResource.fromJava(configResource), ZIO.fromCompletionStage(kf.toCompletionStage).unit)
+        _.asScala.map { case (jConfigResource, kf) =>
+          val configResource = ConfigResource.fromJava(jConfigResource)
+          val ops            = configs.getOrElse(configResource, Iterable.empty)
+          (
+            configResource,
+            ZIO.fromCompletionStage(kf.toCompletionStage).unit <* awaitConfigsVisible(Map(configResource -> ops))
+          )
         }.toMap
       }
 
@@ -832,62 +843,67 @@ object AdminClient {
       }.map(_.asScala.view.map(AclBinding(_)).toSet)
 
     override def createAcls(acls: Set[AclBinding], options: Option[CreateAclOptions]): Task[Unit] =
-      withPermit {
-        fromKafkaFutureVoid {
-          ZIO.attempt {
-            options
-              .fold(adminClient.createAcls(acls.map(_.asJava).asJava))(opt =>
-                adminClient.createAcls(acls.map(_.asJava).asJava, opt.asJava)
-              )
-              .all()
-          }
+      fromKafkaFutureVoid {
+        ZIO.attempt {
+          options
+            .fold(adminClient.createAcls(acls.map(_.asJava).asJava)) { opt =>
+              adminClient.createAcls(acls.map(_.asJava).asJava, opt.asJava)
+            }
+            .all()
         }
-      }
+      } <*
+        awaitVisible(
+          describeAcls(AclBindingFilter(ResourcePatternFilter.Any, AccessControlEntryFilter.Any), None),
+          (current: Set[AclBinding]) => acls.forall(current.contains)
+        )
 
     override def createAclsAsync(
       acls: Set[AclBinding],
       options: Option[CreateAclOptions]
     ): Task[Map[AclBinding, Task[Unit]]] =
-      withPermit {
-        ZIO.attempt {
-          options
-            .fold(adminClient.createAcls(acls.map(_.asJava).asJava))(opt =>
-              adminClient.createAcls(acls.map(_.asJava).asJava, opt.asJava)
-            )
-            .values()
-        }
+      ZIO.attempt {
+        options
+          .fold(adminClient.createAcls(acls.map(_.asJava).asJava)) { opt =>
+            adminClient.createAcls(acls.map(_.asJava).asJava, opt.asJava)
+          }
+          .values()
       }.map {
         _.asScala.view.map { case (k, v) =>
-          (AclBinding(k), ZIO.fromCompletionStage(v.toCompletionStage).unit)
+          val binding = AclBinding(k)
+          val await =
+            awaitVisible(
+              describeAcls(AclBindingFilter(ResourcePatternFilter.Any, AccessControlEntryFilter.Any), None),
+              (current: Set[AclBinding]) => current.contains(binding)
+            )
+          (binding, ZIO.fromCompletionStage(v.toCompletionStage).unit <* await)
         }.toMap
       }
 
     override def deleteAcls(filters: Set[AclBindingFilter], options: Option[DeleteAclsOptions]): Task[Set[AclBinding]] =
-      withPermit {
-        fromKafkaFuture {
-          ZIO.attempt {
-            options
-              .fold(adminClient.deleteAcls(filters.map(_.asJava).asJava))(opt =>
-                adminClient.deleteAcls(filters.map(_.asJava).asJava, opt.asJava)
-              )
-              .all()
-          }
+      fromKafkaFuture {
+        ZIO.attempt {
+          options
+            .fold(adminClient.deleteAcls(filters.map(_.asJava).asJava)) { opt =>
+              adminClient.deleteAcls(filters.map(_.asJava).asJava, opt.asJava)
+            }
+            .all()
         }
       }
-        .map(_.asScala.view.map(AclBinding(_)).toSet)
+        .map(_.asScala.view.map(AclBinding(_)).toSet) <*
+        ZIO.foreachDiscard(filters) { filter =>
+          awaitVisible(describeAcls(filter, None), (current: Set[AclBinding]) => current.isEmpty)
+        }
 
     override def deleteAclsAsync(
       filters: Set[AclBindingFilter],
       options: Option[DeleteAclsOptions]
     ): Task[Map[AclBindingFilter, Task[Map[AclBinding, Option[Throwable]]]]] =
-      withPermit {
-        ZIO.attempt {
-          options
-            .fold(adminClient.deleteAcls(filters.map(_.asJava).asJava))(opt =>
-              adminClient.deleteAcls(filters.map(_.asJava).asJava, opt.asJava)
-            )
-            .values()
-        }
+      ZIO.attempt {
+        options
+          .fold(adminClient.deleteAcls(filters.map(_.asJava).asJava)) { opt =>
+            adminClient.deleteAcls(filters.map(_.asJava).asJava, opt.asJava)
+          }
+          .values()
       }.map {
         _.asScala.view.map { case (k, v) =>
           (
@@ -899,13 +915,60 @@ object AdminClient {
                   // FilterResult.binding() is claimed to be nullable but in fact it is not: see DeleteAclsResponse.aclBinding
                   AclBinding(filterRes.binding()) -> Option(filterRes.exception())
                 }.toMap
-              )
+              ) <* awaitVisible(describeAcls(AclBindingFilter(k), None), (current: Set[AclBinding]) => current.isEmpty)
           )
         }.toMap
       }
 
-    private def withPermit[R, E, A](f: => ZIO[R, E, A]): ZIO[R, E, A] =
-      writeOperationSemaphore.withPermit(f)
+    /**
+     * Polls `read` (exponential backoff starting at 50ms) until `ready` reports the change is visible, or 5 seconds
+     * elapses, with a silent success on timeout.
+     */
+    // noinspection SimplifySleepInspection
+    private def awaitVisible[A](read: => Task[A], ready: A => Boolean): Task[Unit] =
+      ZIO.sleep(50.millis) *>
+        read
+          .repeat(
+            Schedule.exponential(50.millis) &&
+              Schedule.upTo(5.seconds) &&
+              Schedule.recurUntil(ready)
+          )
+          .unit
+
+    /**
+     * Visibility check for `incrementalAlterConfigs`. For requests containing only Set and Delete ops it polls
+     * `describeConfigs` until each op's effect is observable. Requests containing Append or Subtract fall back to
+     * `visibilityFallbackSleep` because verifying them would require comparing against pre-op state.
+     */
+    private def awaitConfigsVisible(configs: Map[ConfigResource, Iterable[AlterConfigOp]]): Task[Unit] = {
+      val hasAppendOrSubtract = configs.valuesIterator.flatten.exists { op =>
+        op.opType == AlterConfigOpType.Append || op.opType == AlterConfigOpType.Substract
+      }
+      if (hasAppendOrSubtract) ZIO.sleep(visibilityFallbackSleep)
+      else {
+        awaitVisible(
+          describeConfigs(configs.keys.toList),
+          (current: Map[ConfigResource, KafkaConfig]) =>
+            configs.forall { case (resource, ops) =>
+              current.get(resource).exists(config => ops.forall(op => isConfigOpVisible(config, op)))
+            }
+        )
+      }
+    }
+
+    private def isConfigOpVisible(config: KafkaConfig, op: AlterConfigOp): Boolean = {
+      val key = op.configEntry.name()
+      op.opType match {
+        case AlterConfigOpType.Set =>
+          config.entries.get(key).exists { entry =>
+            entry.value() == op.configEntry.value() &&
+            entry.source() != ConfigEntry.ConfigSource.DEFAULT_CONFIG
+          }
+        case AlterConfigOpType.Delete =>
+          config.entries.get(key).forall(_.source() == ConfigEntry.ConfigSource.DEFAULT_CONFIG)
+        case _ => true
+      }
+    }
 
   }
 
@@ -1564,67 +1627,21 @@ object AdminClient {
    *
    * @param settings
    *   the admin client settings
-   * @param writeOperationSemaphore
-   *   a semaphore that is used to limit the number of concurrent write operations (such as create topic, delete topic,
-   *   and delete offsets) from this client, or `None` to construct that semaphore with
-   *   `settings.maxConcurrentWriteOperations`. Keep the number of permits low to prevent the operation to be lost, or
-   *   not being able to see the effect of the operation. Experimentally, we have established that `5` is a good value.
    */
-  def make(
-    settings: AdminClientSettings,
-    writeOperationSemaphore: Option[Semaphore] = None
-  ): ZIO[Scope, Throwable, AdminClient] =
-    for {
-      ws <- writeOperationSemaphore match {
-              case Some(s) => ZIO.succeed(s)
-              case None    => Semaphore.make(settings.maxConcurrentWriteOperations.toLong)
-            }
-      adminClient <- fromScopedJavaClient(javaClientFromSettings(settings), ws)
-    } yield adminClient
+  def make(settings: AdminClientSettings): ZIO[Scope, Throwable, AdminClient] =
+    fromScopedJavaClient(javaClientFromSettings(settings))
 
   /**
    * Make a Kafka [[AdminClient]] by wrapping a provided Java admin client.
    *
    * @param javaClient
    *   the java admin client to wrap
-   * @param writeOperationSemaphore
-   *   a semaphore that is used to limit the number of concurrent write operations (such as create topic, delete topic,
-   *   and delete offsets), from this client. Keep the number of permits low to prevent the operation to be lost, or not
-   *   being able to see the effect of the operation. Experimentally, we have established that `5` is a good value.
-   */
-  def fromJavaClient(javaClient: JAdmin, writeOperationSemaphore: Semaphore): URIO[Any, AdminClient] =
-    ZIO.succeed(new LiveAdminClient(javaClient, writeOperationSemaphore))
-
-  /**
-   * Make a Kafka [[AdminClient]] by wrapping a provided Java admin client. The client allows at most 5 concurrent write
-   * operations (such as create topic, delete topic, and delete offsets).
    */
   def fromJavaClient(javaClient: JAdmin): URIO[Any, AdminClient] =
-    for {
-      writeOperationSemaphore <- Semaphore.make(5)
-      adminClient             <- fromJavaClient(javaClient, writeOperationSemaphore)
-    } yield adminClient
+    ZIO.succeed(new LiveAdminClient(javaClient))
 
   /**
    * Make a Kafka [[AdminClient]] by wrapping a provided Java admin client. The client closes with the provided scope.
-   *
-   * @param writeOperationSemaphore
-   *   a semaphore that is used to limit the number of concurrent write operations (such as create topic, delete topic,
-   *   and delete offsets), from this client. Keep the number of permits low to prevent the operation to be lost, or not
-   *   being able to see the effect of the operation. Experimentally, we have established that `5` is a good value.
-   */
-  def fromScopedJavaClient[R, E](
-    scopedJavaClient: ZIO[R & Scope, E, JAdmin],
-    writeOperationSemaphore: Semaphore
-  ): ZIO[R & Scope, E, AdminClient] =
-    for {
-      javaClient  <- scopedJavaClient
-      adminClient <- fromJavaClient(javaClient, writeOperationSemaphore)
-    } yield adminClient
-
-  /**
-   * Make a Kafka [[AdminClient]] by wrapping a provided Java admin client. The client closes with the provided scope
-   * and allows at most 5 concurrent write operations (such as create topic, delete topic, and delete offsets).
    */
   def fromScopedJavaClient[R, E](scopedJavaClient: ZIO[R & Scope, E, JAdmin]): ZIO[R & Scope, E, AdminClient] =
     for {

--- a/zio-kafka/src/main/scala/zio/kafka/admin/AdminClientSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/admin/AdminClientSettings.scala
@@ -17,31 +17,12 @@ import zio.kafka.security.KafkaCredentialStore
  */
 final case class AdminClientSettings(
   closeTimeout: Duration,
-  maxConcurrentWriteOperations: Int,
   properties: Map[String, AnyRef]
 ) {
   def driverSettings: Map[String, AnyRef] = properties
 
   def withBootstrapServers(servers: List[String]): AdminClientSettings =
     withProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, servers.mkString(","))
-
-  /**
-   * Set the maximum number of write operations (create topic, delete topic, delete offsets, etc.) that can be executed
-   * concurrently by the admin client. Keep this number low to prevent the operation to be lost, or not being able to
-   * see the effect of the operation. Experimentally, we have established that `5` is a good value.
-   *
-   * Defaults to 5.
-   *
-   * Note: this setting is ignored when the client is created with a custom [[Semaphore]]. See `AdminClient.make()`. for
-   * more details.
-   */
-  def withMaxConcurrentWriteOperations(maxConcurrentWriteOperations: Int): AdminClientSettings = {
-    require(
-      maxConcurrentWriteOperations >= 0,
-      s"maxConcurrentWriteOperations must be strictly positive, got $maxConcurrentWriteOperations"
-    )
-    copy(maxConcurrentWriteOperations = maxConcurrentWriteOperations)
-  }
 
   def withProperty(key: String, value: AnyRef): AdminClientSettings =
     copy(properties = properties + (key -> value))
@@ -60,7 +41,6 @@ object AdminClientSettings {
   def apply(bootstrapServers: List[String]): AdminClientSettings =
     AdminClientSettings(
       closeTimeout = 30.seconds,
-      maxConcurrentWriteOperations = 1,
       properties = Map.empty
     ).withBootstrapServers(bootstrapServers)
 }


### PR DESCRIPTION
## Context

For a long time this project has been plagued by a concurrency bug in the AdminClient that only manifests itself while running the unit tests on a compute constraint machine like the GitHub runners.

 _Deeper investigation shows that the 'bug' is actually in the kafka broker._

The KafkaFuture's we get from the kafka client complete when the controller commits the change to the metadata log, not when the broker's in-memory metadata cache (which we read from with an admin read operation) has applied that commit. On slower machines the broker hasn't pulled the metadata update by the time the next read arrives.

**This is not acceptable,** we need to know when a write operation completed. For example, you can't consume from or publish to a topic when it was not actually created yet.

In the past we tried to work around the problem with several approaches:
- `kafka18818Workaround` a 550ms sleep after each write operation
- explicit polling for some operations (`createTopics`, `deleteTopics` in #1611)
- limit the number of concurrent writes operations (#1667, #1696 and #1697)

Of these only explicit polling works well.

## The workaround: explicit polling

Where possible, all write operations are followed by polling for the results. The poll is done with exponential backup starting at 50ms. After 5s we silently give up. In effect, we assume that the write operation succeeded, and that there was a subsequent write operation that undid the first.

The effect of some write operations are expensive to poll. These are `deleteRecords`, `removeMembersFromConsumerGroup` and `incrementalAlterConfigs` with an Append-or-Subtract op. For these three cases we fall back to a `visibilitySleep` that defaults to 1 second.

Since overloading rules do not allow adding a default parameter to the `removeMembersFromConsumerGroup` variant that deletes all members, `removeAllMembersFromConsumerGroup` was introduced.

As a bonus, the tests now run in half the time on a fast machine (3.5 to 1.5 minutes on my laptop).

## Clean up

Now that we poll for the effect, we no longer need the `writeOperationSemaphore` feature of the AdminClient that was introduced in zio-kafka 3.4.0.

Some tests did result polling, this is no longer needed.

## Source & binary compatibility

This change is NOT source-compatible and NOT binary-compatible with the previous release. Callers passing a custom `Semaphore` to `AdminClient.make` / `AdminClient.fromJavaClient` / `AdminClient.fromScopedJavaClient`, or using `AdminClientSettings.withMaxConcurrentWriteOperations`, will fail to compile.

We assume however, that not many users adopted this feature yet.

## References

- #1611 — Await completion of some admin operations (first polling for createTopics/deleteTopics, replacing the global sleep).
- #1667 — Limit number of concurrent admin write operations (added the semaphore; removed kafka18818Workaround under the assumption KAFKA-18818 was fixed).
- #1696 — Reduce concurrent admin operations (test-side semaphore 5 → 1).
- #1697 — Reduce concurrent admin operations (settings default 5 → 1).
- KAFKA-18818 — upstream Jira on admin op eventual consistency.

## Also in this PR

`AlterConfigOpType.Substract` has a typo. It is now an alias to the correctly spelled `AlterConfigOpType.Subtract`.