### PR TITLE
Feature: opt-in detection of TopicAuthorizationException after silent poll

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -297,6 +297,53 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
             }
           )
         }
+      },
+      test("emptyPollCountToMetaRefresh detects TopicAuthorizationException via committed() after N empty polls") {
+        // Verifies that when poll() silently returns 0 records (as Kafka does on ACL DENY READ),
+        // the runloop detects the authorization failure via committed() after the configured threshold.
+        val authException = new TopicAuthorizationException("acl-denied")
+        // Subclass MockConsumer to make committed() throw on demand.
+        @volatile var throwOnCommitted = false
+        val mockConsumer: BinaryMockConsumer = new BinaryMockConsumer("latest") {
+          override def committed(
+            partitions: java.util.Set[TopicPartition]
+          ): java.util.Map[TopicPartition, org.apache.kafka.clients.consumer.OffsetAndMetadata] =
+            if (throwOnCommitted) throw authException
+            else super.committed(partitions)
+        }
+        val settings = consumerSettings
+          .withAuthErrorRetrySchedule(Schedule.recurs(0))
+          .withMetricsObserver(ConsumerMetricsObserver.NoOp)
+          .withEmptyPollCountToMetaRefresh(3) // probe committed() after 3 consecutive empty polls
+        withRunloop(mockConsumer = mockConsumer, settings = settings) { (_, partitionsHub, runloop) =>
+          // Poll 1: assign tp10 with no records — empty-poll counter reaches 1.
+          mockConsumer.schedulePollTask { () =>
+            mockConsumer.updateEndOffsets(Map(tp10 -> Long.box(0L)).asJava)
+            mockConsumer.rebalance(Seq(tp10).asJava)
+          }
+          // Poll 2: empty — counter reaches 2.
+          mockConsumer.schedulePollTask(() => ())
+          // Poll 3: arm the committed() exception — counter reaches 3 (= threshold),
+          // committed() is called and throws TopicAuthorizationException, crashing the runloop.
+          mockConsumer.schedulePollTask { () =>
+            throwOnCommitted = true
+          }
+          for {
+            streamStream <- ZStream.fromHubScoped(partitionsHub)
+            _            <- runloop.addSubscription(Subscription.Topics(Set(tp10.topic())))
+            exit <- streamStream
+                      .map(_.exit)
+                      .flattenExitOption
+                      .flattenChunks
+                      .flatMapPar(Int.MaxValue) { case (_, stream) => stream }
+                      .runDrain
+                      .timeout(10.seconds)
+                      .exit
+          } yield assertTrue(
+            // The stream should fail with the auth exception surfaced by committed(), not time out.
+            exit.causeOption.exists(_.squash == authException)
+          )
+        }
       }
     ) @@ withLiveClock
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -38,7 +38,8 @@ final case class ConsumerSettings(
   runloopMetricsSchedule: Schedule[Any, Unit, Long] = Schedule.fixed(500.millis),
   authErrorRetrySchedule: Schedule[Any, Throwable, Any] = Schedule.recurs(5) && Schedule.spaced(500.millis),
   maxStreamPullIntervalOption: Option[Duration] = None,
-  diagnostics: Consumer.ConsumerDiagnostics = Consumer.NoDiagnostics
+  diagnostics: Consumer.ConsumerDiagnostics = Consumer.NoDiagnostics,
+  emptyPollCountToMetaRefresh: Option[Int] = None
 ) {
 
   /**
@@ -346,6 +347,22 @@ final case class ConsumerSettings(
    */
   def withAuthErrorRetrySchedule(authErrorRetrySchedule: Schedule[Any, Throwable, Any]): ConsumerSettings =
     copy(authErrorRetrySchedule = authErrorRetrySchedule)
+
+  /**
+   * When set, enables a metadata-refresh probe after this many consecutive empty polls for a topic.
+   *
+   * After `n` consecutive polls where a subscribed topic returned no records, `committed()` is called for the assigned
+   * partitions of that topic to force a broker round-trip. This surfaces any
+   * [[org.apache.kafka.common.errors.TopicAuthorizationException]] that `poll()` would otherwise swallow silently when
+   * a READ ACL is denied at runtime.
+   *
+   * Set to `None` (the default) to disable the probe. A value of `3` is a reasonable starting point.
+   *
+   * Note: users subscribing to a very large number of topics may want to set a higher value or leave this disabled,
+   * since each probe issues a request to the broker.
+   */
+  def withEmptyPollCountToMetaRefresh(count: Int): ConsumerSettings =
+    copy(emptyPollCountToMetaRefresh = Some(count))
 
   /**
    * Controls how to consume records produced transactionally.

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -259,11 +259,13 @@ private[consumer] final class Runloop private (
                                    .map(_.tp)
                                    .filter(tp => counts.getOrElse(tp.topic(), 0) >= threshold)
                                    .distinctBy(_.topic())
-                                 (if (partitionsToProbe.nonEmpty)
-                                    // committed() throws TopicAuthorizationException on DENY READ,
-                                    // unlike poll() which silently returns 0 records.
-                                    ZIO.attempt(c.committed(partitionsToProbe.toSet.asJava)).unit
-                                  else ZIO.unit).as(counts)
+                                 if (partitionsToProbe.nonEmpty)
+                                   // committed() throws TopicAuthorizationException on DENY READ,
+                                   // unlike poll() which silently returns 0 records.
+                                   ZIO
+                                     .attempt(c.committed(partitionsToProbe.toSet.asJava))
+                                     .as(counts -- partitionsToProbe.map(_.topic()))
+                                 else ZIO.succeed(counts)
                              }
 
             _ <- metricsObserver.observePoll(toResumeCount, toPauseCount, pollDuration, polledRecords.count())

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -226,7 +226,7 @@ private[consumer] final class Runloop private (
                s" resuming ${partitionsToFetch.size} out of ${state.assignedStreams.size} partitions"
            )
       _ <- currentStateRef.set(state)
-      pollResult <-
+      pollResultAndCounts <-
         consumer.runloopAccess { c =>
           for {
             assignment <- ZIO.attempt(c.assignment())
@@ -236,6 +236,40 @@ private[consumer] final class Runloop private (
 
             pullDurationAndRecords <- doPoll(c).timed
             (pollDuration, polledRecords) = pullDurationAndRecords
+
+            // When emptyPollCountToMetaRefresh is set, track consecutive empty polls per topic.
+            // Once the count reaches the threshold, call committed() to force a broker round-trip
+            // that surfaces any TopicAuthorizationException that poll() would otherwise swallow silently.
+            // All bookkeeping is skipped when the setting is None to avoid overhead for users that
+            // do not use topic-level ACLs.
+            updatedCounts <- settings.emptyPollCountToMetaRefresh match {
+                               case None => ZIO.succeed(state.emptyPollCounts)
+                               case Some(threshold) =>
+                                 val polledTopics  = polledRecords.partitions().asScala.map(_.topic()).toSet
+                                 val fetchedTopics = partitionsToFetch.map(_.topic())
+                                 // Also include subscribed topics with no assigned streams yet
+                                 // (e.g. ACL DENY before the consumer group has joined).
+                                 val unassignedTopics: Set[String] = state.subscriptionState match {
+                                   case SubscriptionState.Subscribed(_, Subscription.Topics(topics))
+                                       if state.assignedStreams.isEmpty =>
+                                     topics
+                                   case _ => Set.empty
+                                 }
+                                 val topicsToTrack = fetchedTopics ++ unassignedTopics
+                                 val counts = topicsToTrack.foldLeft(state.emptyPollCounts) { (acc, topic) =>
+                                   if (polledTopics.contains(topic)) acc - topic
+                                   else acc + (topic -> (acc.getOrElse(topic, 0) + 1))
+                                 }
+                                 val partitionsToProbe = state.assignedStreams
+                                   .map(_.tp)
+                                   .filter(tp => counts.getOrElse(tp.topic(), 0) >= threshold)
+                                   .distinctBy(_.topic())
+                                 (if (partitionsToProbe.nonEmpty)
+                                    // committed() throws TopicAuthorizationException on DENY READ,
+                                    // unlike poll() which silently returns 0 records.
+                                    ZIO.attempt(c.committed(partitionsToProbe.toSet.asJava)).unit
+                                  else ZIO.unit).as(counts)
+                             }
 
             _ <- metricsObserver.observePoll(toResumeCount, toPauseCount, pollDuration, polledRecords.count())
             _ <- diagnostics.emit {
@@ -349,8 +383,9 @@ private[consumer] final class Runloop private (
                                 assignedStreams = updatedAssignedStreams
                               )
                           }
-          } yield pollresult
+          } yield (pollresult, updatedCounts)
         }
+      (pollResult, updatedCounts) = pollResultAndCounts
       fulfillResult <- offerRecordsToStreams(
                          pollResult.assignedStreams,
                          pollResult.pendingRequests,
@@ -361,7 +396,8 @@ private[consumer] final class Runloop private (
       _ <- checkStreamPullInterval(pollResult.assignedStreams)
     } yield state.copy(
       pendingRequests = fulfillResult.pendingRequests,
-      assignedStreams = pollResult.assignedStreams
+      assignedStreams = pollResult.assignedStreams,
+      emptyPollCounts = updatedCounts
     )
   }
 
@@ -757,7 +793,11 @@ object Runloop {
      * underlying KafkaConsumer.
      */
     assignedStreams: Chunk[PartitionStreamControl],
-    subscriptionState: SubscriptionState
+    subscriptionState: SubscriptionState,
+    // Counts consecutive empty polls per topic. Reset to 0 when the topic returns records.
+    // Entries for topics no longer subscribed are implicitly ignored as they will not appear
+    // in topicsToTrack, so this map does not grow unboundedly.
+    emptyPollCounts: Map[String, Int]
   ) {
     def addRequest(r: RunloopCommand.Request): State = copy(pendingRequests = pendingRequests :+ r)
   }
@@ -766,7 +806,8 @@ object Runloop {
     val initial: State = State(
       pendingRequests = Chunk.empty,
       assignedStreams = Chunk.empty,
-      subscriptionState = SubscriptionState.NotSubscribed
+      subscriptionState = SubscriptionState.NotSubscribed,
+      emptyPollCounts = Map.empty
     )
   }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -247,16 +247,7 @@ private[consumer] final class Runloop private (
                                case Some(threshold) =>
                                  val polledTopics  = polledRecords.partitions().asScala.map(_.topic()).toSet
                                  val fetchedTopics = partitionsToFetch.map(_.topic())
-                                 // Also include subscribed topics with no assigned streams yet
-                                 // (e.g. ACL DENY before the consumer group has joined).
-                                 val unassignedTopics: Set[String] = state.subscriptionState match {
-                                   case SubscriptionState.Subscribed(_, Subscription.Topics(topics))
-                                       if state.assignedStreams.isEmpty =>
-                                     topics
-                                   case _ => Set.empty
-                                 }
-                                 val topicsToTrack = fetchedTopics ++ unassignedTopics
-                                 val counts = topicsToTrack.foldLeft(state.emptyPollCounts) { (acc, topic) =>
+                                 val counts = fetchedTopics.foldLeft(state.emptyPollCounts) { (acc, topic) =>
                                    if (polledTopics.contains(topic)) acc - topic
                                    else acc + (topic -> (acc.getOrElse(topic, 0) + 1))
                                  }


### PR DESCRIPTION
# Problem

When a `READ ACL` is revoked at runtime, `poll()` silently returns `0` records for the affected topic instead of throwing `TopicAuthorizationException`. This leaves `Consumer.consumeWith` running indefinitely with no indication that authorization has been lost.

# Fix

Add `ConsumerSettings.withEmptyPollCountToMetaRefresh(n: Int)`: after n consecutive polls where a subscribed topic returned no records, call `committed()` for the assigned partitions of that topic. Method `committed()` throws `TopicAuthorizationException` on `DENY READ`, unlike `poll()` which swallows it silently.

The feature is disabled by default (`None`) — there is no overhead for users who do not use topic-level ACLs. All bookkeeping (Set operations, counter updates, committed() calls) is skipped entirely when the setting is not set.

The empty-poll count is tracked in `State.emptyPollCounts: Map[String, Int]` per topic, and reset when the topic returns records.

# Notes
  
- `committed()` was chosen over `partitionsFor()` because it throws on `DENY READ`, while `partitionsFor()` only throws on `DENY DESCRIBE`.
- Users subscribing to a very large number of low volume topics should set a higher threshold or leave this disabled.
