### PR TITLE
Fix consumer hang when Runloop crashes with empty dataQueue

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/PartitionStreamControlSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/PartitionStreamControlSpec.scala
@@ -8,7 +8,7 @@ import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
 import zio.kafka.diagnostics.Diagnostics
 import zio.test._
 
-import java.util.concurrent.TimeoutException
+import scala.util.control.NoStackTrace
 
 object PartitionStreamControlSpec extends ZIOSpecDefault {
   override def spec: Spec[Any, Throwable] = suite("PartitionStreamControl")(
@@ -67,12 +67,24 @@ object PartitionStreamControlSpec extends ZIOSpecDefault {
           exit <- control.offerRecords(records).exit
         } yield assertTrue(exit.isFailure)
       },
-      test("halt completes the stream with a TimeoutException") {
+      test("halt fails the stream with the given cause") {
+        val boom = new RuntimeException("boom") with NoStackTrace
         for {
           control <- createTestControl
-          _       <- control.halt
+          _       <- control.halt(Cause.fail(boom))
           result  <- control.stream.runCollect.exit
-        } yield assertTrue(result.isFailure, result.causeOrNull.squash.isInstanceOf[TimeoutException])
+        } yield assertTrue(result.isFailure, result.causeOrNull.squash == boom)
+      },
+      test("halt unblocks a stream waiting on an empty dataQueue") {
+        val boom = new RuntimeException("boom") with NoStackTrace
+        for {
+          control <- createTestControl
+          fiber   <- control.stream.runCollect.fork
+          // Give the stream fiber time to park on dataQueue.take
+          _      <- ZIO.sleep(500.millis)
+          _      <- control.halt(Cause.fail(boom))
+          result <- fiber.join.exit
+        } yield assertTrue(result.isFailure, result.causeOrNull.squash == boom)
       },
       test("finalizing the stream will set isCompleted") {
         for {

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -2,12 +2,13 @@ package zio.kafka.consumer.internal
 
 import org.apache.kafka.clients.consumer.{ ConsumerRebalanceListener, ConsumerRecord, MockConsumer }
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.{ AuthenticationException, AuthorizationException }
+import org.apache.kafka.common.errors.{ AuthenticationException, AuthorizationException, TopicAuthorizationException }
 import zio._
 import zio.kafka.ZIOSpecDefaultSlf4j
 import zio.kafka.consumer.Consumer.ConsumerDiagnostics
 import zio.kafka.consumer.diagnostics.DiagnosticEvent
 import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
+import zio.kafka.consumer.metrics.ConsumerMetricsObserver
 import zio.kafka.consumer.{ ConsumerSettings, Subscription }
 import zio.kafka.diagnostics.{ Diagnostics, SlidingDiagnostics }
 import zio.metrics.{ MetricState, Metrics }
@@ -181,12 +182,49 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
             authErrorCount.contains(2d)
           )
         }
+      },
+      test("partition stream fails when Runloop crashes after auth retries exhaust with empty dataQueue") {
+        val authException = new TopicAuthorizationException("acl-denied")
+        // recurs(0): no retries, so the Runloop crashes on the first auth exception.
+        // NoOp metricsObserver: this test does not pollute the global auth-error counter that
+        // other tests asserts on, so tests stay independent and can run concurrently.
+        val settings = consumerSettings
+          .withAuthErrorRetrySchedule(Schedule.recurs(0))
+          .withMetricsObserver(ConsumerMetricsObserver.NoOp)
+        withRunloop(settings = settings) { (mockConsumer, partitionsHub, runloop) =>
+          // 1st poll: assign the partition with no records, so the per-partition stream parks on dataQueue.take.
+          mockConsumer.schedulePollTask { () =>
+            mockConsumer.updateEndOffsets(Map(tp10 -> Long.box(0L)).asJava)
+            mockConsumer.rebalance(Seq(tp10).asJava)
+          }
+          // 2nd poll: throw an auth exception. With `recurs(0)` the Runloop crashes immediately.
+          mockConsumer.schedulePollTask { () =>
+            mockConsumer.setPollException(authException)
+          }
+          for {
+            streamStream <- ZStream.fromHubScoped(partitionsHub)
+            _            <- runloop.addSubscription(Subscription.Topics(Set(tp10.topic())))
+            exit <- streamStream
+                      .map(_.exit)
+                      .flattenExitOption
+                      .flattenChunks
+                      .flatMapPar(Int.MaxValue) { case (_, stream) => stream }
+                      .runDrain
+                      .timeout(10.seconds)
+                      .exit
+          } yield assertTrue(
+            // Since runloop informs the partition streams when it crashes, `exit` contains the auth exception.
+            // Without informing the partition streams, this would time out (and not get an auth exception).
+            exit.causeOption.exists(_.squash == authException)
+          )
+        }
       }
     ) @@ withLiveClock
 
   private def withRunloop(
     diagnostics: ConsumerDiagnostics = Diagnostics.NoOp,
-    mockConsumer: BinaryMockConsumer = new BinaryMockConsumer("latest")
+    mockConsumer: BinaryMockConsumer = new BinaryMockConsumer("latest"),
+    settings: ConsumerSettings = consumerSettings
   )(
     f: (BinaryMockConsumer, PartitionsHub, Runloop) => ZIO[Scope, Throwable, TestResult]
   ): ZIO[Scope, Throwable, TestResult] =
@@ -198,9 +236,9 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
         partitionsHub <- ZIO
                            .acquireRelease(Hub.unbounded[Take[Throwable, PartitionAssignment]])(_.shutdown)
                            .provide(ZLayer.succeed(consumerScope))
-        runloopConfig <- RunloopConfig(consumerSettings)
+        runloopConfig <- RunloopConfig(settings)
         runloop <- Runloop.make(
-                     consumerSettings,
+                     settings,
                      runloopConfig,
                      diagnostics,
                      consumerAccess,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -9,9 +9,6 @@ import zio.stream.ZStream
 import zio._
 import zio.kafka.consumer.diagnostics.DiagnosticEvent
 
-import java.util.concurrent.TimeoutException
-import scala.util.control.NoStackTrace
-
 abstract class PartitionStream {
   def tp: TopicPartition
   def queueSize: UIO[Int]
@@ -91,12 +88,11 @@ final class PartitionStreamControl private (
   private[internal] def maxStreamPullIntervalExceeded(now: NanoTime): UIO[Boolean] =
     queueInfoRef.get.map(_.deadlineExceeded(now))
 
-  /** To be invoked when the stream is no longer processing. */
-  private[internal] def halt: UIO[Unit] = {
-    val timeOutMessage = s"No records were pulled for more than $maxStreamPullInterval for topic partition $tp."
-    val consumeTimeout = new TimeoutException(timeOutMessage) with NoStackTrace
-    interruptionPromise.fail(consumeTimeout).unit
-  }
+  /**
+   * To be invoked when the stream is no longer processing. It fails the stream with the given cause.
+   */
+  private[internal] def halt(cause: Cause[Throwable]): UIO[Unit] =
+    interruptionPromise.failCause(cause).unit
 
   /** To be invoked when the partition was revoked, lost or otherwise needs to be ended. */
   private[internal] def end: ZIO[Any, Nothing, Unit] =

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -14,7 +14,9 @@ import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
 import zio.kafka.consumer.metrics.{ ConsumerMetricsObserver, ZioMetricsConsumerMetricsObserver }
 import zio.stream._
 
+import java.util.concurrent.TimeoutException
 import scala.jdk.CollectionConverters._
+import scala.util.control.NoStackTrace
 
 //noinspection SimplifyWhenInspection,SimplifyUnlessInspection
 private[consumer] final class Runloop private (
@@ -381,13 +383,20 @@ private[consumer] final class Runloop private (
           "interval when processing a batch of records needs more time."
       )
 
+    def haltTimeout(stream: PartitionStreamControl): UIO[Unit] = {
+      val timeOutMessage =
+        s"No records were pulled for more than ${runloopConfig.maxStreamPullInterval} for topic partition ${stream.tp}."
+      val consumeTimeout = new TimeoutException(timeOutMessage) with NoStackTrace
+      stream.halt(Cause.fail(consumeTimeout))
+    }
+
     for {
       now <- Clock.nanoTime
       anyExceeded <- ZIO.foldLeft(streams)(false) { case (acc, stream) =>
                        stream
                          .maxStreamPullIntervalExceeded(now)
                          .tap(ZIO.when(_)(logShutdown(stream)))
-                         .tap(exceeded => if (exceeded) stream.halt else ZIO.unit)
+                         .tap(exceeded => if (exceeded) haltTimeout(stream) else ZIO.unit)
                          .map(acc || _)
                      }
       _ <- shutdown.when(anyExceeded)
@@ -557,7 +566,15 @@ private[consumer] final class Runloop private (
         } yield updatedStateAfterPoll
       }
       .tapErrorCause(cause => ZIO.logErrorCause("Error in Runloop", cause))
-      .onError(cause => partitionsHub.offer(Take.failCause(cause)))
+      // Propagate the failure to active per-partition streams and to any new hub subscribers, then exit cleanly.
+      // The fiber exit status is irrelevant once the failure has been published to all consumers.
+      .catchAllCause { cause =>
+        for {
+          state <- currentStateRef.get
+          _     <- ZIO.foreachDiscard(state.assignedStreams)(_.halt(cause))
+          _     <- partitionsHub.offer(Take.failCause(cause))
+        } yield ()
+      }
   }
 
   def shouldPoll(state: State): UIO[Boolean] =


### PR DESCRIPTION
As reported by @acrow in #1705.

When the internal Runloop crashes with a fatal exception (e.g. `TopicAuthorizationException` after `authErrorRetrySchedule` is exhausted), consumers are supposed to fail with that exception so the user's `.retry(...)` can decide what to do. This works on the first occurrence of the exception because records are typically in flight: the per-partition stream pulls a chunk, then sees `interruptionPromise` or hub failure and propagates the error.

But on the second occurrence (right after a retry with the same denied ACL), no records ever arrive. Every per-partition stream is parked on `dataQueue.take.raceFirst(interruptionPromise.await)` (PartitionStreamControl.scala:161). When the Runloop dies, it does `partitionsHub.offer(Take.failCause(cause))` (Runloop.scala:560) — but per-partition streams do not subscribe to the hub. Nothing fails `interruptionPromise`, nothing offers `EndOfStream` to `dataQueue`, so the partition stream fibers hang forever, hanging the consumer as well.

The fix is to explicitly halt the active per-partition streams when the runloop crashes.

Fixes #1705.