### PR TITLE
Fix: removeSubscription hangs after Runloop crashes - followup 3

### DIFF
--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -71,14 +71,18 @@ private[consumer] final class Runloop private (
   private[internal] def endStreamsBySubscription(subscription: Subscription): Task[Unit] =
     offerAndAwaitCommand(RunloopCommand.EndStreamsBySubscription(subscription, _))
 
-  private[internal] def offerAndAwaitCommand[E <: Throwable, A](f: Promise[E, A] => RunloopCommand): Task[A] =
-    // This can be called from a finalizer (uninterruptible). However, raceFirst in an interruptible region
-    // won't work because we can't interrupt the loser.
-    ZIO.interruptible {
+  private[internal] def offerAndAwaitCommand[A](f: Promise[Throwable, A] => RunloopCommand): Task[A] =
+    // This method can be called from a finalizer (uninterruptible) as well as from regular code. We run the race
+    // in a separate (daemon) fiber that is explicitly interruptible, so that `raceFirst` can abort its losing
+    // await, and then `join` it uninterruptibly. This way a caller's interruption (e.g. the
+    // `runWithGracefulShutdown` finalizer) cannot abort the await before the runloop has processed the command,
+    // while the runloop can still cause us to stop waiting by completing `runloopDone`.
+    ZIO.uninterruptible {
       for {
-        promise <- Promise.make[E, A]
+        promise <- Promise.make[Throwable, A]
         _       <- commandQueue.offer(f(promise))
-        r       <- promise.await.raceFirst(runloopDone.await)
+        fiber   <- ZIO.interruptible(promise.await.raceFirst(runloopDone.await)).forkDaemon
+        r       <- fiber.join
       } yield r
     }
 


### PR DESCRIPTION
This is a followup of #1712 and #1733. Here we change `offerAndAwaitCommand` by awaiting both promises in an interruptible region on a separate fiber.