### PR TITLE
Commit leaderEpoch

### DIFF
--- a/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/ProducerSpec.scala
@@ -15,6 +15,7 @@ import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
 
+import scala.jdk.OptionConverters.RichOptional
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 
@@ -648,7 +649,13 @@ object ProducerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
 
             aliceTopicPartition = new TopicPartition(topic, aliceHadMoneyCommittableRecord.partition)
             committedOffset <- consumer2.committed(Set(aliceTopicPartition)).map(_.get(aliceTopicPartition).flatten)
-          } yield assertTrue(committedOffset.exists(_.offset == 1L))
+            recordedEpoch  = aliceHadMoneyCommittableRecord.offset.leaderEpoch.toScala.map(Int.unbox)
+            committedEpoch = committedOffset.flatMap(_.leaderEpoch().toScala.map(Int.unbox))
+          } yield assertTrue(
+            committedOffset.exists(_.offset == 1L),
+            committedEpoch.exists(_ >= 0),
+            recordedEpoch == committedEpoch
+          )
         },
         test("not committing offsets after a failed transaction") {
           for {

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -26,6 +26,7 @@ import zio.test._
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import scala.jdk.OptionConverters.RichOptional
 import scala.reflect.ClassTag
 
 //noinspection SimplifyAssertInspection
@@ -930,6 +931,41 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           offsets <- consumer.committed((0 until partitionCount).map(new TopicPartition(topic, _)).toSet)
         } yield assert(offsets.values.map(_.map(_.offset)))(forall(isSome(equalTo(nrMessages.toLong / partitionCount))))
       },
+      test("commits an offset with leader epoch") {
+        for {
+          topic  <- randomTopic
+          group  <- randomGroup
+          client <- randomClient
+
+          _        <- KafkaTestUtils.createCustomTopic(topic)
+          producer <- KafkaTestUtils.makeProducer
+          _        <- KafkaTestUtils.produceOne(producer, topic, "key", "msg")
+
+          // Consume messages
+          subscription = Subscription.topics(topic)
+          consumer         <- KafkaTestUtils.makeConsumer(client, Some(group))
+          recordedEpochRef <- Ref.make[Option[Int]](None)
+          _ <- consumer
+                 .plainStream(subscription, Serde.string, Serde.string)
+                 .mapZIO { record =>
+                   val epoch = record.record.leaderEpoch().toScala.map(Int.unbox)
+                   recordedEpochRef.set(epoch).as(record.offset)
+                 }
+                 .take(1)
+                 .transduce(Consumer.collectOffsets)
+                 .take(1)
+                 .mapZIO(_.commit)
+                 .runDrain
+          offsets       <- consumer.committed(Set(new TopicPartition(topic, 0)))
+          recordedEpoch <- recordedEpochRef.get
+          committedEpoch = offsets.values.headOption.flatten.flatMap { om =>
+                             om.leaderEpoch().toScala.map(Int.unbox)
+                           }
+        } yield assertTrue(
+          committedEpoch.exists(_ >= 0),
+          recordedEpoch == committedEpoch
+        )
+      },
       test("commits an offset with metadata") {
         for {
           topic    <- randomTopic
@@ -944,15 +980,15 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
           // Consume messages
           subscription = Subscription.topics(topic)
           consumer <- KafkaTestUtils.makeConsumer(client, Some(group))
-          offsets <- consumer
-                       .partitionedStream(subscription, Serde.string, Serde.string)
-                       .flatMap(_._2.map(_.offset.withMetadata(metadata)))
-                       .take(1)
-                       .transduce(Consumer.collectOffsets)
-                       .take(1)
-                       .mapZIO(_.commit)
-                       .runDrain *>
-                       consumer.committed(Set(new TopicPartition(topic, 0)))
+          _ <- consumer
+                 .partitionedStream(subscription, Serde.string, Serde.string)
+                 .flatMap(_._2.map(_.offset.withMetadata(metadata)))
+                 .take(1)
+                 .transduce(Consumer.collectOffsets)
+                 .take(1)
+                 .mapZIO(_.commit)
+                 .runDrain
+          offsets <- consumer.committed(Set(new TopicPartition(topic, 0)))
         } yield assert(offsets.values.headOption.flatten.map(_.metadata))(isSome(equalTo(metadata)))
       },
       test("access to the java consumer must be fair") {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/CommittableRecord.scala
@@ -42,6 +42,7 @@ final case class CommittableRecord[K, V](
     OffsetImpl(
       topic = record.topic(),
       partition = record.partition(),
+      leaderEpoch = record.leaderEpoch(),
       offset = record.offset(),
       commitHandle = commitHandle,
       consumerGroupMetadata = consumerGroupMetadata,

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Offset.scala
@@ -4,10 +4,13 @@ import org.apache.kafka.clients.consumer.{ ConsumerGroupMetadata, OffsetAndMetad
 import org.apache.kafka.common.TopicPartition
 import zio._
 
+import java.util.{ Optional => JOption }
+
 trait Offset {
 
   def topic: String
   def partition: Int
+  def leaderEpoch: JOption[Integer]
   def offset: Long
   def commit: Task[Unit]
   def batch: OffsetBatch
@@ -15,7 +18,9 @@ trait Offset {
   def withMetadata(metadata: String): Offset
 
   private[consumer] def metadata: Option[String]
-  private[consumer] def asJavaOffsetAndMetadata: OffsetAndMetadata = new OffsetAndMetadata(offset, metadata.orNull)
+
+  private[consumer] def asJavaOffsetAndMetadata: OffsetAndMetadata =
+    new OffsetAndMetadata(offset, leaderEpoch, metadata.orNull)
 
   /**
    * Attempts to commit and retries according to the given policy when the commit fails with a
@@ -44,6 +49,7 @@ object Offset {
 private final case class OffsetImpl(
   topic: String,
   partition: Int,
+  leaderEpoch: JOption[Integer],
   offset: Long,
   commitHandle: Map[TopicPartition, OffsetAndMetadata] => Task[Unit],
   consumerGroupMetadata: Option[ConsumerGroupMetadata],

--- a/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/producer/TransactionalProducer.scala
@@ -47,7 +47,7 @@ object TransactionalProducer {
             case Some(consumerGroupMetadata) =>
               val offsets: util.Map[TopicPartition, OffsetAndMetadata] =
                 offsetBatch.offsets.map { case (topicPartition, offset) =>
-                  topicPartition -> new OffsetAndMetadata(offset.offset + 1, offset.metadata)
+                  topicPartition -> new OffsetAndMetadata(offset.offset + 1, offset.leaderEpoch(), offset.metadata)
                 }.asJava
 
               ZIO.attemptBlocking(live.p.sendOffsetsToTransaction(offsets, consumerGroupMetadata))


### PR DESCRIPTION
When committing, include the optional `leaderEpoch`. This prevents consumers from fetching records from the wrong, outdated leader. See https://www.confluent.io/blog/guide-to-consumer-offsets for more details.