### PR TITLE
Support tombstone records in producer diagnostics

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/producer/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/producer/ProducerSpec.scala
@@ -123,6 +123,25 @@ object ProducerSpec extends ZIOSpecDefault {
             )
           )
         },
+        test("tombstone success") {
+          val mockBehavior = AsyncProducerTestSupport
+            .newMockBehavior[Array[Byte], Array[Byte]]()
+            .sendSucceed()
+            .callbackSucceed()
+          val recordToSend    = makeTombstoneProducerRecord()
+          val producedRecords = Chunk(ProducerEvent.ProducedRecord("testTopic", 0, ProducerEvent.NoValue))
+          for {
+            diagnostics      <- SlidingDiagnostics.make[ProducerEvent](100)
+            _                <- runSingleRecordTest(mockBehavior, recordToSend, diagnostics = diagnostics)
+            diagnosticEvents <- diagnostics.queue.takeAll
+          } yield assertTrue(
+            diagnosticEvents == Chunk(
+              ProducerEvent.RecordsOffered(0, producedRecords),
+              ProducerEvent.RecordsSent(0, producedRecords, Set.empty),
+              ProducerEvent.ProducerFinalized
+            )
+          )
+        },
         test("failure") {
           val mockBehavior = AsyncProducerTestSupport
             .newMockBehavior[Array[Byte], Array[Byte]]()
@@ -544,5 +563,11 @@ object ProducerSpec extends ZIOSpecDefault {
     value: String = "value"
   ): ProducerRecord[Array[Byte], Array[Byte]] =
     new ProducerRecord[Array[Byte], Array[Byte]](topic, key.getBytes, value.getBytes)
+
+  private def makeTombstoneProducerRecord(
+    topic: String = "testTopic",
+    key: String = "key"
+  ): ProducerRecord[Array[Byte], Array[Byte]] =
+    new ProducerRecord[Array[Byte], Array[Byte]](topic, key.getBytes, null)
 
 }

--- a/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/Producer.scala
@@ -622,9 +622,11 @@ private[producer] final class ProducerLive(
       makeDiagnosticsEmitter(Chunk.single(record))
 
     override def makeDiagnosticsEmitter(records: Chunk[ByteRecord]): DiagnosticsEmitter = {
+      def length(recordValue: Array[Byte]): Int =
+        if (recordValue != null) recordValue.length else ProducerEvent.NoValue
       val batchId = batchIds.getAndIncrement()
       val producedRecords =
-        records.map(record => ProducerEvent.ProducedRecord(record.topic(), record.partition(), record.value().length))
+        records.map(record => ProducerEvent.ProducedRecord(record.topic(), record.partition(), length(record.value())))
       new BatchDiagnosticsEmitter(batchId, producedRecords)
     }
   }

--- a/zio-kafka/src/main/scala/zio/kafka/producer/ProducerEvent.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/ProducerEvent.scala
@@ -22,11 +22,14 @@ sealed trait ProducerEvent
  */
 object ProducerEvent {
 
+  /** Record value length for records that have no value. */
+  val NoValue = -1
+
   /**
    * Represents key data about a record that was handled by the producer.
    *
    * @param size
-   *   the size of the record's value
+   *   the size of the record's value in bytes, or [[NoValue]] (`-1`) when the record has no value
    */
   final case class ProducedRecord(topic: String, partition: Int, size: Int)
 


### PR DESCRIPTION
The producer diagnostics tried to get the length of every record, even for tombstone records (where the value is `null`) leading to a `NullPointerException`.

Fixes #1714.