### PR TITLE
Support External offsets with leaderEpoch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import sbt.Def
 import MimaSettings.mimaSettings
+import org.typelevel.scalacoptions.ScalacOptions
 import scala.sys.process.*
 import scala.util.Try
 
@@ -54,7 +55,6 @@ inThisBuild(
     Test / fork              := true,
     run / fork               := true,
     ciJvmOptions ++= Seq("-Xms6G", "-Xmx6G", "-Xss4M", "-XX:+UseG1GC"),
-    tpolecatExcludeOptions += org.typelevel.scalacoptions.ScalacOptions.lintInferAny,
     scalafixDependencies ++= List(
       "com.github.vovapolu"                      %% "scaluzzi" % "0.1.23",
       "io.github.ghostbuster91.scalafix-unified" %% "unified"  % "0.0.9"
@@ -108,9 +108,8 @@ lazy val root = project
 def stdSettings(prjName: String) = Seq(
   name              := s"$prjName",
   scalafmtOnCompile := !insideCI.value,
-  Compile / compile / scalacOptions ++=
-    optionsOn("2.13")("-Wconf:cat=unused-nowarn:s").value,
-  scalacOptions -= "-Xlint:infer-any",
+  tpolecatExcludeOptions ++= Set(ScalacOptions.lintInferAny, ScalacOptions.deprecation),
+  tpolecatScalacOptions += ScalacOptions.warnOption("conf:cat=deprecation:s"),
   // workaround for bad constant pool issue
   (Compile / doc) := Def.taskDyn {
     val default = (Compile / doc).taskValue

--- a/docs/partition-assignment-and-offset-retrieval.md
+++ b/docs/partition-assignment-and-offset-retrieval.md
@@ -3,6 +3,8 @@ id: partition-assignment-and-offset-retrieval
 title: "Partition Assignment And Offset Retrieval"
 ---
 
+# Consumer partition assignment
+
 `zio-kafka` offers several ways to control which Kafka topics and partitions are assigned to your application.
 
 | Use case                                           | Method                                                  |
@@ -11,12 +13,29 @@ title: "Partition Assignment And Offset Retrieval"
 | Topics matching a pattern                          | `Subscription.pattern("topic.*")`                       |
 | Manual partition assignment                        | `Subscription.manual("my_topic" -> 1, "my_topic" -> 2)` |
 
-By default `zio-kafka` starts streaming a partition from the last committed offset for the consumer group, or the latest message on the topic if no offset has yet been committed. You can also choose to store offsets outside of Kafka. This can be useful in cases where consistency between data stores and consumer offset is required.
+The example `Subscription.manual("my_topic" -> 1, "my_topic" -> 2)` subscribes to partitions `1` and `2` of topic `my_topic`.
 
-| Use case                                                           | Method                                                                       |
-|--------------------------------------------------------------------|------------------------------------------------------------------------------|
-| Offsets in Kafka, start at latest message if no offset committed   | `OffsetRetrieval.Auto()`                                                     |
-| Offsets in Kafka, start at earliest message if no offset committed | `OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest)`                          |
-| Manual/external offset storage                                     | `Manual(getOffsets: Set[TopicPartition] => Task[Map[TopicPartition, Long]])` |
+# Consumer starting offsets / offset retrieval
 
-For manual offset retrieval, the `getOffsets` function is called for each topic-partition that is assigned to the consumer, either via Kafka's rebalancing or via a manual assignment.
+By default `zio-kafka` starts streaming a partition from the last committed offset for the active consumer group, or
+else the latest offset on the partition in case no offset has yet been committed.
+
+You can also choose to store offsets externally, outside of Kafka. This is useful when consistency between external
+data and the consumer offset is required. For example, you can store the offset in a transactional database together
+with the data that is derived from the record of that offset. Although it is optional, Kafka recommends you store a
+`leaderEpoch` together with the offset as it prevents consuming from a broker that is unaware it is no longer a leader.
+For more details about why leaderEpoch is important
+see https://www.confluent.io/blog/guide-to-consumer-offsets/#part-ii-in-depth-analysis-and-insights.
+
+| Use case                                                          | `OffsetRetrieval` method                                                              |
+|-------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| Offsets in Kafka, start at latest record if no offset committed   | `Auto()`                                                                              |
+| Offsets in Kafka, start at earliest record if no offset committed | `Auto(AutoOffsetStrategy.Earliest)`                                                   |
+| Offsets in Kafka, fail if no offset committed                     | `Auto(AutoOffsetStrategy.None)`                                                       |
+| External offset storage                                           | `External(getOffsets: Set[TopicPartition] => Task[Map[TopicPartition, OffsetEpoch]])` |
+
+For external offset retrieval, the `getOffsets` function is called for each topic-partition that is assigned to the
+consumer, either via Kafka's rebalancing or via a manual assignment.
+
+Offset retrieval is configured via `ConsumerSettings.withOffsetRetrieval()`. You can find more details in the scaladocs
+of that method.

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSettingsSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSettingsSpec.scala
@@ -7,6 +7,7 @@ import org.apache.kafka.clients.consumer.{
   RoundRobinAssignor
 }
 import zio._
+import zio.kafka.consumer.Consumer.OffsetRetrieval
 import zio.kafka.ZIOSpecDefaultSlf4j
 import zio.test._
 import zio.test.Assertion._
@@ -90,6 +91,16 @@ object ConsumerSettingsSpec extends ZIOSpecDefaultSlf4j {
             )
           }
             .reduce(_ && _)
+        },
+        test("rejects OffsetRetrieval.Manual") {
+          assertFailsWithIllegalArgumentException(
+            ConsumerSettings(List("host"))
+              .copy(offsetRetrieval = OffsetRetrieval.Manual(_ => ZIO.succeed(Map.empty)))
+              .validate,
+            "Invalid consumer settings: OffsetRetrieval.Manual is no longer supported. Switch to " +
+              "OffsetRetrieval.External, use OffsetRetrieval.Manual.toExternal to convert an existing Manual " +
+              "implementation, or use ConsumerSettings.withOffsetRetrieval which converts it automatically."
+          )
         },
         test("rejects with multiple problems") {
           assertFailsWithIllegalArgumentException(

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/ConsumerSpec.scala
@@ -12,7 +12,13 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import zio._
 import zio.kafka.ZIOSpecDefaultSlf4j
-import zio.kafka.consumer.Consumer.{ AutoOffsetStrategy, CommitTimeout, ConsumerDiagnostics, OffsetRetrieval }
+import zio.kafka.consumer.Consumer.{
+  AutoOffsetStrategy,
+  CommitTimeout,
+  ConsumerDiagnostics,
+  OffsetEpoch,
+  OffsetRetrieval
+}
 import zio.kafka.consumer.diagnostics.DiagnosticEvent
 import zio.kafka.consumer.diagnostics.DiagnosticEvent.{ ConsumerFinalized, RunloopFinalized, SubscriptionFinalized }
 import zio.kafka.diagnostics.{ Diagnostics, SlidingDiagnostics }
@@ -35,6 +41,28 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
 
   override def spec: Spec[TestEnvironment with Scope, Throwable] =
     suite("ConsumerSpec")(
+      suite("OffsetRetrieval.Manual#toExternal")(
+        test("converts Manual to External") {
+          val tp1 = new TopicPartition("topic1", 0)
+          val tp2 = new TopicPartition("topic2", 1)
+          val tps = Set(tp1, tp2)
+          val getManualOffsets: Set[TopicPartition] => Task[Map[TopicPartition, Long]] =
+            _ => ZIO.succeed(Map(tp1 -> 100L, tp2 -> 200L))
+
+          val manual   = OffsetRetrieval.Manual(getManualOffsets, AutoOffsetStrategy.Earliest)
+          val external = manual.toExternal
+
+          for {
+            externalOffsets <- external.getOffsets(tps)
+          } yield assertTrue(
+            external.defaultStrategy == AutoOffsetStrategy.Earliest,
+            externalOffsets == Map(
+              tp1 -> OffsetEpoch(100L, None),
+              tp2 -> OffsetEpoch(200L, None)
+            )
+          )
+        }
+      ),
       test("make validates ConsumerSettings") {
         val settings = ConsumerSettings(List("host")).withProperty("enable.auto.commit", "true")
         val consumer = Consumer.make(settings).exit
@@ -191,7 +219,8 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                  )
                }
 
-          offsetRetrieval = OffsetRetrieval.Manual(tps => ZIO.attempt(tps.map(_ -> manualOffsetSeek.toLong).toMap))
+          offsetRetrieval =
+            OffsetRetrieval.External(tps => ZIO.succeed(tps.map(_ -> OffsetEpoch(manualOffsetSeek.toLong, None)).toMap))
           consumer <- KafkaTestUtils.makeConsumer(
                         client,
                         Some(group),
@@ -1181,17 +1210,17 @@ object ConsumerSpec extends ZIOSpecDefaultSlf4j with KafkaRandom {
                        }
                        .runCollect
                    }
-            // Start a new consumer with manual offsets. The given offset per partition is:
+            // Start a new consumer with external offsets. The given offset per partition is:
             //  p0: 3, before the current offset => should consume from the given offset
             //  p1: _Maxvalue_, offset out of range (invalid) => should consume using default strategy
             //  p2: _nothing_ given => should consume from the committed offset
             //  p4: _nothing_ given => should consume using default strategy
-            offsetRetrieval = OffsetRetrieval.Manual(
+            offsetRetrieval = OffsetRetrieval.External(
                                 getOffsets = _ =>
                                   ZIO.attempt(
                                     Map(
-                                      new TopicPartition(topic, 0) -> manualOffsetSeek,
-                                      new TopicPartition(topic, 1) -> Long.MaxValue
+                                      new TopicPartition(topic, 0) -> OffsetEpoch(manualOffsetSeek, None),
+                                      new TopicPartition(topic, 1) -> OffsetEpoch(Long.MaxValue, None)
                                     )
                                   ),
                                 defaultStrategy = defaultStrategy

--- a/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
+++ b/zio-kafka-test/src/test/scala/zio/kafka/consumer/internal/RunloopSpec.scala
@@ -7,7 +7,7 @@ import zio._
 import zio.kafka.ZIOSpecDefaultSlf4j
 import zio.kafka.consumer.Consumer.ConsumerDiagnostics
 import zio.kafka.consumer.diagnostics.DiagnosticEvent
-import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
+import zio.kafka.consumer.internal.Runloop.PartitionAssignment
 import zio.kafka.consumer.metrics.ConsumerMetricsObserver
 import zio.kafka.consumer.{ ConsumerSettings, Subscription }
 import zio.kafka.diagnostics.{ Diagnostics, SlidingDiagnostics }
@@ -58,8 +58,14 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
           )
         }
       },
+      // This test is flaky because Runloop emits the new stream _before_ it emits the associated diagnostics the test
+      // relies on. (Diagnostics are a best-efford feature.) Most of the time the ZIO scheduler lets Runloop emit both
+      // the new stream and the diagnostics before another thread runs. However, in rare cases, this test consumes the
+      // new stream before the diagnostics is emitted. In those cases this test does not see the diagnostics and fails
+      // on an empty `rebalanceEvents`.
+      // Because the problem occurs so rarely, we simply add the `flaky` aspect.
       test(
-        "runloop does not starts a new stream for partition which being revoked right after assignment within the same RebalanceEvent"
+        "runloop does not start a new stream for a partition that was revoked right after assignment within the same RebalanceEvent"
       ) {
         SlidingDiagnostics.make[DiagnosticEvent](100).flatMap { diagnostics =>
           withRunloop(diagnostics) { (mockConsumer, partitionsHub, runloop) =>
@@ -97,7 +103,7 @@ object RunloopSpec extends ZIOSpecDefaultSlf4j {
             )
           }
         }
-      },
+      } @@ flaky(3),
       test(
         "runloop continues polling after a lost partition"
       ) {

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/Consumer.scala
@@ -388,14 +388,44 @@ object Consumer {
         .flatMap(_.consumeWith[R, R1, K, V](subscription, keyDeserializer, valueDeserializer, commitRetryPolicy)(f))
     }
 
+  /**
+   * A committed offset with leader epoch.
+   *
+   * See ConsumerSettings.withOffsetRetrieval.
+   *
+   * @param offset
+   *   the next offset to consume from
+   * @param leaderEpoch
+   *   the leaderEpoch of the offset, or `None` if unknown
+   */
+  final case class OffsetEpoch(offset: Long, leaderEpoch: Option[Int])
+
   /** See ConsumerSettings.withOffsetRetrieval. */
   sealed trait OffsetRetrieval
   object OffsetRetrieval {
+
+    /** Automatic offset retrieval. See ConsumerSettings.withOffsetRetrieval. */
     final case class Auto(reset: AutoOffsetStrategy = AutoOffsetStrategy.Latest) extends OffsetRetrieval
+
+    /** External offset retrieval. See ConsumerSettings.withOffsetRetrieval. */
+    final case class External(
+      getOffsets: Set[TopicPartition] => Task[Map[TopicPartition, OffsetEpoch]],
+      defaultStrategy: AutoOffsetStrategy = AutoOffsetStrategy.Latest
+    ) extends OffsetRetrieval
+
+    /** External offset retrieval. See ConsumerSettings.withOffsetRetrieval. */
+    @deprecated("Use OffsetRetrieval.External instead", "3.8.0")
     final case class Manual(
       getOffsets: Set[TopicPartition] => Task[Map[TopicPartition, Long]],
       defaultStrategy: AutoOffsetStrategy = AutoOffsetStrategy.Latest
-    ) extends OffsetRetrieval
+    ) extends OffsetRetrieval {
+
+      /** Returns a wrapper that converts deprecated `Manual` to `External`. */
+      def toExternal: External = OffsetRetrieval.External(
+        tps => getOffsets(tps).map(_.map { case (tp, offset) => (tp, OffsetEpoch(offset, None)) }),
+        defaultStrategy
+      )
+    }
   }
 
   sealed trait AutoOffsetStrategy { self =>

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/ConsumerSettings.scala
@@ -114,21 +114,28 @@ final case class ConsumerSettings(
    *   OffsetRetrieval.Auto(AutoOffsetStrategy.Latest) // the default
    *   OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest)
    *   OffsetRetrieval.Auto(AutoOffsetStrategy.None)
-   *   OffsetRetrieval.Manual(getOffsets, defaultStrategy)
+   *   OffsetRetrieval.External(getOffsets, defaultStrategy)
+   *   OffsetRetrieval.Manual(getOffsets, defaultStrategy) // deprecated
    * }}}
    *
    * The `Auto` options make consuming start from the latest committed offset. When no committed offset is available,
    * the given offset strategy is used and consuming starts from the `Latest` offset (the default), the `Earliest`
    * offset, or results in an error for `None`.
    *
-   * The `Manual` option allows fine-grained control over which offset to consume from. The provided `getOffsets`
-   * function should return an offset for each topic-partition that is being assigned. When the returned offset is
-   * smaller than the log start offset or larger than the log end offset, the `defaultStrategy` is used and consuming
-   * starts from the `Latest` offset (the default), the `Earliest` offset, or results in an error for `None`.
+   * The option `External` (and deprecated `Manual`) allows fine-grained control over which offset to start consumption
+   * from. The provided `getOffsets` function should return an offset for each topic-partition that is being assigned.
+   * When the returned offset is smaller than the log start offset or larger than the log end offset, the
+   * `defaultStrategy` is used and consuming starts from the `Latest` offset (the default), the `Earliest` offset, or
+   * results in an error for `None`.
    *
    * When the returned map does ''not'' contain an entry for a topic-partition, the consumer will continue from the last
    * committed offset. When no committed offset is available, the `defaultStrategy` is used and consuming starts from
    * the `Latest` offset (the default), the `Earliest` offset, or results in an error for `None`.
+   *
+   * `External` allows you to optionally provide the `leaderEpoch` together with the offset. It is recommended you
+   * provide the leaderEpoch if you can as it prevents consuming from a broker that is unaware it is no longer a leader.
+   * The older `Manual` works the same as `External`, except that it does not allow you to provide a leaderEpoch.
+   * `Manual` is deprecated and will be removed in a future zio-kaka release.
    *
    * This configuration applies to both subscribed and assigned partitions.
    *
@@ -136,11 +143,12 @@ final case class ConsumerSettings(
    * https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset for more information.
    */
   def withOffsetRetrieval(retrieval: OffsetRetrieval): ConsumerSettings = {
-    val resetStrategy = retrieval match {
-      case OffsetRetrieval.Auto(reset)                => reset
-      case OffsetRetrieval.Manual(_, defaultStrategy) => defaultStrategy
+    val (updatedRetrieval, resetStrategy) = retrieval match {
+      case r @ OffsetRetrieval.Auto(reset)                  => (r, reset)
+      case r @ OffsetRetrieval.External(_, defaultStrategy) => (r, defaultStrategy)
+      case r @ OffsetRetrieval.Manual(_, defaultStrategy)   => (r.toExternal, defaultStrategy)
     }
-    copy(offsetRetrieval = retrieval)
+    copy(offsetRetrieval = updatedRetrieval)
       .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, resetStrategy.toConfig)
   }
 
@@ -406,6 +414,12 @@ final case class ConsumerSettings(
         assert(
           commitTimeout.toNanos > 2L * pollTimeout.toNanos,
           s"Commit timeout must be larger than 2 * pollTimeout, saw commitTimeout ${commitTimeout} and pollTimeout ${pollTimeout}."
+        ) ++
+        assert(
+          !offsetRetrieval.isInstanceOf[OffsetRetrieval.Manual],
+          "OffsetRetrieval.Manual is no longer supported. Switch to OffsetRetrieval.External, use " +
+            "OffsetRetrieval.Manual.toExternal to convert an existing Manual implementation, " +
+            "or use ConsumerSettings.withOffsetRetrieval which converts it automatically."
         )
     }
 

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/Runloop.scala
@@ -10,12 +10,12 @@ import zio.kafka.consumer.diagnostics.DiagnosticEvent
 import zio.kafka.consumer.internal.ConsumerAccess.ByteArrayKafkaConsumer
 import zio.kafka.consumer.internal.RebalanceCoordinator._
 import zio.kafka.consumer.internal.Runloop._
-import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
 import zio.kafka.consumer.metrics.{ ConsumerMetricsObserver, ZioMetricsConsumerMetricsObserver }
 import zio.stream._
 
 import java.util.concurrent.TimeoutException
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOption
 import scala.util.control.NoStackTrace
 
 //noinspection SimplifyWhenInspection,SimplifyUnlessInspection
@@ -176,14 +176,22 @@ private[consumer] final class Runloop private (
   private def doSeekForNewPartitions(c: ByteArrayKafkaConsumer, tps: Set[TopicPartition]): Task[Set[TopicPartition]] =
     settings.offsetRetrieval match {
       case OffsetRetrieval.Auto(_) => ZIO.succeed(Set.empty)
-      case OffsetRetrieval.Manual(getOffsets, _) =>
+      case OffsetRetrieval.External(getOffsets, _) =>
         if (tps.isEmpty) ZIO.succeed(Set.empty)
         else
-          getOffsets(tps).flatMap { offsets =>
-            ZIO
-              .attempt(offsets.foreach { case (tp, offset) => c.seek(tp, offset) })
-              .as(offsets.keySet)
+          getOffsets(tps).flatMap { offsetEpochs =>
+            ZIO.attempt {
+              // tp = topic-partition, oe = offset-epoch, om = offset and metadata
+              offsetEpochs.foreach { case (tp, oe) =>
+                val om = new OffsetAndMetadata(oe.offset, oe.leaderEpoch.map(Int.box).toJava, "")
+                c.seek(tp, om)
+              }
+            }
+              .as(offsetEpochs.keySet)
           }
+      case _: OffsetRetrieval.Manual =>
+        // ConsumerSettings converts Manual to External, it should not show up here.
+        ZIO.die(new UnsupportedOperationException("OffsetRetrieval.Manual not expected here"))
     }
 
   /**
@@ -676,6 +684,8 @@ private[consumer] final class Runloop private (
 }
 
 object Runloop {
+  type PartitionAssignment = (TopicPartition, Stream[Throwable, ByteArrayCommittableRecord])
+
   private implicit final class StreamOps[R, E, A](private val stream: ZStream[R, E, A]) extends AnyVal {
 
     /**

--- a/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
+++ b/zio-kafka/src/main/scala/zio/kafka/consumer/internal/RunloopAccess.scala
@@ -1,14 +1,12 @@
 package zio.kafka.consumer.internal
 
-import org.apache.kafka.common.TopicPartition
 import zio._
 import zio.kafka.consumer.Consumer.ConsumerDiagnostics
 import zio.kafka.consumer.diagnostics.DiagnosticEvent
-import zio.kafka.consumer.internal.Runloop.ByteArrayCommittableRecord
-import zio.kafka.consumer.internal.RunloopAccess.PartitionAssignment
+import zio.kafka.consumer.internal.Runloop.PartitionAssignment
 import zio.kafka.consumer._
 import zio.kafka.diagnostics.Diagnostics
-import zio.stream.{ Stream, Take, ZStream }
+import zio.stream.{ Take, ZStream }
 
 private[internal] sealed trait RunloopState
 private[internal] object RunloopState {
@@ -85,8 +83,6 @@ private[consumer] final class RunloopAccess private (
 }
 
 private[consumer] object RunloopAccess {
-  type PartitionAssignment = (TopicPartition, Stream[Throwable, ByteArrayCommittableRecord])
-
   def make(
     settings: ConsumerSettings,
     consumerAccess: ConsumerAccess,


### PR DESCRIPTION
Kafka recommends committing offsets with a leaderEpoch as it prevents consuming from a broker that is unaware it is no longer a leader. The same is true for _seeking_ to an offset which is used when the offsets are stored in an external system.

To support this, `OffsetRetrieval.Manual` is **deprecated** and replaced by `OffsetRetrieval.External`. External works the same as Manual except that it (optionally) allows the user to give a leaderEpoch in addition to the offset.

Also:
- Tweak compiler settings to allow (our own) deprecated code to be used.
- Update docs.
- Fix recursive compiler issue for scala 3.3.8 by moving type alias `PartitionAssignment` from `RunloopAccess` to `Runloop`.
- 'Fix' a flaky test with the 'flaky' aspect.

Related to #1760.