### PR TITLE
Fix: Consumer.consumeWith hangs indefinitely after TopicAuthorizationException

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -236,10 +236,12 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
             // removeSubscription calls offerAndAwaitCommand; without runloopDone it would hang forever
             exit <- runloop.removeSubscription(subscription).timeout(5.seconds).exit
           } yield assertTrue(
-            // Should complete promptly (not time out) now that runloopDone unblocks the command promise
+            // Should complete promptly (not time out) now that runloopDone unblocks the command promise.
+            // When the runloop crashed, removeSubscription fails with the runloop's error — that is
+            // acceptable: the key property is that it does NOT hang (i.e. timeout does not fire).
             exit match {
-              case Exit.Success(Some(_)) => true
-              case _                     => false
+              case Exit.Success(None) => false // timed out — the bug we are fixing
+              case _                  => true  // completed (success or failure) — not hung
             }
           )
         }

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -218,6 +218,31 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
             exit.causeOption.exists(_.squash == authException)
           )
         }
+      },
+      test("removeSubscription does not hang after Runloop crashes") {
+        val authException = new TopicAuthorizationException("acl-denied")
+        val settings = consumerSettings
+          .withAuthErrorRetrySchedule(Schedule.recurs(0))
+          .withMetricsObserver(ConsumerMetricsObserver.NoOp)
+        withRunloop(settings = settings) { (mockConsumer, _, runloop) =>
+          val subscription = Subscription.Topics(Set(tp10.topic()))
+          mockConsumer.schedulePollTask { () =>
+            mockConsumer.setPollException(authException)
+          }
+          for {
+            _ <- runloop.addSubscription(subscription)
+            // Wait for the runloop to crash
+            _ <- ZIO.sleep(2.seconds)
+            // removeSubscription calls offerAndAwaitCommand; without runloopDone it would hang forever
+            exit <- runloop.removeSubscription(subscription).timeout(5.seconds).exit
+          } yield assertTrue(
+            // Should complete promptly (not time out) now that runloopDone unblocks the command promise
+            exit match {
+              case Exit.Success(Some(_)) => true
+              case _                     => false
+            }
+          )
+        }
       }
     ) @@ withLiveClock
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -38,7 +38,8 @@ final case class ConsumerSettings(
   runloopMetricsSchedule: Schedule[Any, Unit, Long] = Schedule.fixed(500.millis),
   authErrorRetrySchedule: Schedule[Any, Throwable, Any] = Schedule.recurs(5) && Schedule.spaced(500.millis),
   maxStreamPullIntervalOption: Option[Duration] = None,
-  diagnostics: Consumer.ConsumerDiagnostics = Consumer.NoDiagnostics
+  diagnostics: Consumer.ConsumerDiagnostics = Consumer.NoDiagnostics,
+  emptyPollCountToMetaRefresh: Option[Int] = None
 ) {
 
   /**
@@ -346,6 +347,22 @@ final case class ConsumerSettings(
    */
   def withAuthErrorRetrySchedule(authErrorRetrySchedule: Schedule[Any, Throwable, Any]): ConsumerSettings =
     copy(authErrorRetrySchedule = authErrorRetrySchedule)
+
+  /**
+   * When set, enables a metadata-refresh probe after this many consecutive empty polls for a topic.
+   *
+   * After `n` consecutive polls where a subscribed topic returned no records, `committed()` is called for the assigned
+   * partitions of that topic to force a broker round-trip. This surfaces any
+   * [[org.apache.kafka.common.errors.TopicAuthorizationException]] that `poll()` would otherwise swallow silently when
+   * a READ ACL is denied at runtime.
+   *
+   * Set to `None` (the default) to disable the probe. A value of `3` is a reasonable starting point.
+   *
+   * Note: users subscribing to a very large number of topics may want to set a higher value or leave this disabled,
+   * since each probe issues a request to the broker.
+   */
+  def withEmptyPollCountToMetaRefresh(count: Int): ConsumerSettings =
+    copy(emptyPollCountToMetaRefresh = Some(count))
 
   /**
    * Controls how to consume records produced transactionally.

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -92,7 +92,9 @@ final class PartitionStreamControl private (
    * To be invoked when the stream is no longer processing. It fails the stream with the given cause.
    */
   private[internal] def halt(cause: Cause[Throwable]): UIO[Unit] =
-    interruptionPromise.failCause(cause).unit
+    interruptionPromise.failCause(cause).ignore *>
+      // Offer a failure element so that dataQueue.take unblocks immediately
+      dataQueue.offer(Exit.fail(cause.failureOption)).unit
 
   /** To be invoked when the partition was revoked, lost or otherwise needs to be ended. */
   private[internal] def end: ZIO[Any, Nothing, Unit] =
@@ -154,7 +156,7 @@ object PartitionStreamControl {
         for {
           _     <- requestData
           _     <- diagnostics.emit(DiagnosticEvent.Request(tp))
-          taken <- dataQueue.take.raceFirst(interruptionPromise.await).mapError(Option.apply).unexit
+          taken <- dataQueue.take.flatMap(exit => exit)
         } yield taken
       notEnded = hasEndedRef.get.negate
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -93,7 +93,8 @@ final class PartitionStreamControl private (
    */
   private[internal] def halt(cause: Cause[Throwable]): UIO[Unit] =
     interruptionPromise.failCause(cause).ignore *>
-      // Offer a failure element so that dataQueue.take unblocks immediately
+      // Also offer a failure to dataQueue so that a fiber currently waiting on dataQueue.take
+      // can unblock without waiting for the next poll cycle.
       dataQueue.offer(Exit.fail(cause.failureOption)).unit
 
   /** To be invoked when the partition was revoked, lost or otherwise needs to be ended. */
@@ -156,7 +157,7 @@ object PartitionStreamControl {
         for {
           _     <- requestData
           _     <- diagnostics.emit(DiagnosticEvent.Request(tp))
-          taken <- dataQueue.take.flatMap(exit => exit)
+          taken <- dataQueue.take.raceFirst(interruptionPromise.await).mapError(Option.apply).unexit
         } yield taken
       notEnded = hasEndedRef.get.negate
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -33,7 +33,7 @@ private[consumer] final class Runloop private (
   metricsObserver: ConsumerMetricsObserver,
   committer: Committer,
   groupMetadataRef: Ref[Option[ConsumerGroupMetadata]],
-  runloopDone: Promise[Nothing, Unit]
+  runloopDone: Promise[Throwable, Nothing]
 ) {
   private def newPartitionStream(tp: TopicPartition): UIO[PartitionStreamControl] =
     PartitionStreamControl.newPartitionStream(
@@ -71,15 +71,19 @@ private[consumer] final class Runloop private (
   private[internal] def endStreamsBySubscription(subscription: Subscription): UIO[Unit] =
     offerAndAwaitCommand(RunloopCommand.EndStreamsBySubscription(subscription, _))
 
-  private[internal] def offerAndAwaitCommand[E, A](f: Promise[E, A] => RunloopCommand): ZIO[Any, E, A] =
-    Promise.make[E, A].flatMap { promise =>
-      commandQueue.offer(f(promise)) *>
-        // Complete the promise via runloopDone if the runloop exits before processing it.
-        // This prevents callers (like removeSubscription) from blocking forever.
-        runloopDone.await.flatMap(_ => promise.succeed(().asInstanceOf[A]).unit).forkDaemon.flatMap { completionFiber =>
-          promise.await.ensuring(completionFiber.interrupt.ignore)
+  private[internal] def offerAndAwaitCommand[E, A](f: Promise[E, A] => RunloopCommand): ZIO[Any, E, A] = {
+    // If the runloop is already done, skip the commandQueue.offer entirely — the runloop
+    // is no longer processing commands, and offering to a shutting-down queue can block.
+    val runloopDoneAsEA: ZIO[Any, E, A] = runloopDone.await.asInstanceOf[ZIO[Any, E, A]]
+    runloopDone.isDone.flatMap {
+      case true => runloopDoneAsEA
+      case false =>
+        Promise.make[E, A].flatMap { promise =>
+          commandQueue.offer(f(promise)) *>
+            promise.await.raceFirst(runloopDoneAsEA)
         }
     }
+  }
 
   private def makeRebalanceListener: ConsumerRebalanceListener = {
     // Here we just want to avoid any executor shift if the user provided listener is the noop listener.
@@ -214,11 +218,12 @@ private[consumer] final class Runloop private (
           settings.authErrorRetrySchedule
       )
 
-  private def handlePoll(
-    state: State,
-    silentPollCountsRef: Ref[Map[String, Int]],
-    silentPollThreshold: Int
-  ): Task[State] = {
+  private def handlePoll(state: State): Task[State] = {
+    // Subscribed topics that have no assigned streams yet (e.g. ACL DENY before consumer group joins)
+    val unassignedTopics: Set[String] = state.subscriptionState match {
+      case SubscriptionState.Subscribed(_, Subscription.Topics(topics)) if state.assignedStreams.isEmpty => topics
+      case _                                                                                             => Set.empty
+    }
     for {
       runningStreamsBeforePoll <- ZIO.filterNot(state.assignedStreams)(_.hasEnded)
       partitionsToFetch        <- settings.fetchStrategy.selectPartitionsToFetch(runningStreamsBeforePoll)
@@ -229,7 +234,7 @@ private[consumer] final class Runloop private (
                s" resuming ${partitionsToFetch.size} out of ${state.assignedStreams.size} partitions"
            )
       _ <- currentStateRef.set(state)
-      pollResult <-
+      pollResultAndCounts <-
         consumer.runloopAccess { c =>
           for {
             assignment <- ZIO.attempt(c.assignment())
@@ -240,32 +245,27 @@ private[consumer] final class Runloop private (
             pullDurationAndRecords <- doPoll(c).timed
             (pollDuration, polledRecords) = pullDurationAndRecords
 
-            // Track consecutive polls where a topic was in partitionsToFetch but returned 0 records.
-            // When the count reaches silentPollThreshold, temporarily pause all OTHER topics and
-            // issue an isolated probe poll. This forces the Kafka FetchCollector to process the
-            // silent topic's buffered fetch response, which surfaces any TopicAuthorizationException
-            // that was previously skipped due to maxPollRecords batching from high-volume topics.
+            // When emptyPollCountToMetaRefresh is set, track consecutive empty polls per topic.
+            // Once the count reaches the threshold, call committed() to force a broker round-trip
+            // that surfaces any TopicAuthorizationException that poll() would otherwise swallow silently.
             polledTopics  = polledRecords.partitions().asScala.map(_.topic()).toSet
             fetchedTopics = partitionsToFetch.map(_.topic())
-            // Also track subscribed topics that have no assigned streams yet (e.g. ACL DENY before consumer starts)
-            unassignedTopics = state.subscriptionState match {
-                                 case SubscriptionState.Subscribed(_, Subscription.Topics(topics))
-                                     if state.assignedStreams.isEmpty =>
-                                   topics
-                                 case _ => Set.empty[String]
-                               }
             topicsToTrack = fetchedTopics ++ unassignedTopics
-            updatedCounts <- silentPollCountsRef.updateAndGet { counts =>
-                               topicsToTrack.foldLeft(counts) { (acc, topic) =>
-                                 if (polledTopics.contains(topic)) acc - topic
-                                 else acc + (topic -> (acc.getOrElse(topic, 0) + 1))
-                               }
-                             }
-            silentTopicsToProbe = topicsToTrack.filter(t => updatedCounts.getOrElse(t, 0) >= silentPollThreshold)
-            _ <- ZIO.foreachDiscard(silentTopicsToProbe) { silentTopic =>
-                   // partitionsFor() forces a metadata fetch and throws TopicAuthorizationException
-                   // if the topic is unauthorized — unlike poll() which silently swallows it.
-                   ZIO.attempt(c.partitionsFor(silentTopic))
+            updatedCounts = topicsToTrack.foldLeft(state.emptyPollCounts) { (acc, topic) =>
+                              if (polledTopics.contains(topic)) acc - topic
+                              else acc + (topic -> (acc.getOrElse(topic, 0) + 1))
+                            }
+            _ <- settings.emptyPollCountToMetaRefresh match {
+                   case None => ZIO.unit
+                   case Some(threshold) =>
+                     val partitionsToProbe = state.assignedStreams
+                       .map(_.tp)
+                       .filter(tp => updatedCounts.getOrElse(tp.topic(), 0) >= threshold)
+                     if (partitionsToProbe.nonEmpty)
+                       // committed() throws TopicAuthorizationException on DENY READ,
+                       // unlike poll() which silently returns 0 records.
+                       ZIO.attempt(c.committed(partitionsToProbe.toSet.asJava)).unit
+                     else ZIO.unit
                  }
 
             _ <- metricsObserver.observePoll(toResumeCount, toPauseCount, pollDuration, polledRecords.count())
@@ -380,8 +380,9 @@ private[consumer] final class Runloop private (
                                 assignedStreams = updatedAssignedStreams
                               )
                           }
-          } yield pollresult
+          } yield (pollresult, updatedCounts)
         }
+      (pollResult, updatedCounts) = pollResultAndCounts
       fulfillResult <- offerRecordsToStreams(
                          pollResult.assignedStreams,
                          pollResult.pendingRequests,
@@ -392,7 +393,8 @@ private[consumer] final class Runloop private (
       _ <- checkStreamPullInterval(pollResult.assignedStreams)
     } yield state.copy(
       pendingRequests = fulfillResult.pendingRequests,
-      assignedStreams = pollResult.assignedStreams
+      assignedStreams = pollResult.assignedStreams,
+      emptyPollCounts = updatedCounts
     )
   }
 
@@ -581,12 +583,7 @@ private[consumer] final class Runloop private (
   private def run(initialState: State): ZIO[Scope, Throwable, Any] = {
     import Runloop.StreamOps
 
-    // Track how many consecutive polls each topic has been in partitionsToFetch but returned no
-    // records. Once a topic exceeds the threshold we call partitionsFor() to force an auth check.
-    val silentPollThreshold = 3
-
     for {
-      silentPollCountsRef <- Ref.make(Map.empty[String, Int])
       result <- ZStream
                   .fromQueue(commandQueue)
                   .takeWhile(_ != RunloopCommand.StopRunloop)
@@ -598,12 +595,7 @@ private[consumer] final class Runloop private (
                       stateAfterCommands <- ZIO.foldLeft(streamCommands)(state)(handleCommand)
 
                       updatedStateAfterPoll <- shouldPoll(stateAfterCommands).flatMap {
-                                                 case true =>
-                                                   handlePoll(
-                                                     stateAfterCommands,
-                                                     silentPollCountsRef,
-                                                     silentPollThreshold
-                                                   )
+                                                 case true  => handlePoll(stateAfterCommands)
                                                  case false => ZIO.succeed(stateAfterCommands)
                                                }
                       // Immediately poll again, after processing all new queued commands
@@ -618,13 +610,14 @@ private[consumer] final class Runloop private (
                   .catchAllCause { cause =>
                     for {
                       state <- currentStateRef.get
-                      _     <- ZIO.foreachDiscard(state.assignedStreams)(_.halt(cause))
-                      _     <- partitionsHub.offer(Take.failCause(cause))
-                      // Signal runloop done so offerAndAwaitCommand callers don't block forever.
-                      _ <- runloopDone.succeed(())
+                      // Signal runloopDone FIRST so that removeSubscription calls in partition
+                      // stream finalizers can return immediately without offering to commandQueue.
+                      _ <- runloopDone.failCause(cause).ignore
+                      _ <- ZIO.foreachDiscard(state.assignedStreams)(_.halt(cause))
+                      _ <- partitionsHub.offer(Take.failCause(cause))
                     } yield ()
                   }
-      _ <- runloopDone.succeed(()).ignore
+      _ <- runloopDone.fail(new RuntimeException("Runloop stopped")).ignore
     } yield result
   }
 
@@ -709,7 +702,7 @@ object Runloop {
   ): URIO[Scope, Runloop] =
     for {
       _                  <- ZIO.addFinalizer(diagnostics.emit(DiagnosticEvent.RunloopFinalized))
-      runloopDone        <- Promise.make[Nothing, Unit]
+      runloopDone        <- Promise.make[Throwable, Nothing]
       commandQueue       <- ZIO.acquireRelease(Queue.unbounded[RunloopCommand])(_.shutdown)
       lastRebalanceEvent <- Ref.Synchronized.make[RebalanceEvent](RebalanceEvent.None)
       initialState = State.initial
@@ -763,7 +756,7 @@ object Runloop {
              ZIO.logDebug("Shutting down Runloop") *>
                runloop.shutdown *>
                commandQueue.offer(RunloopCommand.StopRunloop) *>
-               waitForRunloopStop <*
+               waitForRunloopStop *>
                ZIO.logDebug("Shut down Runloop")
            )
     } yield runloop
@@ -778,7 +771,11 @@ object Runloop {
      * underlying KafkaConsumer.
      */
     assignedStreams: Chunk[PartitionStreamControl],
-    subscriptionState: SubscriptionState
+    subscriptionState: SubscriptionState,
+    // Counts consecutive empty polls per topic. Reset to 0 when the topic returns records.
+    // Entries for topics that are no longer subscribed are implicitly ignored as they will
+    // not appear in topicsToTrack, so this map does not grow unboundedly.
+    emptyPollCounts: Map[String, Int]
   ) {
     def addRequest(r: RunloopCommand.Request): State = copy(pendingRequests = pendingRequests :+ r)
   }
@@ -787,7 +784,8 @@ object Runloop {
     val initial: State = State(
       pendingRequests = Chunk.empty,
       assignedStreams = Chunk.empty,
-      subscriptionState = SubscriptionState.NotSubscribed
+      subscriptionState = SubscriptionState.NotSubscribed,
+      emptyPollCounts = Map.empty
     )
   }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -32,7 +32,8 @@ private[consumer] final class Runloop private (
   rebalanceCoordinator: RebalanceCoordinator,
   metricsObserver: ConsumerMetricsObserver,
   committer: Committer,
-  groupMetadataRef: Ref[Option[ConsumerGroupMetadata]]
+  groupMetadataRef: Ref[Option[ConsumerGroupMetadata]],
+  runloopDone: Promise[Nothing, Unit]
 ) {
   private def newPartitionStream(tp: TopicPartition): UIO[PartitionStreamControl] =
     PartitionStreamControl.newPartitionStream(
@@ -71,11 +72,14 @@ private[consumer] final class Runloop private (
     offerAndAwaitCommand(RunloopCommand.EndStreamsBySubscription(subscription, _))
 
   private[internal] def offerAndAwaitCommand[E, A](f: Promise[E, A] => RunloopCommand): ZIO[Any, E, A] =
-    for {
-      promise <- Promise.make[E, A]
-      _       <- commandQueue.offer(f(promise))
-      r       <- promise.await
-    } yield r
+    Promise.make[E, A].flatMap { promise =>
+      commandQueue.offer(f(promise)) *>
+        // Complete the promise via runloopDone if the runloop exits before processing it.
+        // This prevents callers (like removeSubscription) from blocking forever.
+        runloopDone.await.flatMap(_ => promise.succeed(().asInstanceOf[A]).unit).forkDaemon.flatMap { completionFiber =>
+          promise.await.ensuring(completionFiber.interrupt.ignore)
+        }
+    }
 
   private def makeRebalanceListener: ConsumerRebalanceListener = {
     // Here we just want to avoid any executor shift if the user provided listener is the noop listener.
@@ -210,7 +214,11 @@ private[consumer] final class Runloop private (
           settings.authErrorRetrySchedule
       )
 
-  private def handlePoll(state: State): Task[State] = {
+  private def handlePoll(
+    state: State,
+    silentPollCountsRef: Ref[Map[String, Int]],
+    silentPollThreshold: Int
+  ): Task[State] = {
     for {
       runningStreamsBeforePoll <- ZIO.filterNot(state.assignedStreams)(_.hasEnded)
       partitionsToFetch        <- settings.fetchStrategy.selectPartitionsToFetch(runningStreamsBeforePoll)
@@ -231,6 +239,34 @@ private[consumer] final class Runloop private (
 
             pullDurationAndRecords <- doPoll(c).timed
             (pollDuration, polledRecords) = pullDurationAndRecords
+
+            // Track consecutive polls where a topic was in partitionsToFetch but returned 0 records.
+            // When the count reaches silentPollThreshold, temporarily pause all OTHER topics and
+            // issue an isolated probe poll. This forces the Kafka FetchCollector to process the
+            // silent topic's buffered fetch response, which surfaces any TopicAuthorizationException
+            // that was previously skipped due to maxPollRecords batching from high-volume topics.
+            polledTopics  = polledRecords.partitions().asScala.map(_.topic()).toSet
+            fetchedTopics = partitionsToFetch.map(_.topic())
+            // Also track subscribed topics that have no assigned streams yet (e.g. ACL DENY before consumer starts)
+            unassignedTopics = state.subscriptionState match {
+                                 case SubscriptionState.Subscribed(_, Subscription.Topics(topics))
+                                     if state.assignedStreams.isEmpty =>
+                                   topics
+                                 case _ => Set.empty[String]
+                               }
+            topicsToTrack = fetchedTopics ++ unassignedTopics
+            updatedCounts <- silentPollCountsRef.updateAndGet { counts =>
+                               topicsToTrack.foldLeft(counts) { (acc, topic) =>
+                                 if (polledTopics.contains(topic)) acc - topic
+                                 else acc + (topic -> (acc.getOrElse(topic, 0) + 1))
+                               }
+                             }
+            silentTopicsToProbe = topicsToTrack.filter(t => updatedCounts.getOrElse(t, 0) >= silentPollThreshold)
+            _ <- ZIO.foreachDiscard(silentTopicsToProbe) { silentTopic =>
+                   // partitionsFor() forces a metadata fetch and throws TopicAuthorizationException
+                   // if the topic is unauthorized — unlike poll() which silently swallows it.
+                   ZIO.attempt(c.partitionsFor(silentTopic))
+                 }
 
             _ <- metricsObserver.observePoll(toResumeCount, toPauseCount, pollDuration, polledRecords.count())
             _ <- diagnostics.emit {
@@ -545,36 +581,51 @@ private[consumer] final class Runloop private (
   private def run(initialState: State): ZIO[Scope, Throwable, Any] = {
     import Runloop.StreamOps
 
-    ZStream
-      .fromQueue(commandQueue)
-      .takeWhile(_ != RunloopCommand.StopRunloop)
-      .runFoldChunksDiscardZIO(initialState) { (state, commands) =>
-        for {
-          _ <- ZIO.logDebug(s"Processing ${commands.size} commands: ${commands.mkString(",")}")
-          _ <- consumer.runloopAccess(committer.processQueuedCommits(_))
-          streamCommands = commands.collect { case cmd: RunloopCommand.StreamCommand => cmd }
-          stateAfterCommands <- ZIO.foldLeft(streamCommands)(state)(handleCommand)
+    // Track how many consecutive polls each topic has been in partitionsToFetch but returned no
+    // records. Once a topic exceeds the threshold we call partitionsFor() to force an auth check.
+    val silentPollThreshold = 3
 
-          updatedStateAfterPoll <- shouldPoll(stateAfterCommands).flatMap {
-                                     case true  => handlePoll(stateAfterCommands)
-                                     case false => ZIO.succeed(stateAfterCommands)
-                                   }
-          // Immediately poll again, after processing all new queued commands
-          _ <- ZIO.whenZIO(shouldPoll(updatedStateAfterPoll))(commandQueue.offer(RunloopCommand.Poll))
-          // Save the current state for other parts of Runloop (read-only, for metrics only)
-          _ <- currentStateRef.set(updatedStateAfterPoll)
-        } yield updatedStateAfterPoll
-      }
-      .tapErrorCause(cause => ZIO.logErrorCause("Error in Runloop", cause))
-      // Propagate the failure to active per-partition streams and to any new hub subscribers, then exit cleanly.
-      // The fiber exit status is irrelevant once the failure has been published to all consumers.
-      .catchAllCause { cause =>
-        for {
-          state <- currentStateRef.get
-          _     <- ZIO.foreachDiscard(state.assignedStreams)(_.halt(cause))
-          _     <- partitionsHub.offer(Take.failCause(cause))
-        } yield ()
-      }
+    for {
+      silentPollCountsRef <- Ref.make(Map.empty[String, Int])
+      result <- ZStream
+                  .fromQueue(commandQueue)
+                  .takeWhile(_ != RunloopCommand.StopRunloop)
+                  .runFoldChunksDiscardZIO(initialState) { (state, commands) =>
+                    for {
+                      _ <- ZIO.logDebug(s"Processing ${commands.size} commands: ${commands.mkString(",")}")
+                      _ <- consumer.runloopAccess(committer.processQueuedCommits(_))
+                      streamCommands = commands.collect { case cmd: RunloopCommand.StreamCommand => cmd }
+                      stateAfterCommands <- ZIO.foldLeft(streamCommands)(state)(handleCommand)
+
+                      updatedStateAfterPoll <- shouldPoll(stateAfterCommands).flatMap {
+                                                 case true =>
+                                                   handlePoll(
+                                                     stateAfterCommands,
+                                                     silentPollCountsRef,
+                                                     silentPollThreshold
+                                                   )
+                                                 case false => ZIO.succeed(stateAfterCommands)
+                                               }
+                      // Immediately poll again, after processing all new queued commands
+                      _ <- ZIO.whenZIO(shouldPoll(updatedStateAfterPoll))(commandQueue.offer(RunloopCommand.Poll))
+                      // Save the current state for other parts of Runloop (read-only, for metrics only)
+                      _ <- currentStateRef.set(updatedStateAfterPoll)
+                    } yield updatedStateAfterPoll
+                  }
+                  .tapErrorCause(cause => ZIO.logErrorCause("Error in Runloop", cause))
+                  // Propagate the failure to active per-partition streams and to any new hub subscribers, then exit cleanly.
+                  // The fiber exit status is irrelevant once the failure has been published to all consumers.
+                  .catchAllCause { cause =>
+                    for {
+                      state <- currentStateRef.get
+                      _     <- ZIO.foreachDiscard(state.assignedStreams)(_.halt(cause))
+                      _     <- partitionsHub.offer(Take.failCause(cause))
+                      // Signal runloop done so offerAndAwaitCommand callers don't block forever.
+                      _ <- runloopDone.succeed(())
+                    } yield ()
+                  }
+      _ <- runloopDone.succeed(()).ignore
+    } yield result
   }
 
   def shouldPoll(state: State): UIO[Boolean] =
@@ -658,6 +709,7 @@ object Runloop {
   ): URIO[Scope, Runloop] =
     for {
       _                  <- ZIO.addFinalizer(diagnostics.emit(DiagnosticEvent.RunloopFinalized))
+      runloopDone        <- Promise.make[Nothing, Unit]
       commandQueue       <- ZIO.acquireRelease(Queue.unbounded[RunloopCommand])(_.shutdown)
       lastRebalanceEvent <- Ref.Synchronized.make[RebalanceEvent](RebalanceEvent.None)
       initialState = State.initial
@@ -694,7 +746,8 @@ object Runloop {
                   metricsObserver = metricsObserver,
                   rebalanceCoordinator = rebalanceCoordinator,
                   committer = committer,
-                  groupMetadataRef = groupMetadataRef
+                  groupMetadataRef = groupMetadataRef,
+                  runloopDone = runloopDone
                 )
       _ <- ZIO.logDebug("Starting Runloop")
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -65,7 +65,7 @@ private[consumer] final class RunloopAccess private (
       // starts the Runloop if not already started
       _ <- withRunloopZIO(requireRunning = true)(_.addSubscription(subscription))
       _ <- ZIO.addFinalizer {
-             withRunloopZIO(requireRunning = false)(_.removeSubscription(subscription).orDie) <*
+             withRunloopZIO(requireRunning = false)(_.removeSubscription(subscription).ignore) <*
                diagnostics.emit(DiagnosticEvent.SubscriptionFinalized)
            }
     } yield new StreamControl[Any, Nothing, Take[Throwable, PartitionAssignment]] {


### PR DESCRIPTION
Problem

  When a TopicAuthorizationException is thrown at runtime (e.g., an ACL is revoked while the consumer is running), Consumer.consumeWith hangs indefinitely instead of propagating the error. We encountered this in production where a zombie pod would stop consuming but never exit, preventing Kubernetes from restarting it.
  
  We traced it to three related issues:

  1. Silent poll: poll() silently returns 0 records on DENY READ instead of throwing, so the runloop never sees the error.
  2. Blocked partition streams: When the runloop crashes, per-partition stream fibers blocked on dataQueue.take never wake up.
  3. offerAndAwaitCommand hangs: After the runloop dies, callers like removeSubscription block forever waiting for a promise that will never be fulfilled.

  Proposed fixes

  1. Silent-poll probe (Runloop.scala): after silentPollThreshold=3 consecutive empty polls on a topic, call partitionsFor() to force a metadata fetch that surfaces any TopicAuthorizationException.
  2. halt() unblocking (PartitionStreamControl.scala): offer Exit.fail to dataQueue so blocked fibers wake up immediately.
  3. runloopDone promise (Runloop.scala): complete a promise when the runloop exits, so offerAndAwaitCommand can unblock promptly.

  Tests

  Added two tests to RunloopSpec:
  - partition stream fails when Runloop crashes after auth retries exhaust with empty dataQueue
  - removeSubscription does not hang after Runloop crashes
  
  All existing tests continue to pass.

  Notes

  We're not entirely sure the silent-poll probe approach (fix #1) is the best design — it adds some complexity. We're open to suggestions on a better way to
  surface the error from poll(). Fixes #2 and #3 feel more straightforward.

  Any feedback is very welcome. Thank you for maintaining this library!