### PR TITLE
Fix: removeSubscription hangs after Runloop crashes

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -245,6 +245,58 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
             }
           )
         }
+      },
+      test("removeSubscription does not hang in uninterruptible context after Runloop crashes") {
+        // Simulates ZIO.addFinalizer: removeSubscription is called inside ZIO.uninterruptible.
+        // A raceFirst-based fix would hang here because raceFirst tries to interrupt the losing
+        // fiber, but the interrupt is masked in uninterruptible context.
+        val authException = new TopicAuthorizationException("acl-denied")
+        val settings = consumerSettings
+          .withAuthErrorRetrySchedule(Schedule.recurs(0))
+          .withMetricsObserver(ConsumerMetricsObserver.NoOp)
+        withRunloop(settings = settings) { (mockConsumer, _, runloop) =>
+          val subscription = Subscription.Topics(Set(tp10.topic()))
+          mockConsumer.schedulePollTask { () =>
+            mockConsumer.setPollException(authException)
+          }
+          for {
+            _ <- runloop.addSubscription(subscription)
+            _ <- ZIO.sleep(2.seconds)
+            exit <- ZIO.uninterruptible {
+                      runloop.removeSubscription(subscription)
+                    }.timeout(5.seconds).exit
+          } yield assertTrue(
+            exit match {
+              case Exit.Success(None) => false
+              case _                  => true
+            }
+          )
+        }
+      },
+      test("endStreamsBySubscription does not hang in uninterruptible context after Runloop crashes") {
+        // Simulates StreamControl.end called from ZIO.addFinalizer (uninterruptible context).
+        val authException = new TopicAuthorizationException("acl-denied")
+        val settings = consumerSettings
+          .withAuthErrorRetrySchedule(Schedule.recurs(0))
+          .withMetricsObserver(ConsumerMetricsObserver.NoOp)
+        withRunloop(settings = settings) { (mockConsumer, _, runloop) =>
+          val subscription = Subscription.Topics(Set(tp10.topic()))
+          mockConsumer.schedulePollTask { () =>
+            mockConsumer.setPollException(authException)
+          }
+          for {
+            _ <- runloop.addSubscription(subscription)
+            _ <- ZIO.sleep(2.seconds)
+            exit <- ZIO.uninterruptible {
+                      runloop.endStreamsBySubscription(subscription)
+                    }.timeout(5.seconds).exit
+          } yield assertTrue(
+            exit match {
+              case Exit.Success(None) => false
+              case _                  => true
+            }
+          )
+        }
       }
     ) @@ withLiveClock
 

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -218,6 +218,33 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
             exit.causeOption.exists(_.squash == authException)
           )
         }
+      },
+      test("removeSubscription does not hang after Runloop crashes") {
+        val authException = new TopicAuthorizationException("acl-denied")
+        val settings = consumerSettings
+          .withAuthErrorRetrySchedule(Schedule.recurs(0))
+          .withMetricsObserver(ConsumerMetricsObserver.NoOp)
+        withRunloop(settings = settings) { (mockConsumer, _, runloop) =>
+          val subscription = Subscription.Topics(Set(tp10.topic()))
+          mockConsumer.schedulePollTask { () =>
+            mockConsumer.setPollException(authException)
+          }
+          for {
+            _ <- runloop.addSubscription(subscription)
+            // Wait for the runloop to crash
+            _ <- ZIO.sleep(2.seconds)
+            // removeSubscription calls offerAndAwaitCommand; without runloopDone it would hang forever
+            exit <- runloop.removeSubscription(subscription).timeout(5.seconds).exit
+          } yield assertTrue(
+            // Should complete promptly (not time out) now that runloopDone unblocks the command promise.
+            // When the runloop crashes, removeSubscription may fail with the runloop's error — that is
+            // acceptable: the key property is that it does NOT hang (i.e. the timeout does not fire).
+            exit match {
+              case Exit.Success(None) => false // timed out — the bug we are fixing
+              case _                  => true  // completed (success or failure) — not hung
+            }
+          )
+        }
       }
     ) @@ withLiveClock
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/PartitionStreamControl.scala
@@ -154,7 +154,7 @@ object PartitionStreamControl {
         for {
           _     <- requestData
           _     <- diagnostics.emit(DiagnosticEvent.Request(tp))
-          taken <- dataQueue.take.raceFirst(interruptionPromise.await).mapError(Option.apply).unexit
+          taken <- dataQueue.take.raceFirst(interruptionPromise.await.mapError(Option.apply)).unexit
         } yield taken
       notEnded = hasEndedRef.get.negate
 
@@ -172,7 +172,8 @@ object PartitionStreamControl {
                  ZStream.repeatZIOOption {
                    // First try to take a chunk of records that are available right now.
                    // When no data is available, request more data and await its arrival.
-                   dataQueue.poll.flatMap {
+                   // Race with interruptionPromise so that halt() unblocks this path immediately.
+                   dataQueue.poll.raceFirst(interruptionPromise.await.mapError(Option.apply)).flatMap {
                      case None       => requestAndAwaitData
                      case Some(exit) => exit
                    }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -32,7 +32,8 @@ private[consumer] final class Runloop private (
   rebalanceCoordinator: RebalanceCoordinator,
   metricsObserver: ConsumerMetricsObserver,
   committer: Committer,
-  groupMetadataRef: Ref[Option[ConsumerGroupMetadata]]
+  groupMetadataRef: Ref[Option[ConsumerGroupMetadata]],
+  runloopDone: Promise[Throwable, Nothing]
 ) {
   private def newPartitionStream(tp: TopicPartition): UIO[PartitionStreamControl] =
     PartitionStreamControl.newPartitionStream(
@@ -67,14 +68,27 @@ private[consumer] final class Runloop private (
   private[internal] def removeSubscription(subscription: Subscription): Task[Unit] =
     offerAndAwaitCommand(RunloopCommand.RemoveSubscription(subscription, _))
 
-  private[internal] def endStreamsBySubscription(subscription: Subscription): UIO[Unit] =
+  private[internal] def endStreamsBySubscription(subscription: Subscription): Task[Unit] =
     offerAndAwaitCommand(RunloopCommand.EndStreamsBySubscription(subscription, _))
 
   private[internal] def offerAndAwaitCommand[E, A](f: Promise[E, A] => RunloopCommand): ZIO[Any, E, A] =
     for {
       promise <- Promise.make[E, A]
       _       <- commandQueue.offer(f(promise))
-      r       <- promise.await
+      // If the runloop already crashed (runloopDone completed before our offer was processed),
+      // `drainCommandQueue` may have already run and missed our command. Fail the promise now so
+      // `promise.await` below does not block forever. The `asInstanceOf` is safe: all command
+      // error types (InvalidSubscriptionUnion, Throwable) are subtypes of Throwable, and ZIO
+      // stores Cause[E] as-is without type-erased differences at runtime.
+      _ <- runloopDone.isDone.flatMap { done =>
+             if (done)
+               runloopDone.await.exit.flatMap {
+                 case Exit.Failure(cause) => promise.failCause(cause.asInstanceOf[Cause[E]]).unit
+                 case _                   => ZIO.unit
+               }
+             else ZIO.unit
+           }
+      r <- promise.await
     } yield r
 
   private def makeRebalanceListener: ConsumerRebalanceListener = {
@@ -573,13 +587,28 @@ private[consumer] final class Runloop private (
           state <- currentStateRef.get
           _     <- ZIO.foreachDiscard(state.assignedStreams)(_.halt(cause))
           _     <- partitionsHub.offer(Take.failCause(cause))
+          _     <- runloopDone.failCause(cause).ignore
+          _     <- drainCommandQueue(cause)
         } yield ()
       }
+      .zipLeft(runloopDone.fail(new RuntimeException("Consumer shutting down")).ignore)
   }
 
   def shouldPoll(state: State): UIO[Boolean] =
     committer.pendingCommitCount.map { pendingCommitCount =>
       state.subscriptionState.isSubscribed && (state.pendingRequests.nonEmpty || pendingCommitCount > 0 || state.assignedStreams.isEmpty)
+    }
+
+  // Fail all pending promise-bearing commands so that any callers waiting on them are unblocked immediately.
+  private def drainCommandQueue(cause: Cause[Throwable]): UIO[Unit] =
+    commandQueue.takeAll.flatMap { commands =>
+      ZIO.foreachDiscard(commands) {
+        case RunloopCommand.AddSubscription(_, cont) =>
+          cont.failCause(cause.asInstanceOf[Cause[InvalidSubscriptionUnion]]).unit
+        case RunloopCommand.RemoveSubscription(_, cont)       => cont.failCause(cause).unit
+        case RunloopCommand.EndStreamsBySubscription(_, cont) => cont.failCause(cause).unit
+        case _                                                => ZIO.unit
+      }
     }
 
   private def observeRunloopMetrics(runloopMetricsSchedule: Schedule[Any, Unit, Long]): ZIO[Any, Nothing, Unit] = {
@@ -658,6 +687,7 @@ object Runloop {
   ): URIO[Scope, Runloop] =
     for {
       _                  <- ZIO.addFinalizer(diagnostics.emit(DiagnosticEvent.RunloopFinalized))
+      runloopDone        <- Promise.make[Throwable, Nothing]
       commandQueue       <- ZIO.acquireRelease(Queue.unbounded[RunloopCommand])(_.shutdown)
       lastRebalanceEvent <- Ref.Synchronized.make[RebalanceEvent](RebalanceEvent.None)
       initialState = State.initial
@@ -694,7 +724,8 @@ object Runloop {
                   metricsObserver = metricsObserver,
                   rebalanceCoordinator = rebalanceCoordinator,
                   committer = committer,
-                  groupMetadataRef = groupMetadataRef
+                  groupMetadataRef = groupMetadataRef,
+                  runloopDone = runloopDone
                 )
       _ <- ZIO.logDebug("Starting Runloop")
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -58,7 +58,7 @@ private[consumer] final class Runloop private (
         )
         .unit
 
-  private[internal] def addSubscription(subscription: Subscription): IO[InvalidSubscriptionUnion, Unit] =
+  private[internal] def addSubscription(subscription: Subscription): Task[Unit] =
     for {
       _ <- ZIO.logDebug(s"Add subscription $subscription")
       _ <- offerAndAwaitCommand(RunloopCommand.AddSubscription(subscription, _))
@@ -71,24 +71,16 @@ private[consumer] final class Runloop private (
   private[internal] def endStreamsBySubscription(subscription: Subscription): Task[Unit] =
     offerAndAwaitCommand(RunloopCommand.EndStreamsBySubscription(subscription, _))
 
-  private[internal] def offerAndAwaitCommand[E, A](f: Promise[E, A] => RunloopCommand): ZIO[Any, E, A] =
+  private[internal] def offerAndAwaitCommand[E <: Throwable, A](f: Promise[E, A] => RunloopCommand): Task[A] =
     for {
       promise <- Promise.make[E, A]
       _       <- commandQueue.offer(f(promise))
-      // If the runloop already crashed (runloopDone completed before our offer was processed),
-      // `drainCommandQueue` may have already run and missed our command. Fail the promise now so
-      // `promise.await` below does not block forever. The `asInstanceOf` is safe: all command
-      // error types (InvalidSubscriptionUnion, Throwable) are subtypes of Throwable, and ZIO
-      // stores Cause[E] as-is without type-erased differences at runtime.
-      _ <- runloopDone.isDone.flatMap { done =>
-             if (done)
-               runloopDone.await.exit.flatMap {
-                 case Exit.Failure(cause) => promise.failCause(cause.asInstanceOf[Cause[E]]).unit
-                 case _                   => ZIO.unit
-               }
-             else ZIO.unit
+      // The runloop might not see the offered command when it already completed. In that case we fail the promise
+      // immediately so that `promise.await` does not block forever.
+      r <- runloopDone.isDone.flatMap {
+             case true  => runloopDone.await
+             case false => promise.await
            }
-      r <- promise.await
     } yield r
 
   private def makeRebalanceListener: ConsumerRebalanceListener = {
@@ -544,7 +536,7 @@ private[consumer] final class Runloop private (
 
   /**
    * Poll behavior:
-   *   - Run until the StopRunloop command is received
+   *   - Run on every command until the StopRunloop command is received
    *   - Process all currently queued Commits
    *   - Process all currently queued commands
    *   - Poll the Kafka broker
@@ -553,6 +545,9 @@ private[consumer] final class Runloop private (
    *     - Poll continuously when there are (still) unfulfilled requests or pending commits
    *     - Poll periodically when we are subscribed but do not have assigned streams yet. This happens after
    *       initialization and rebalancing
+   *   - When ending (due to stop command or error):
+   *     - Signal that the runloop is done to prevent new commands
+   *     - Drain remaining commands
    *
    * Note that this method is executed on a dedicated single-thread Executor
    */
@@ -581,35 +576,42 @@ private[consumer] final class Runloop private (
       }
       .tapErrorCause(cause => ZIO.logErrorCause("Error in Runloop", cause))
       // Propagate the failure to active per-partition streams and to any new hub subscribers, then exit cleanly.
-      // The fiber exit status is irrelevant once the failure has been published to all consumers.
       .catchAllCause { cause =>
         for {
           state <- currentStateRef.get
           _     <- ZIO.foreachDiscard(state.assignedStreams)(_.halt(cause))
           _     <- partitionsHub.offer(Take.failCause(cause))
-          _     <- runloopDone.failCause(cause).ignore
           _     <- drainCommandQueue(cause)
         } yield ()
       }
-      .zipLeft(runloopDone.fail(new RuntimeException("Consumer shutting down")).ignore)
+      .zipLeft {
+        drainCommandQueue(Cause.fail(new RuntimeException("Consumer shutting down") with NoStackTrace))
+      }
+    // The fiber exit status is irrelevant; failures are observed via the per-partition streams.
   }
 
-  def shouldPoll(state: State): UIO[Boolean] =
+  private def shouldPoll(state: State): UIO[Boolean] =
     committer.pendingCommitCount.map { pendingCommitCount =>
       state.subscriptionState.isSubscribed && (state.pendingRequests.nonEmpty || pendingCommitCount > 0 || state.assignedStreams.isEmpty)
     }
 
-  // Fail all pending promise-bearing commands so that any callers waiting on them are unblocked immediately.
+  /**
+   * Signal end of runloop and fail all pending command promises still sitting in commandQueue so that callers in
+   * `offerAndAwaitCommand` are not left waiting forever after the runloop exits.
+   */
   private def drainCommandQueue(cause: Cause[Throwable]): UIO[Unit] =
-    commandQueue.takeAll.flatMap { commands =>
-      ZIO.foreachDiscard(commands) {
-        case RunloopCommand.AddSubscription(_, cont) =>
-          cont.failCause(cause.asInstanceOf[Cause[InvalidSubscriptionUnion]]).unit
-        case RunloopCommand.RemoveSubscription(_, cont)       => cont.failCause(cause).unit
-        case RunloopCommand.EndStreamsBySubscription(_, cont) => cont.failCause(cause).unit
-        case _                                                => ZIO.unit
+    runloopDone.failCause(cause).ignore *>
+      commandQueue.takeAll.flatMap { commands =>
+        ZIO.foreachDiscard(commands) {
+          case RunloopCommand.AddSubscription(_, cont)          => cont.failCause(cause).unit
+          case RunloopCommand.RemoveSubscription(_, cont)       => cont.failCause(cause).unit
+          case RunloopCommand.EndStreamsBySubscription(_, cont) => cont.failCause(cause).unit
+          // Explicitly list the other commands to ensure new commands are handled correctly
+          case RunloopCommand.CommitAvailable | RunloopCommand.Poll | RunloopCommand.RemoveAllSubscriptions |
+              RunloopCommand.Request(_) | RunloopCommand.StopAllStreams | RunloopCommand.StopRunloop =>
+            ZIO.unit
+        }
       }
-    }
 
   private def observeRunloopMetrics(runloopMetricsSchedule: Schedule[Any, Unit, Long]): ZIO[Any, Nothing, Unit] = {
     val observe = for {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -58,14 +58,14 @@ private[consumer] final class RunloopAccess private (
    */
   def subscribe(
     subscription: Subscription
-  ): ZIO[Scope, InvalidSubscriptionUnion, StreamControl[Any, Nothing, Take[Throwable, PartitionAssignment]]] =
+  ): ZIO[Scope, Throwable, StreamControl[Any, Nothing, Take[Throwable, PartitionAssignment]]] =
     for {
       ended                     <- Promise.make[Nothing, Unit] // For ending the stream of partition streams
       partitionAssignmentStream <- ZStream.fromHubScoped(partitionHub)
       // starts the Runloop if not already started
       _ <- withRunloopZIO(requireRunning = true)(_.addSubscription(subscription))
       _ <- ZIO.addFinalizer {
-             withRunloopZIO(requireRunning = false)(_.removeSubscription(subscription).orDie) <*
+             withRunloopZIO(requireRunning = false)(_.removeSubscription(subscription).ignore) <*
                diagnostics.emit(DiagnosticEvent.SubscriptionFinalized)
            }
     } yield new StreamControl[Any, Nothing, Take[Throwable, PartitionAssignment]] {
@@ -73,7 +73,9 @@ private[consumer] final class RunloopAccess private (
         ended
       ) // This also prevents any partitions assigned during a rebalance after initiating the graceful shutdown to be consumed
       override def end =
-        ended.succeed(()).ignore *> withRunloopZIO(requireRunning = false)(_.endStreamsBySubscription(subscription))
+        ended.succeed(()).ignore *> withRunloopZIO(requireRunning = false)(
+          _.endStreamsBySubscription(subscription).ignore
+        )
 
     }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
@@ -25,8 +25,7 @@ object RunloopCommand {
   /** Used by a stream to request more records. */
   final case class Request(tp: TopicPartition) extends StreamCommand
 
-  final case class AddSubscription(subscription: Subscription, cont: Promise[InvalidSubscriptionUnion, Unit])
-      extends StreamCommand {
+  final case class AddSubscription(subscription: Subscription, cont: Promise[Throwable, Unit]) extends StreamCommand {
     @inline def succeed: UIO[Unit]                           = cont.succeed(()).unit
     @inline def fail(e: InvalidSubscriptionUnion): UIO[Unit] = cont.fail(e).unit
   }

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopCommand.scala
@@ -32,7 +32,7 @@ object RunloopCommand {
   }
   final case class RemoveSubscription(subscription: Subscription, cont: Promise[Throwable, Unit]) extends StreamCommand
 
-  final case class EndStreamsBySubscription(subscription: Subscription, cont: Promise[Nothing, Unit])
+  final case class EndStreamsBySubscription(subscription: Subscription, cont: Promise[Throwable, Unit])
       extends StreamCommand {
     @inline def succeed: UIO[Unit] = cont.succeed(()).unit
   }


### PR DESCRIPTION
The consumer doesn't always cleanly shut down after errors.

## Problem

When the Runloop crashes (e.g. after `TopicAuthorizationException` exhausts retries), scope finalizers for active subscriptions call `removeSubscription` → `offerAndAwaitCommand`. At this point the `Runloop.make` scope finalizer may be concurrently shutting down the `commandQueue`.  This causes `commandQueue.offer` to block, leaving `removeSubscription` hung indefinitely, never aborting the partition stream, letting `Consumer.consumeWith` hang forever.

## Fixes

1. Add `runloopDone: Promise[Throwable, Nothing]` that is completed (failed with the runloop cause) when the runloop exits. `offerAndAwaitCommand` offers the command and then checks `runloopDone.isDone` to see if the commands promise will ever be fulfilled:
  - If already done → don't wait on the command promise and return `runloopDone.await` directly
  - If not done → wait for `promise.await` (Note: this is wrong (caused by patch requested by maintainer (sorry)), we should race against `runloopDone.await` as well, to be fixed in next PR.) Update: fixed in #1733.

2. Ensure partition stream control can always end by racing `interruptionPromise.await` also when polling for more data.

## Also

- `RunloopAccess` changed `removeSubscription.orDie` to `.ignore` since failure is expected when the runloop has already crashed.
- Small optimization in partition stream control (the `Some` wrapper is only needed in error path).
- Method `shouldPoll` made private.

## Tests

Added `RunloopSpec` test: removeSubscription does not hang after Runloop crashes — verifies that `removeSubscription` completes promptly (does not time out) after the runloop crashes.