### PR TITLE
Fix flaky resume test

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/SubscriptionsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/SubscriptionsSpec.scala
@@ -3,6 +3,7 @@ package zio.kafka.consumer
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import zio._
 import zio.kafka.ZIOSpecDefaultSlf4j
+import zio.kafka.producer.Producer
 import zio.kafka.serde.Serde
 import zio.kafka.testkit.KafkaTestUtils
 import zio.kafka.testkit.{ Kafka, KafkaRandom }
@@ -264,7 +265,10 @@ object SubscriptionsSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
 
           _ <- KafkaTestUtils.createCustomTopic(topic1, partitionCount = 48) // Large number of partitions
 
-          producer <- KafkaTestUtils.makeProducer
+          // Idempotence is disabled: this test only needs the records in the topic, and an idempotent producer can
+          // livelock re-sending sequence 0 against the embedded broker (OutOfOrderSequenceException) until the test
+          // times out.
+          producer <- KafkaTestUtils.producerSettings.map(_.withIdempotence(false)).flatMap(Producer.make)
           _        <- KafkaTestUtils.produceMany(producer, topic1, kvs)
 
           recordsConsumed <- Ref.make(Chunk.empty[CommittableRecord[String, String]])

--- a/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/ProducerSettings.scala
@@ -68,6 +68,16 @@ final case class ProducerSettings(
     withProperties(compression.properties)
 
   /**
+   * @param idempotence
+   *   when `true` (the default) the producer writes idempotently: each record is assigned a sequence number so the
+   *   broker can deduplicate retries, guaranteeing exactly-once, in-order delivery per partition. Set to `false` to
+   *   disable sequence tracking (e.g. for tests, or high-throughput producing where occasional duplicates on retry are
+   *   acceptable).
+   */
+  def withIdempotence(idempotence: Boolean): ProducerSettings =
+    withProperty(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, idempotence.toString)
+
+  /**
    * @param sendBufferSize
    *   The maximum number of record chunks that can queue up while waiting for the underlying producer to become
    *   available. Performance critical users that publish a lot of records one by one (instead of in chunks), should


### PR DESCRIPTION
Test SubscriptionsSpec - can resume a stream for the same subscription sometimes overwhelms the embeded broker. This results in `OutOfOrderSequenceException` errors; the broker actually got the records while the client is not aware of that and starts an infinite retry loop. This is likely a java-kafka-client bug.

We work around the problem by disabling idempotence.

Also: make it easy to disabling idempotence by adding a helper method in ProducerSettings.